### PR TITLE
[Optimization] New go-routine to ensure new shards are being discovered

### DIFF
--- a/lib/ttlmap/ttlmap_test.go
+++ b/lib/ttlmap/ttlmap_test.go
@@ -28,7 +28,10 @@ func (t *TTLMapTestSuite) TestTTLMap_Complete() {
 
 	// Now, insert all of this and then wait 100 ms.
 	for key, duration := range keyToDuration {
-		store.Set(key, key, duration)
+		store.Set(SetArgs{
+			Key:   key,
+			Value: key,
+		}, duration)
 	}
 
 	for key := range keyToDuration {

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -60,14 +60,16 @@ func (s *Store) Run(ctx context.Context) {
 	s.scanForNewShards(ctx)
 
 	log := logger.FromContext(ctx)
-	select {
-	case <-ctx.Done():
-		close(s.shardChan)
-		log.Info("Terminating process...")
-		return
-	case <-ticker.C:
-		log.Info("Scanning for new shards...")
-		s.scanForNewShards(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			close(s.shardChan)
+			log.Info("Terminating process...")
+			return
+		case <-ticker.C:
+			log.Info("Scanning for new shards...")
+			s.scanForNewShards(ctx)
+		}
 	}
 
 }

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -56,6 +56,9 @@ func (s *Store) Run(ctx context.Context) {
 	// Start to subscribe to the channel
 	go s.ListenToChannel(ctx)
 
+	// Scan it for the first time manually, so we don't have to wait 5 mins
+	s.scanForNewShards(ctx)
+
 	log := logger.FromContext(ctx)
 	select {
 	case <-ctx.Done():
@@ -66,6 +69,7 @@ func (s *Store) Run(ctx context.Context) {
 		log.Info("Scanning for new shards...")
 		s.scanForNewShards(ctx)
 	}
+
 }
 
 func (s *Store) scanForNewShards(ctx context.Context) {

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -54,7 +54,7 @@ func (s *Store) Run(ctx context.Context) {
 	ticker := time.NewTicker(shardScannerInterval)
 
 	// Start to subscribe to the channel
-	go s.ProcessShard(ctx)
+	go s.ListenToChannel(ctx)
 
 	log := logger.FromContext(ctx)
 	select {

--- a/sources/dynamodb/offsets/offsets.go
+++ b/sources/dynamodb/offsets/offsets.go
@@ -13,6 +13,10 @@ type OffsetStorage struct {
 	ttlMap *ttlmap.TTLMap
 }
 
+func shardProcessingKey(shardId string) string {
+	return fmt.Sprintf("processing#shardId#%s", shardId)
+}
+
 func shardProcessKey(shardId string) string {
 	return fmt.Sprintf("processed#shardId#%s", shardId)
 }
@@ -27,6 +31,17 @@ func (o *OffsetStorage) SetShardProcessed(shardID string) {
 
 func (o *OffsetStorage) GetShardProcessed(shardID string) bool {
 	_, isOk := o.ttlMap.Get(shardProcessKey(shardID))
+	return isOk
+}
+
+// SetShardProcessing sets the shard processing flag for the given shardID
+// This is used so that we don't process the same shard twice
+func (o *OffsetStorage) SetShardProcessing(shardID string) {
+	o.ttlMap.Set(shardProcessingKey(shardID), true, ShardExpirationAndBuffer)
+}
+
+func (o *OffsetStorage) GetShardProcessing(shardID string) bool {
+	_, isOk := o.ttlMap.Get(shardProcessingKey(shardID))
 	return isOk
 }
 

--- a/sources/dynamodb/offsets/offsets.go
+++ b/sources/dynamodb/offsets/offsets.go
@@ -26,7 +26,10 @@ func shardSeqNumberKey(shardId string) string {
 }
 
 func (o *OffsetStorage) SetShardProcessed(shardID string) {
-	o.ttlMap.Set(shardProcessKey(shardID), true, ShardExpirationAndBuffer)
+	o.ttlMap.Set(ttlmap.SetArgs{
+		Key:   shardProcessKey(shardID),
+		Value: true,
+	}, ShardExpirationAndBuffer)
 }
 
 func (o *OffsetStorage) GetShardProcessed(shardID string) bool {
@@ -37,7 +40,13 @@ func (o *OffsetStorage) GetShardProcessed(shardID string) bool {
 // SetShardProcessing sets the shard processing flag for the given shardID
 // This is used so that we don't process the same shard twice
 func (o *OffsetStorage) SetShardProcessing(shardID string) {
-	o.ttlMap.Set(shardProcessingKey(shardID), true, ShardExpirationAndBuffer)
+	o.ttlMap.Set(ttlmap.SetArgs{
+		Key:   shardProcessingKey(shardID),
+		Value: true,
+		// Don't flush this to disk
+		// This is only used to alleviate shard contention and prevent memory leak by having built-in GC.
+		DoNotFlushToDisk: true,
+	}, ShardExpirationAndBuffer)
 }
 
 func (o *OffsetStorage) GetShardProcessing(shardID string) bool {
@@ -46,7 +55,10 @@ func (o *OffsetStorage) GetShardProcessing(shardID string) bool {
 }
 
 func (o *OffsetStorage) SetLastProcessedSequenceNumber(shardID string, sequenceNumber string) {
-	o.ttlMap.Set(shardSeqNumberKey(shardID), sequenceNumber, ShardExpirationAndBuffer)
+	o.ttlMap.Set(ttlmap.SetArgs{
+		Key:   shardSeqNumberKey(shardID),
+		Value: sequenceNumber,
+	}, ShardExpirationAndBuffer)
 }
 
 func (o *OffsetStorage) LastProcessedSequenceNumber(shardID string) (string, bool) {

--- a/sources/dynamodb/shard.go
+++ b/sources/dynamodb/shard.go
@@ -12,102 +12,113 @@ import (
 	"time"
 )
 
-func (s *Store) ProcessShard(ctx context.Context, shard *dynamodbstreams.Shard) {
-	var attempts int
-	log := logger.FromContext(ctx)
-	if s.storage.GetShardProcessed(*shard.ShardId) {
-		log.WithField("shardId", *shard.ShardId).Info("shard has been processed, skipping...")
-		return
-	}
+func (s *Store) ProcessShard(ctx context.Context) {
+	for shard := range s.shardChan {
+		var attempts int
+		log := logger.FromContext(ctx)
 
-	log.WithField("shardId", *shard.ShardId).Info("processing shard...")
-
-	iteratorType := "TRIM_HORIZON"
-	var startingSequenceNumber string
-	if seqNumber, exists := s.storage.LastProcessedSequenceNumber(*shard.ShardId); exists {
-		iteratorType = "AFTER_SEQUENCE_NUMBER"
-		startingSequenceNumber = seqNumber
-	}
-
-	iteratorInput := &dynamodbstreams.GetShardIteratorInput{
-		StreamArn:         ptr.ToString(s.streamArn),
-		ShardId:           shard.ShardId,
-		ShardIteratorType: ptr.ToString(iteratorType),
-	}
-
-	if startingSequenceNumber != "" {
-		iteratorInput.SequenceNumber = ptr.ToString(startingSequenceNumber)
-	}
-
-	iteratorOutput, err := s.streams.GetShardIterator(iteratorInput)
-	if err != nil {
-		log.WithError(err).WithFields(map[string]interface{}{
-			"streamArn": s.streamArn,
-			"shardId":   *shard.ShardId,
-		}).Warn("failed to get shard iterator...")
-		return
-	}
-
-	shardIterator := iteratorOutput.ShardIterator
-	// Get records from shard iterator
-	for shardIterator != nil {
-		getRecordsInput := &dynamodbstreams.GetRecordsInput{
-			ShardIterator: shardIterator,
-			Limit:         ptr.ToInt64(1000),
+		// Is there another go-routine processing this shard?
+		if s.storage.GetShardProcessing(*shard.ShardId) {
+			log.WithField("shardId", *shard.ShardId).Info("shard is already being processed, skipping...")
+			return
 		}
 
-		getRecordsOutput, err := s.streams.GetRecords(getRecordsInput)
+		// If no one is processing it, let's mark it as being processed.
+		s.storage.SetShardProcessing(*shard.ShardId)
+		if s.storage.GetShardProcessed(*shard.ShardId) {
+			log.WithField("shardId", *shard.ShardId).Info("shard has been processed, skipping...")
+			return
+		}
+
+		log.WithField("shardId", *shard.ShardId).Info("processing shard...")
+
+		iteratorType := "TRIM_HORIZON"
+		var startingSequenceNumber string
+		if seqNumber, exists := s.storage.LastProcessedSequenceNumber(*shard.ShardId); exists {
+			iteratorType = "AFTER_SEQUENCE_NUMBER"
+			startingSequenceNumber = seqNumber
+		}
+
+		iteratorInput := &dynamodbstreams.GetShardIteratorInput{
+			StreamArn:         ptr.ToString(s.streamArn),
+			ShardId:           shard.ShardId,
+			ShardIteratorType: ptr.ToString(iteratorType),
+		}
+
+		if startingSequenceNumber != "" {
+			iteratorInput.SequenceNumber = ptr.ToString(startingSequenceNumber)
+		}
+
+		iteratorOutput, err := s.streams.GetShardIterator(iteratorInput)
 		if err != nil {
 			log.WithError(err).WithFields(map[string]interface{}{
 				"streamArn": s.streamArn,
 				"shardId":   *shard.ShardId,
-			}).Warn("failed to get records from shard iterator...")
-			break
+			}).Warn("failed to get shard iterator...")
+			return
 		}
 
-		var messages []kafka.Message
-		for _, record := range getRecordsOutput.Records {
-			msg, err := dynamo.NewMessage(record, s.tableName)
+		shardIterator := iteratorOutput.ShardIterator
+		// Get records from shard iterator
+		for shardIterator != nil {
+			getRecordsInput := &dynamodbstreams.GetRecordsInput{
+				ShardIterator: shardIterator,
+				Limit:         ptr.ToInt64(1000),
+			}
+
+			getRecordsOutput, err := s.streams.GetRecords(getRecordsInput)
 			if err != nil {
 				log.WithError(err).WithFields(map[string]interface{}{
 					"streamArn": s.streamArn,
 					"shardId":   *shard.ShardId,
-					"record":    record,
-				}).Fatal("failed to cast message from DynamoDB")
+				}).Warn("failed to get records from shard iterator...")
+				break
 			}
 
-			message, err := msg.KafkaMessage(ctx)
-			if err != nil {
-				log.WithError(err).WithFields(map[string]interface{}{
-					"streamArn": s.streamArn,
-					"shardId":   *shard.ShardId,
-					"record":    record,
-				}).Fatal("failed to cast message from DynamoDB")
+			var messages []kafka.Message
+			for _, record := range getRecordsOutput.Records {
+				msg, err := dynamo.NewMessage(record, s.tableName)
+				if err != nil {
+					log.WithError(err).WithFields(map[string]interface{}{
+						"streamArn": s.streamArn,
+						"shardId":   *shard.ShardId,
+						"record":    record,
+					}).Fatal("failed to cast message from DynamoDB")
+				}
+
+				message, err := msg.KafkaMessage(ctx)
+				if err != nil {
+					log.WithError(err).WithFields(map[string]interface{}{
+						"streamArn": s.streamArn,
+						"shardId":   *shard.ShardId,
+						"record":    record,
+					}).Fatal("failed to cast message from DynamoDB")
+				}
+
+				messages = append(messages, message)
 			}
 
-			messages = append(messages, message)
-		}
+			if err = kafkalib.NewBatch(messages, s.batchSize).Publish(ctx); err != nil {
+				log.WithError(err).Fatalf("failed to publish messages, exiting...")
+			}
 
-		if err = kafkalib.NewBatch(messages, s.batchSize).Publish(ctx); err != nil {
-			log.WithError(err).Fatalf("failed to publish messages, exiting...")
-		}
+			if len(getRecordsOutput.Records) > 0 {
+				attempts = 0
+				lastRecord := getRecordsOutput.Records[len(getRecordsOutput.Records)-1]
+				s.storage.SetLastProcessedSequenceNumber(*shard.ShardId, *lastRecord.Dynamodb.SequenceNumber)
+			} else {
+				attempts += 1
+			}
 
-		if len(getRecordsOutput.Records) > 0 {
-			attempts = 0
-			lastRecord := getRecordsOutput.Records[len(getRecordsOutput.Records)-1]
-			s.storage.SetLastProcessedSequenceNumber(*shard.ShardId, *lastRecord.Dynamodb.SequenceNumber)
-		} else {
-			attempts += 1
-		}
+			sleepDuration := time.Duration(jitter.JitterMs(jitterSleepBaseMs, attempts)) * time.Millisecond
+			time.Sleep(sleepDuration)
 
-		sleepDuration := time.Duration(jitter.JitterMs(jitterSleepBaseMs, attempts)) * time.Millisecond
-		time.Sleep(sleepDuration)
-
-		shardIterator = getRecordsOutput.NextShardIterator
-		if shardIterator == nil {
-			// This means this shard has been fully processed, let's add it to our processed list.
-			logger.FromContext(ctx).WithField("shardId", *shard.ShardId).Info("shard has been fully processed, adding it to the processed list...")
-			s.storage.SetShardProcessed(*shard.ShardId)
+			shardIterator = getRecordsOutput.NextShardIterator
+			if shardIterator == nil {
+				// This means this shard has been fully processed, let's add it to our processed list.
+				logger.FromContext(ctx).WithField("shardId", *shard.ShardId).Info("shard has been fully processed, adding it to the processed list...")
+				s.storage.SetShardProcessed(*shard.ShardId)
+			}
 		}
 	}
 

--- a/sources/dynamodb/shard.go
+++ b/sources/dynamodb/shard.go
@@ -24,7 +24,6 @@ func (s *Store) processShard(ctx context.Context, shard *dynamodbstreams.Shard) 
 
 	// Is there another go-routine processing this shard?
 	if s.storage.GetShardProcessing(*shard.ShardId) {
-		log.WithField("shardId", *shard.ShardId).Info("shard is already being processed, skipping...")
 		return
 	}
 

--- a/sources/dynamodb/shard.go
+++ b/sources/dynamodb/shard.go
@@ -12,113 +12,118 @@ import (
 	"time"
 )
 
-func (s *Store) ProcessShard(ctx context.Context) {
+func (s *Store) ListenToChannel(ctx context.Context) {
 	for shard := range s.shardChan {
-		var attempts int
-		log := logger.FromContext(ctx)
+		go s.processShard(ctx, shard)
+	}
+}
 
-		// Is there another go-routine processing this shard?
-		if s.storage.GetShardProcessing(*shard.ShardId) {
-			log.WithField("shardId", *shard.ShardId).Info("shard is already being processed, skipping...")
-			return
+func (s *Store) processShard(ctx context.Context, shard *dynamodbstreams.Shard) {
+
+	var attempts int
+	log := logger.FromContext(ctx)
+
+	// Is there another go-routine processing this shard?
+	if s.storage.GetShardProcessing(*shard.ShardId) {
+		log.WithField("shardId", *shard.ShardId).Info("shard is already being processed, skipping...")
+		return
+	}
+
+	// If no one is processing it, let's mark it as being processed.
+	s.storage.SetShardProcessing(*shard.ShardId)
+	if s.storage.GetShardProcessed(*shard.ShardId) {
+		log.WithField("shardId", *shard.ShardId).Info("shard has been processed, skipping...")
+		return
+	}
+
+	log.WithField("shardId", *shard.ShardId).Info("processing shard...")
+
+	iteratorType := "TRIM_HORIZON"
+	var startingSequenceNumber string
+	if seqNumber, exists := s.storage.LastProcessedSequenceNumber(*shard.ShardId); exists {
+		iteratorType = "AFTER_SEQUENCE_NUMBER"
+		startingSequenceNumber = seqNumber
+	}
+
+	iteratorInput := &dynamodbstreams.GetShardIteratorInput{
+		StreamArn:         ptr.ToString(s.streamArn),
+		ShardId:           shard.ShardId,
+		ShardIteratorType: ptr.ToString(iteratorType),
+	}
+
+	if startingSequenceNumber != "" {
+		iteratorInput.SequenceNumber = ptr.ToString(startingSequenceNumber)
+	}
+
+	iteratorOutput, err := s.streams.GetShardIterator(iteratorInput)
+	if err != nil {
+		log.WithError(err).WithFields(map[string]interface{}{
+			"streamArn": s.streamArn,
+			"shardId":   *shard.ShardId,
+		}).Warn("failed to get shard iterator...")
+		return
+	}
+
+	shardIterator := iteratorOutput.ShardIterator
+	// Get records from shard iterator
+	for shardIterator != nil {
+		getRecordsInput := &dynamodbstreams.GetRecordsInput{
+			ShardIterator: shardIterator,
+			Limit:         ptr.ToInt64(1000),
 		}
 
-		// If no one is processing it, let's mark it as being processed.
-		s.storage.SetShardProcessing(*shard.ShardId)
-		if s.storage.GetShardProcessed(*shard.ShardId) {
-			log.WithField("shardId", *shard.ShardId).Info("shard has been processed, skipping...")
-			return
-		}
-
-		log.WithField("shardId", *shard.ShardId).Info("processing shard...")
-
-		iteratorType := "TRIM_HORIZON"
-		var startingSequenceNumber string
-		if seqNumber, exists := s.storage.LastProcessedSequenceNumber(*shard.ShardId); exists {
-			iteratorType = "AFTER_SEQUENCE_NUMBER"
-			startingSequenceNumber = seqNumber
-		}
-
-		iteratorInput := &dynamodbstreams.GetShardIteratorInput{
-			StreamArn:         ptr.ToString(s.streamArn),
-			ShardId:           shard.ShardId,
-			ShardIteratorType: ptr.ToString(iteratorType),
-		}
-
-		if startingSequenceNumber != "" {
-			iteratorInput.SequenceNumber = ptr.ToString(startingSequenceNumber)
-		}
-
-		iteratorOutput, err := s.streams.GetShardIterator(iteratorInput)
+		getRecordsOutput, err := s.streams.GetRecords(getRecordsInput)
 		if err != nil {
 			log.WithError(err).WithFields(map[string]interface{}{
 				"streamArn": s.streamArn,
 				"shardId":   *shard.ShardId,
-			}).Warn("failed to get shard iterator...")
-			return
+			}).Warn("failed to get records from shard iterator...")
+			break
 		}
 
-		shardIterator := iteratorOutput.ShardIterator
-		// Get records from shard iterator
-		for shardIterator != nil {
-			getRecordsInput := &dynamodbstreams.GetRecordsInput{
-				ShardIterator: shardIterator,
-				Limit:         ptr.ToInt64(1000),
-			}
-
-			getRecordsOutput, err := s.streams.GetRecords(getRecordsInput)
+		var messages []kafka.Message
+		for _, record := range getRecordsOutput.Records {
+			msg, err := dynamo.NewMessage(record, s.tableName)
 			if err != nil {
 				log.WithError(err).WithFields(map[string]interface{}{
 					"streamArn": s.streamArn,
 					"shardId":   *shard.ShardId,
-				}).Warn("failed to get records from shard iterator...")
-				break
+					"record":    record,
+				}).Fatal("failed to cast message from DynamoDB")
 			}
 
-			var messages []kafka.Message
-			for _, record := range getRecordsOutput.Records {
-				msg, err := dynamo.NewMessage(record, s.tableName)
-				if err != nil {
-					log.WithError(err).WithFields(map[string]interface{}{
-						"streamArn": s.streamArn,
-						"shardId":   *shard.ShardId,
-						"record":    record,
-					}).Fatal("failed to cast message from DynamoDB")
-				}
-
-				message, err := msg.KafkaMessage(ctx)
-				if err != nil {
-					log.WithError(err).WithFields(map[string]interface{}{
-						"streamArn": s.streamArn,
-						"shardId":   *shard.ShardId,
-						"record":    record,
-					}).Fatal("failed to cast message from DynamoDB")
-				}
-
-				messages = append(messages, message)
+			message, err := msg.KafkaMessage(ctx)
+			if err != nil {
+				log.WithError(err).WithFields(map[string]interface{}{
+					"streamArn": s.streamArn,
+					"shardId":   *shard.ShardId,
+					"record":    record,
+				}).Fatal("failed to cast message from DynamoDB")
 			}
 
-			if err = kafkalib.NewBatch(messages, s.batchSize).Publish(ctx); err != nil {
-				log.WithError(err).Fatalf("failed to publish messages, exiting...")
-			}
+			messages = append(messages, message)
+		}
 
-			if len(getRecordsOutput.Records) > 0 {
-				attempts = 0
-				lastRecord := getRecordsOutput.Records[len(getRecordsOutput.Records)-1]
-				s.storage.SetLastProcessedSequenceNumber(*shard.ShardId, *lastRecord.Dynamodb.SequenceNumber)
-			} else {
-				attempts += 1
-			}
+		if err = kafkalib.NewBatch(messages, s.batchSize).Publish(ctx); err != nil {
+			log.WithError(err).Fatalf("failed to publish messages, exiting...")
+		}
 
-			sleepDuration := time.Duration(jitter.JitterMs(jitterSleepBaseMs, attempts)) * time.Millisecond
-			time.Sleep(sleepDuration)
+		if len(getRecordsOutput.Records) > 0 {
+			attempts = 0
+			lastRecord := getRecordsOutput.Records[len(getRecordsOutput.Records)-1]
+			s.storage.SetLastProcessedSequenceNumber(*shard.ShardId, *lastRecord.Dynamodb.SequenceNumber)
+		} else {
+			attempts += 1
+		}
 
-			shardIterator = getRecordsOutput.NextShardIterator
-			if shardIterator == nil {
-				// This means this shard has been fully processed, let's add it to our processed list.
-				logger.FromContext(ctx).WithField("shardId", *shard.ShardId).Info("shard has been fully processed, adding it to the processed list...")
-				s.storage.SetShardProcessed(*shard.ShardId)
-			}
+		sleepDuration := time.Duration(jitter.JitterMs(jitterSleepBaseMs, attempts)) * time.Millisecond
+		time.Sleep(sleepDuration)
+
+		shardIterator = getRecordsOutput.NextShardIterator
+		if shardIterator == nil {
+			// This means this shard has been fully processed, let's add it to our processed list.
+			logger.FromContext(ctx).WithField("shardId", *shard.ShardId).Info("shard has been fully processed, adding it to the processed list...")
+			s.storage.SetShardProcessed(*shard.ShardId)
 		}
 	}
 

--- a/sources/dynamodb/shard.go
+++ b/sources/dynamodb/shard.go
@@ -19,7 +19,6 @@ func (s *Store) ListenToChannel(ctx context.Context) {
 }
 
 func (s *Store) processShard(ctx context.Context, shard *dynamodbstreams.Shard) {
-
 	var attempts int
 	log := logger.FromContext(ctx)
 


### PR DESCRIPTION
## Motivation

After the latest PR, #12 - we are now processing multiple shards concurrently. However, we did not have shards auto-discovery built in. 

## Changes

- [x] Adding a new option within `ttlMap` called `DoNotFlushToDisk` which is self-explanatory. However, this is added because we are using it so that we don't run into shard contention when processing. We do not need this item to be durable because it's effectively a mutex with GC built-in.
- [x] `ListenToChannel` which made the Shard scanner and processor communicate via a Go channel


