### PR TITLE
Guardrail around panic and bad data

### DIFF
--- a/lib/ttlmap/ttlmap.go
+++ b/lib/ttlmap/ttlmap.go
@@ -20,7 +20,7 @@ const (
 type ItemWrapper struct {
 	Value            interface{} `yaml:"value"`
 	Expiration       int64       `yaml:"expiration"`
-	DoNotFlushToDisk bool
+	DoNotFlushToDisk bool        `yaml:"-"`
 }
 
 type TTLMap struct {
@@ -115,6 +115,9 @@ func (t *TTLMap) cleanup() {
 }
 
 func (t *TTLMap) flush() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
 	if !t.shouldSave {
 		return nil
 	}
@@ -169,6 +172,8 @@ func (t *TTLMap) loadFromFile() error {
 		data = make(map[string]*ItemWrapper)
 	}
 
+	t.mu.Lock()
 	t.data = data
+	t.mu.Unlock()
 	return nil
 }

--- a/lib/ttlmap/ttlmap.go
+++ b/lib/ttlmap/ttlmap.go
@@ -165,6 +165,10 @@ func (t *TTLMap) loadFromFile() error {
 		return fmt.Errorf("failed to unmarshal data, err: %v", err)
 	}
 
+	if data == nil {
+		data = make(map[string]*ItemWrapper)
+	}
+
 	t.data = data
 	return nil
 }


### PR DESCRIPTION
## Motivation

We are doing this to protect against 2 things.

* Bad data, if there are no data in the offset file, we are loading a nil map to `ttlMap.data` which can cause a panic
* Potential concurrent r/w panic with Flush + GC