### PR TITLE
Standardize logging

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,10 +3,11 @@ package config
 import (
 	"context"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"log"
 	"os"
-	
+
+	"gopkg.in/yaml.v2"
+
 	"github.com/artie-labs/reader/constants"
 )
 
@@ -87,17 +88,17 @@ func (s *Settings) Validate() error {
 func ReadConfig(fp string) (*Settings, error) {
 	bytes, err := os.ReadFile(fp)
 	if err != nil {
-		log.Fatalf("failed to read config file, err: %v", err)
+		log.Fatalf("Failed to read config file, err: %v", err)
 	}
 
 	var settings Settings
 	err = yaml.Unmarshal(bytes, &settings)
 	if err != nil {
-		log.Fatalf("failed to unmarshal config file, err: %v", err)
+		log.Fatalf("Failed to unmarshal config file, err: %v", err)
 	}
 
 	if err = settings.Validate(); err != nil {
-		log.Fatalf("failed to validate config file, err: %v", err)
+		log.Fatalf("Failed to validate config file, err: %v", err)
 	}
 
 	settings.Kafka.GenerateDefault()

--- a/lib/kafkalib/batch.go
+++ b/lib/kafkalib/batch.go
@@ -85,11 +85,11 @@ func (b *Batch) Publish(ctx context.Context) error {
 			}
 
 			sleepDuration := time.Duration(jitter.JitterMs(RetryDelayMs, attempts)) * time.Millisecond
-			slog.With(
+			slog.Warn("Failed to publish message, jitter sleeping before retrying...",
 				slog.Any("err", err),
 				slog.Int("attempts", attempts),
 				slog.Int("maxAttempts", MaxRetries),
-			).Warn("failed to publish message, jitter sleeping before retrying...")
+			)
 			time.Sleep(sleepDuration)
 		}
 

--- a/lib/kafkalib/kafka.go
+++ b/lib/kafkalib/kafka.go
@@ -19,12 +19,12 @@ import (
 func FromContext(ctx context.Context) *kafka.Writer {
 	kafkaVal := ctx.Value(constants.KafkaKey)
 	if kafkaVal == nil {
-		logger.Fatal("kafka is not set in context.Context")
+		logger.Fatal("Kafka is not set in context.Context")
 	}
 
 	kafkaWriter, isOk := kafkaVal.(*kafka.Writer)
 	if !isOk {
-		logger.Fatal("kafka writer is not type *kafka.Writer")
+		logger.Fatal("Kafka writer is not type *kafka.Writer")
 	}
 
 	return kafkaWriter
@@ -37,7 +37,7 @@ func InjectIntoContext(ctx context.Context) context.Context {
 		logger.Fatal("Kafka configuration is not set")
 	}
 
-	slog.With("url", strings.Split(cfg.Kafka.BootstrapServers, ",")).Info("setting bootstrap url")
+	slog.Info("Setting bootstrap url", slog.Any("url", strings.Split(cfg.Kafka.BootstrapServers, ",")))
 
 	writer := &kafka.Writer{
 		Addr:                   kafka.TCP(strings.Split(cfg.Kafka.BootstrapServers, ",")...),

--- a/lib/mtr/mtr.go
+++ b/lib/mtr/mtr.go
@@ -19,12 +19,12 @@ func InjectDatadogIntoCtx(ctx context.Context, namespace string, tags []string, 
 	address := DefaultAddr
 	if !stringutil.Empty(host, port) {
 		address = fmt.Sprintf("%s:%s", host, port)
-		slog.With("address", address).Info("overriding telemetry address with env vars")
+		slog.Info("Overriding telemetry address with env vars", slog.String("address", address))
 	}
 
 	datadogClient, err := statsd.New(address)
 	if err != nil {
-		logger.Fatal("failed to create datadog client", slog.Any("err", err))
+		logger.Fatal("Failed to create datadog client", slog.Any("err", err))
 	}
 
 	datadogClient.Tags = tags
@@ -38,12 +38,12 @@ func InjectDatadogIntoCtx(ctx context.Context, namespace string, tags []string, 
 func FromContext(ctx context.Context) Client {
 	metricsClientVal := ctx.Value(constants.MtrKey)
 	if metricsClientVal == nil {
-		logger.Fatal("metrics client is nil")
+		logger.Fatal("Metrics client is nil")
 	}
 
 	metricsClient, isOk := metricsClientVal.(Client)
 	if !isOk {
-		logger.Fatal("metrics client is not mtr.Client type")
+		logger.Fatal("Metrics client is not mtr.Client type")
 	}
 
 	return metricsClient

--- a/lib/ttlmap/ttlmap.go
+++ b/lib/ttlmap/ttlmap.go
@@ -45,7 +45,7 @@ func NewMap(ctx context.Context, filePath string, cleanupInterval, flushInterval
 	}
 
 	if err := t.loadFromFile(); err != nil {
-		slog.Warn("failed to load ttlmap from memory, starting a new one...", slog.Any("err", err))
+		slog.Warn("Failed to load ttlmap from memory, starting a new one...", slog.Any("err", err))
 	}
 
 	t.cleanupTicker = time.NewTicker(cleanupInterval)
@@ -95,7 +95,7 @@ func (t *TTLMap) cleanUpAndFlushRoutine() {
 			t.cleanup()
 		case <-t.flushTicker.C:
 			if err := t.flush(); err != nil {
-				logger.Fatal("failed to flush", slog.Any("err", err))
+				logger.Fatal("Failed to flush", slog.Any("err", err))
 			}
 		case <-t.closeChan:
 			return

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	cfg, err := config.ReadConfig(configFilePath)
 	if err != nil {
-		logger.Fatal("failed to read config file", slog.Any("err", err))
+		logger.Fatal("Failed to read config file", slog.Any("err", err))
 	}
 
 	_logger, usingSentry := logger.NewLogger(cfg)
@@ -34,7 +34,7 @@ func main() {
 	ctx := config.InjectIntoContext(context.Background(), cfg)
 	ctx = kafkalib.InjectIntoContext(ctx)
 	if cfg.Metrics != nil {
-		slog.Info("injecting datadog")
+		slog.Info("Injecting datadog")
 		ctx = mtr.InjectDatadogIntoCtx(ctx, cfg.Metrics.Namespace, cfg.Metrics.Tags, 0.5)
 	}
 

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -70,11 +70,11 @@ func Load(ctx context.Context) *Store {
 func (s *Store) Run(ctx context.Context) {
 	if s.cfg.Snapshot {
 		if err := s.scanFilesOverBucket(); err != nil {
-			logger.Fatal("scanning files over bucket failed", slog.Any("err", err))
+			logger.Fatal("Scanning files over bucket failed", slog.Any("err", err))
 		}
 
 		if err := s.streamAndPublish(ctx); err != nil {
-			logger.Fatal("stream and publish failed", slog.Any("err", err))
+			logger.Fatal("Stream and publish failed", slog.Any("err", err))
 		}
 
 		slog.Info("Finished snapshotting all the files")


### PR DESCRIPTION
- Uppercase log messages
- Add arguments in log call instead of using `.With()`