### PR TITLE
ScanForNewShards should iterate

### DIFF
--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -92,6 +92,7 @@ func (s *Store) scanForNewShards(ctx context.Context) {
 		}
 
 		if result.StreamDescription.LastEvaluatedShardId == nil {
+			logger.FromContext(ctx).Info("Finished reading all the shards")
 			// If LastEvaluatedShardId is null, we've read all the shards.
 			break
 		}


### PR DESCRIPTION
## Problem

When a DynamoDB stream has more than 100 shards, the API for `DescribeStream` requires one to paginate. 

We were previously not doing so, this PR makes it such that we will iterate over all the shards based on `LastEvaluatedShardId` from `DescribeStream`

## Ref

https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_DescribeStream.html
![image](https://github.com/artie-labs/reader/assets/4412200/d866a697-7190-4451-9b2c-163115d674bd)
