### PR TITLE
Add Go package caching to GitHub Action

### DIFF
--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -5,11 +5,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # Checks out the code
+      - uses: actions/checkout@v4 # Checks out the code
       - name: Setting Go up
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21
+          cache-dependency-path: go.sum
       - name: Run staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -10,7 +10,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.21
-          cache-dependency-path: go.sum
       - name: Run staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
https://github.com/actions/setup-go?tab=readme-ov-file#v4 has caching by default.