### PR TITLE
[Kafka Publish Size] Reduce to 2.5k

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -10,5 +10,5 @@ const (
 
 const (
 	DefaultLimit       = 5_000
-	DefaultPublishSize = 5_000
+	DefaultPublishSize = 2_500
 )


### PR DESCRIPTION
Let's reduce Kafka publish size to 2.5k to be backwards compatible