### PR TITLE
[PostgreSQL] Include DisableSSL

### DIFF
--- a/config/postgres.go
+++ b/config/postgres.go
@@ -7,12 +7,13 @@ import (
 )
 
 type PostgreSQL struct {
-	Host     string             `yaml:"host"`
-	Port     string             `yaml:"port"`
-	Username string             `yaml:"userName"`
-	Password string             `yaml:"password"`
-	Database string             `yaml:"database"`
-	Tables   []*PostgreSQLTable `yaml:"tables"`
+	Host       string             `yaml:"host"`
+	Port       string             `yaml:"port"`
+	Username   string             `yaml:"userName"`
+	Password   string             `yaml:"password"`
+	Database   string             `yaml:"database"`
+	Tables     []*PostgreSQLTable `yaml:"tables"`
+	DisableSSL bool               `yaml:"disableSSL"`
 }
 
 type PostgreSQLTable struct {


### PR DESCRIPTION
## Changes

Adding `DisableSSL` to the config so we can maintain feature parity with `custom-snapshots` and allow us to disable SSL for running this against a local database