### PR TITLE
DynamoDB Snapshot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/artie-labs/transfer/lib/stringutil"
 	"gopkg.in/yaml.v2"
 	"log"
 	"os"
@@ -35,27 +34,6 @@ func (k *Kafka) Validate() error {
 
 	if k.TopicPrefix == "" {
 		return fmt.Errorf("topic prefix not passed in")
-	}
-
-	return nil
-}
-
-type DynamoDB struct {
-	OffsetFile         string `yaml:"offsetFile"`
-	AwsRegion          string `yaml:"awsRegion"`
-	AwsAccessKeyID     string `yaml:"awsAccessKeyId"`
-	AwsSecretAccessKey string `yaml:"awsSecretAccessKey"`
-	StreamArn          string `yaml:"streamArn"`
-	TableName          string `yaml:"tableName"`
-}
-
-func (d *DynamoDB) Validate() error {
-	if d == nil {
-		return fmt.Errorf("dynamodb config is nil")
-	}
-
-	if stringutil.Empty(d.OffsetFile, d.AwsRegion, d.AwsAccessKeyID, d.AwsSecretAccessKey, d.StreamArn, d.TableName) {
-		return fmt.Errorf("one of the dynamoDB configs is empty: offsetFile, awsRegion, awsAccessKeyID, awsSecretAccessKey, streamArn or tableName")
 	}
 
 	return nil

--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"github.com/artie-labs/reader/lib/s3lib"
 	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
@@ -39,7 +40,7 @@ type SnapshotSettings struct {
 	Folder string `yaml:"folder"`
 	// If the files are not specified, that's okay.
 	// We will scan the folder and then load into `specifiedFiles`
-	SpecifiedFiles []string `yaml:"specifiedFiles"`
+	SpecifiedFiles []s3lib.S3File `yaml:"specifiedFiles"`
 }
 
 func (s *SnapshotSettings) Validate() error {

--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"fmt"
+	"github.com/artie-labs/transfer/lib/stringutil"
+)
+
+type DynamoDB struct {
+	OffsetFile         string `yaml:"offsetFile"`
+	AwsRegion          string `yaml:"awsRegion"`
+	AwsAccessKeyID     string `yaml:"awsAccessKeyId"`
+	AwsSecretAccessKey string `yaml:"awsSecretAccessKey"`
+	StreamArn          string `yaml:"streamArn"`
+	TableName          string `yaml:"tableName"`
+
+	Snapshot         bool             `yaml:"snapshot"`
+	SnapshotSettings SnapshotSettings `yaml:"snapshotSettings"`
+}
+
+func (d *DynamoDB) Validate() error {
+	if d == nil {
+		return fmt.Errorf("dynamodb config is nil")
+	}
+
+	if stringutil.Empty(d.OffsetFile, d.AwsRegion, d.AwsAccessKeyID, d.AwsSecretAccessKey, d.StreamArn, d.TableName) {
+		return fmt.Errorf("one of the dynamoDB configs is empty: offsetFile, awsRegion, awsAccessKeyID, awsSecretAccessKey, streamArn or tableName")
+	}
+
+	if d.Snapshot {
+		if err := d.SnapshotSettings.Validate(); err != nil {
+			return fmt.Errorf("snapshot validation failed - err: %v", err)
+		}
+	}
+
+	return nil
+}
+
+type SnapshotSettings struct {
+	Folder string `yaml:"folder"`
+	// If the files are not specified, that's okay.
+	// We will scan the folder and then load into `specifiedFiles`
+	SpecifiedFiles []string `yaml:"specifiedFiles"`
+}
+
+func (s *SnapshotSettings) Validate() error {
+	if s == nil {
+		return fmt.Errorf("settings is nil")
+	}
+
+	if s.Folder == "" {
+		return fmt.Errorf("folder is empty")
+	}
+
+	return nil
+}

--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -13,8 +13,8 @@ type DynamoDB struct {
 	StreamArn          string `yaml:"streamArn"`
 	TableName          string `yaml:"tableName"`
 
-	Snapshot         bool             `yaml:"snapshot"`
-	SnapshotSettings SnapshotSettings `yaml:"snapshotSettings"`
+	Snapshot         bool              `yaml:"snapshot"`
+	SnapshotSettings *SnapshotSettings `yaml:"snapshotSettings"`
 }
 
 func (d *DynamoDB) Validate() error {

--- a/examples/dynamodb/service_account.tf
+++ b/examples/dynamodb/service_account.tf
@@ -43,7 +43,8 @@ resource "aws_iam_policy" "dynamodb_streams_access" {
           "dynamodb:GetShardIterator",
           "dynamodb:DescribeStream",
           "dynamodb:GetRecords",
-          "dynamodb:ListStreams"
+          "dynamodb:ListStreams",
+          "dynamodb:DescribeTable"
         ],
         // Don't want to use "*"? You can specify like this:
         // Resource = [ TABLE_ARN, TABLE_ARN + "/stream/*" ]

--- a/examples/dynamodb/service_account.tf
+++ b/examples/dynamodb/service_account.tf
@@ -16,10 +16,10 @@ resource "aws_iam_role" "dynamodb_streams_role" {
   name = "DynamoDBStreamsRole"
 
   assume_role_policy = jsonencode({
-    Version = "2012-10-17",
+    Version   = "2012-10-17",
     Statement = [
       {
-        Action = "sts:AssumeRole",
+        Action    = "sts:AssumeRole",
         Principal = {
           Service = "ec2.amazonaws.com"
         },
@@ -35,20 +35,37 @@ resource "aws_iam_policy" "dynamodb_streams_access" {
   description = "My policy that grants access to DynamoDB streams"
 
   policy = jsonencode({
-    Version = "2012-10-17",
+    Version   = "2012-10-17",
     Statement = [
       {
-        Effect   = "Allow",
-        Action   = [
+        Effect = "Allow",
+        Action = [
           "dynamodb:GetShardIterator",
           "dynamodb:DescribeStream",
           "dynamodb:GetRecords",
           "dynamodb:ListStreams",
+
+          // Stuff only required for export (snapshot)
           "dynamodb:DescribeTable"
         ],
         // Don't want to use "*"? You can specify like this:
         // Resource = [ TABLE_ARN, TABLE_ARN + "/stream/*" ]
         Resource = "*" # Modify this to restrict access to specific streams or resources
+      },
+      // Export (snapshot) requires access to S3
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:ListBucket"
+        ],
+        "Resource" : "arn:aws:s3:::artie-transfer-test"
+      },
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "s3:GetObject"
+        ],
+        "Resource" : "arn:aws:s3:::artie-transfer-test/AWSDynamoDB/*"
       }
     ]
   })
@@ -79,6 +96,7 @@ resource "aws_iam_user_policy_attachment" "user_dynamodb_streams_attachment" {
 resource "aws_iam_access_key" "dynamodb_streams_user_key" {
   user = aws_iam_user.dynamodb_streams_user.name
 }
+
 
 # Output AWS credentials
 output "aws_access_key_id" {

--- a/lib/dynamo/message.go
+++ b/lib/dynamo/message.go
@@ -7,7 +7,6 @@ import (
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
-	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 	"github.com/segmentio/kafka-go"
 	"strconv"
 	"time"
@@ -85,41 +84,6 @@ func transformNewImage(data map[string]*dynamodb.AttributeValue) map[string]inte
 		transformed[key] = transformAttributeValue(attrValue)
 	}
 	return transformed
-}
-
-func NewMessage(record *dynamodbstreams.Record, tableName string) (*Message, error) {
-	if record == nil || record.Dynamodb == nil {
-		return nil, fmt.Errorf("record is nil or dynamodb does not exist in this event payload")
-	}
-
-	if len(record.Dynamodb.Keys) == 0 {
-		return nil, fmt.Errorf("keys is nil")
-	}
-
-	executionTime := time.Now()
-	if record.Dynamodb.ApproximateCreationDateTime != nil {
-		executionTime = *record.Dynamodb.ApproximateCreationDateTime
-	}
-
-	op := "r"
-	if record.EventName != nil {
-		switch *record.EventName {
-		case "INSERT":
-			op = "c"
-		case "MODIFY":
-			op = "u"
-		case "REMOVE":
-			op = "d"
-		}
-	}
-
-	return &Message{
-		op:            op,
-		tableName:     tableName,
-		executionTime: executionTime,
-		rowData:       transformNewImage(record.Dynamodb.NewImage),
-		primaryKey:    transformNewImage(record.Dynamodb.Keys),
-	}, nil
 }
 
 func (m *Message) artieMessage() (util.SchemaEventPayload, error) {

--- a/lib/dynamo/parse_message.go
+++ b/lib/dynamo/parse_message.go
@@ -1,0 +1,61 @@
+package dynamo
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"time"
+)
+
+func NewMessageFromExport(item *dynamodb.ItemResponse, tableName string) (*Message, error) {
+	//if item == nil || len(item.Item) == 0 {
+	//	return nil, fmt.Errorf("item is nil or keys do not exist in this item payload")
+	//}
+	//
+	//executionTime := time.Now()
+	//op := "r"
+	//return &Message{
+	//	op:            op,
+	//	tableName:     tableName,
+	//	executionTime: executionTime,
+	//	rowData:       transformNewImage(item.Item), // This is an assumed transformation function
+	//	primaryKey:    transformImage(item.Keys),
+	//}, nil
+
+	return nil, nil
+}
+
+func NewMessage(record *dynamodbstreams.Record, tableName string) (*Message, error) {
+	if record == nil || record.Dynamodb == nil {
+		return nil, fmt.Errorf("record is nil or dynamodb does not exist in this event payload")
+	}
+
+	if len(record.Dynamodb.Keys) == 0 {
+		return nil, fmt.Errorf("keys is nil")
+	}
+
+	executionTime := time.Now()
+	if record.Dynamodb.ApproximateCreationDateTime != nil {
+		executionTime = *record.Dynamodb.ApproximateCreationDateTime
+	}
+
+	op := "r"
+	if record.EventName != nil {
+		switch *record.EventName {
+		case "INSERT":
+			op = "c"
+		case "MODIFY":
+			op = "u"
+		case "REMOVE":
+			op = "d"
+		}
+	}
+
+	return &Message{
+		op:            op,
+		tableName:     tableName,
+		executionTime: executionTime,
+		rowData:       transformNewImage(record.Dynamodb.NewImage),
+		primaryKey:    transformNewImage(record.Dynamodb.Keys),
+	}, nil
+}

--- a/lib/dynamo/parse_message.go
+++ b/lib/dynamo/parse_message.go
@@ -12,10 +12,13 @@ func NewMessageFromExport(item dynamodb.ItemResponse, keys []string, tableName s
 		return nil, fmt.Errorf("item is nil or keys do not exist in this item payload")
 	}
 
+	if len(keys) == 0 {
+		return nil, fmt.Errorf("keys is nil")
+	}
+
 	// Snapshot time does not exist on the row
 	// Perhaps we can have it inferred from the manifest file in the future.
 	executionTime := time.Now()
-	op := "r"
 
 	rowData := transformNewImage(item.Item)
 	primaryKeys := make(map[string]interface{})
@@ -29,7 +32,7 @@ func NewMessageFromExport(item dynamodb.ItemResponse, keys []string, tableName s
 	}
 
 	return &Message{
-		op:            op,
+		op:            "r",
 		tableName:     tableName,
 		executionTime: executionTime,
 		rowData:       rowData,

--- a/lib/dynamo/parse_message_test.go
+++ b/lib/dynamo/parse_message_test.go
@@ -1,0 +1,65 @@
+package dynamo
+
+import (
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/stretchr/testify/assert"
+)
+
+func (d *DynamoDBTestSuite) Test_NewMessageFromExport() {
+	type _tc struct {
+		name          string
+		item          dynamodb.ItemResponse
+		keys          []string
+		tableName     string
+		expectedError string
+	}
+
+	tcs := []_tc{
+		{
+			name: "Test with empty item",
+			item: dynamodb.ItemResponse{
+				Item: map[string]*dynamodb.AttributeValue{},
+			},
+			keys:          []string{"id"},
+			tableName:     "test",
+			expectedError: "item is nil or keys do not exist in this item payload",
+		},
+		{
+			name: "Test with empty keys",
+			item: dynamodb.ItemResponse{
+				Item: map[string]*dynamodb.AttributeValue{
+					"id": {
+						S: ptr.ToString("1"),
+					},
+				},
+			},
+			keys:          []string{},
+			tableName:     "test",
+			expectedError: "keys is nil",
+		},
+		{
+			name: "Test with valid item and keys",
+			item: dynamodb.ItemResponse{
+				Item: map[string]*dynamodb.AttributeValue{
+					"id": {
+						S: ptr.ToString("1"),
+					},
+				},
+			},
+			keys:      []string{"id"},
+			tableName: "test",
+		},
+	}
+
+	for _, tc := range tcs {
+		msg, err := NewMessageFromExport(tc.item, tc.keys, tc.tableName)
+		if tc.expectedError != "" {
+			assert.Equal(d.T(), tc.expectedError, err.Error(), tc.name)
+		} else {
+			assert.NoError(d.T(), err, tc.name)
+			assert.Equal(d.T(), tc.tableName, msg.tableName, tc.name)
+			assert.Equal(d.T(), "r", msg.op, tc.name)
+		}
+	}
+}

--- a/lib/s3lib/s3lib.go
+++ b/lib/s3lib/s3lib.go
@@ -1,29 +1,24 @@
 package s3lib
 
 import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"fmt"
-	"github.com/artie-labs/transfer/lib/ptr"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 type S3Client struct {
 	client *s3.S3
 }
 
-func NewClient(region string) (*S3Client, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Region: ptr.ToString(region),
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	svc := s3.New(sess)
-	return &S3Client{client: svc}, nil
+func NewClient(session *session.Session) *S3Client {
+	return &S3Client{client: s3.New(session)}
 }
 
 func bucketAndPrefixFromFilePath(fp string) (*string, *string, error) {
@@ -40,17 +35,25 @@ func bucketAndPrefixFromFilePath(fp string) (*string, *string, error) {
 	return &bucket, &prefix, nil
 }
 
-func (s *S3Client) ListFiles(fp string) ([]string, error) {
+type S3File struct {
+	Bucket *string `yaml:"bucket"`
+	Key    *string `yaml:"key"`
+}
+
+func (s *S3Client) ListFiles(fp string) ([]S3File, error) {
 	bucket, prefix, err := bucketAndPrefixFromFilePath(fp)
 	if err != nil {
 		return nil, err
 	}
 
-	var objects []string
+	var files []S3File
 	err = s.client.ListObjectsPages(&s3.ListObjectsInput{Bucket: bucket, Prefix: prefix},
 		func(page *s3.ListObjectsOutput, lastPage bool) bool {
 			for _, object := range page.Contents {
-				objects = append(objects, *object.Key)
+				files = append(files, S3File{
+					Key:    object.Key,
+					Bucket: bucket,
+				})
 			}
 
 			return true
@@ -60,9 +63,52 @@ func (s *S3Client) ListFiles(fp string) ([]string, error) {
 		return nil, err
 	}
 
-	return objects, nil
+	return files, nil
 }
 
-func StreamJsonGZFile() {
+// StreamJsonGzipFile - will take a S3 File that is in `json.gz` format from DynamoDB's export to S3
+// It's not a typical JSON file in that it is compressed and it's new line delimited via separated via an array
+// Which means we can stream this file row by row to not OOM.
+func (s *S3Client) StreamJsonGzipFile(file S3File, ch chan<- dynamodb.ItemResponse) error {
+	defer close(ch)
 
+	result, err := s.client.GetObject(&s3.GetObjectInput{
+		Bucket: file.Bucket,
+		Key:    file.Key,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get object from S3, err: %v", err)
+	}
+
+	defer result.Body.Close()
+
+	buf := &bytes.Buffer{}
+	_, err = buf.ReadFrom(result.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read from S3 object, err: %v", err)
+	}
+
+	// Create a gzip reader
+	gz, err := gzip.NewReader(buf)
+	if err != nil {
+		return fmt.Errorf("failed to create a GZIP reader for object, err: %v", err)
+	}
+	defer gz.Close()
+
+	scanner := bufio.NewScanner(gz)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var content dynamodb.ItemResponse
+		if err := json.Unmarshal(line, &content); err != nil {
+			return fmt.Errorf("failed to unmarshal, err: %v", err)
+		}
+
+		ch <- content
+	}
+
+	if err = scanner.Err(); err != nil {
+		return fmt.Errorf("error reading from S3 object, err: %v", err)
+	}
+
+	return nil
 }

--- a/lib/s3lib/s3lib.go
+++ b/lib/s3lib/s3lib.go
@@ -1,0 +1,58 @@
+package s3lib
+
+import (
+	"fmt"
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"strings"
+)
+
+func bucketAndPrefixFromFilePath(fp string) (*string, *string, error) {
+	// Remove the s3:// prefix if it's there
+	fp = strings.TrimPrefix(fp, "s3://")
+
+	parts := strings.SplitN(fp, "/", 2)
+	if len(parts) < 2 {
+		return nil, nil, fmt.Errorf("invalid S3 path, missing prefix")
+	}
+
+	bucket := parts[0]
+	prefix := parts[1]
+	return &bucket, &prefix, nil
+}
+
+func ListFiles(region, fp string) ([]string, error) {
+	// Initialize a session using Amazon SDK
+	sess, err := session.NewSession(&aws.Config{
+		Region: ptr.ToString(region),
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	svc := s3.New(sess)
+
+	bucket, prefix, err := bucketAndPrefixFromFilePath(fp)
+	if err != nil {
+		return nil, err
+	}
+
+	var objects []string
+	err = svc.ListObjectsPages(&s3.ListObjectsInput{Bucket: bucket, Prefix: prefix},
+		func(page *s3.ListObjectsOutput, lastPage bool) bool {
+			for _, object := range page.Contents {
+				objects = append(objects, *object.Key)
+			}
+
+			return true
+		})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return objects, nil
+}

--- a/lib/s3lib/s3lib_test.go
+++ b/lib/s3lib/s3lib_test.go
@@ -1,0 +1,75 @@
+package s3lib
+
+import (
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBucketAndPrefixFromFilePath(t *testing.T) {
+	type _tc struct {
+		name           string
+		fp             string
+		expectedBucket *string
+		expectedPrefix *string
+		expectedErr    bool
+	}
+
+	tcs := []_tc{
+		{
+			name:           "valid path (w/ S3 prefix)",
+			fp:             "s3://bucket/prefix",
+			expectedBucket: ptr.ToString("bucket"),
+			expectedPrefix: ptr.ToString("prefix"),
+		},
+		{
+			name:           "valid path (w/ S3 prefix) with trailing slash",
+			fp:             "s3://bucket/prefix/",
+			expectedBucket: ptr.ToString("bucket"),
+			expectedPrefix: ptr.ToString("prefix/"),
+		},
+		{
+			name:           "valid path (w/ S3 prefix) with multiple slashes",
+			fp:             "s3://bucket/prefix/with/multiple/slashes",
+			expectedBucket: ptr.ToString("bucket"),
+			expectedPrefix: ptr.ToString("prefix/with/multiple/slashes"),
+		},
+		// Without S3 prefix
+		{
+			name:           "valid path (w/o S3 prefix)",
+			fp:             "bucket/prefix",
+			expectedBucket: ptr.ToString("bucket"),
+			expectedPrefix: ptr.ToString("prefix"),
+		},
+		{
+			name:           "valid path (w/o S3 prefix) with trailing slash",
+			fp:             "bucket/prefix/",
+			expectedBucket: ptr.ToString("bucket"),
+			expectedPrefix: ptr.ToString("prefix/"),
+		},
+		{
+			name:           "valid path (w/o S3 prefix) with multiple slashes",
+			fp:             "bucket/prefix/with/multiple/slashes",
+			expectedBucket: ptr.ToString("bucket"),
+			expectedPrefix: ptr.ToString("prefix/with/multiple/slashes"),
+		},
+		{
+			name:        "invalid path",
+			fp:          "s3://bucket",
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		actualBucket, actualPrefix, actualErr := bucketAndPrefixFromFilePath(tc.fp)
+		if tc.expectedErr {
+			assert.Error(t, actualErr, tc.name)
+		} else {
+			assert.NoError(t, actualErr, tc.name)
+
+			// Now check the actualBucket and prefix
+			assert.Equal(t, *tc.expectedBucket, *actualBucket, tc.name)
+			assert.Equal(t, *tc.expectedPrefix, *actualPrefix, tc.name)
+		}
+	}
+}

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -71,7 +71,7 @@ func (s *Store) Run(ctx context.Context) {
 			logger.FromContext(ctx).WithError(err).Fatalf("scanning files over bucket failed")
 		}
 
-		if err := s.ReadAndPublish(ctx); err != nil {
+		if err := s.streamAndPublish(ctx); err != nil {
 			logger.FromContext(ctx).WithError(err).Fatalf("scanning files over bucket failed")
 		}
 

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -2,7 +2,6 @@ package dynamodb
 
 import (
 	"context"
-	"fmt"
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib/logger"
 	"github.com/artie-labs/reader/lib/s3lib"
@@ -68,9 +67,6 @@ func Load(ctx context.Context) *Store {
 
 func (s *Store) Run(ctx context.Context) {
 	if s.cfg.Snapshot {
-		keys, err := s.RetrievePrimaryKeys()
-		fmt.Println("keys", keys, "err", err)
-
 		if err := s.scanFilesOverBucket(); err != nil {
 			logger.FromContext(ctx).WithError(err).Fatalf("scanning files over bucket failed")
 		}

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -28,7 +28,6 @@ const shardScannerInterval = 5 * time.Minute
 
 func Load(ctx context.Context) *Store {
 	cfg := config.FromContext(ctx)
-
 	sess, err := session.NewSession(&aws.Config{
 		Region:      ptr.ToString(cfg.DynamoDB.AwsRegion),
 		Credentials: credentials.NewStaticCredentials(cfg.DynamoDB.AwsAccessKeyID, cfg.DynamoDB.AwsSecretAccessKey, ""),

--- a/sources/dynamodb/primary_keys.go
+++ b/sources/dynamodb/primary_keys.go
@@ -1,0 +1,27 @@
+package dynamodb
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+)
+
+func (s *Store) RetrievePrimaryKeys() ([]string, error) {
+	output, err := s.dynamoDBClient.DescribeTable(&dynamodb.DescribeTableInput{
+		TableName: &s.tableName,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []string
+	for _, key := range output.Table.KeySchema {
+		if key.AttributeName != nil {
+			keys = append(keys, *key.AttributeName)
+		} else {
+			return nil, fmt.Errorf("key does not have attribute name, key: %v", key.String())
+		}
+	}
+
+	return keys, nil
+}

--- a/sources/dynamodb/primary_keys.go
+++ b/sources/dynamodb/primary_keys.go
@@ -5,7 +5,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
-func (s *Store) RetrievePrimaryKeys() ([]string, error) {
+// retrievePrimaryKeys - This function is called when we process the DynamoDB table snapshot.
+// This is because the snapshot is a JSON file and it does not contain which are the partition and sort keys.
+func (s *Store) retrievePrimaryKeys() ([]string, error) {
 	output, err := s.dynamoDBClient.DescribeTable(&dynamodb.DescribeTableInput{
 		TableName: &s.tableName,
 	})

--- a/sources/dynamodb/snapshot.go
+++ b/sources/dynamodb/snapshot.go
@@ -29,10 +29,10 @@ func (s *Store) scanFilesOverBucket() error {
 	return nil
 }
 
-func (s *Store) ReadAndPublish(ctx context.Context) error {
+func (s *Store) streamAndPublish(ctx context.Context) error {
 	log := logger.FromContext(ctx)
 
-	keys, err := s.RetrievePrimaryKeys()
+	keys, err := s.retrievePrimaryKeys()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve primary keys, err: %v", err)
 	}

--- a/sources/dynamodb/snapshot.go
+++ b/sources/dynamodb/snapshot.go
@@ -1,5 +1,29 @@
 package dynamodb
 
-func (s *Store) scanFilesOverBucket(bucket string) error {
+import (
+	"context"
+	"fmt"
+	"github.com/artie-labs/reader/lib/logger"
+)
+
+func (s *Store) scanFilesOverBucket() error {
+	files, err := s.s3Client.ListFiles(s.cfg.SnapshotSettings.Folder)
+	if err != nil {
+		return fmt.Errorf("failed to list files, err: %v", err)
+	}
+
+	if len(files) == 0 {
+		return fmt.Errorf("no files found in the folder: %v", s.cfg.SnapshotSettings.Folder)
+	}
+
+	s.cfg.SnapshotSettings.SpecifiedFiles = files
+	return nil
+}
+
+func (s *Store) ReadAndPublish(ctx context.Context) error {
+	for _, file := range s.cfg.SnapshotSettings.SpecifiedFiles {
+		logger.FromContext(ctx).Info("processing file: ", file)
+	}
+
 	return nil
 }

--- a/sources/dynamodb/snapshot.go
+++ b/sources/dynamodb/snapshot.go
@@ -1,0 +1,5 @@
+package dynamodb
+
+func (s *Store) scanFilesOverBucket(bucket string) error {
+	return nil
+}


### PR DESCRIPTION
## Scope of the PR

In this PR, we are adding the ability to take a snapshot of a DynamoDB table. 

## How does snapshotting work?

Snapshot works in 2 ways:

1. You can pass in the S3 folder, or
2. You can specify the files to read which will have parallelism.

```yaml
dynamodb:
  snapshot: true
  snapshotSettings:
    folder: s3://artie-transfer-test/AWSDynamoDB/EXPORT_ID/data
    specifiedFiles:
      - bucket: artie-transfer-test
        key: AWSDynamoDB/EXPORT_ID/data/file.json.gz
```

If you pass in both, the folder will be ignored and Artie Reader will prioritize specifiedFiles.
 


## Changes

- [x] S3 Client
- [x] Ability to have parallelism
- [x] Read from `json.gz`
- [x] Graceful shutdown once completed
- [x] Document