### PR TITLE
Fix bug fetching new batches on subsequent attempts

### DIFF
--- a/lib/kafkalib/batch.go
+++ b/lib/kafkalib/batch.go
@@ -66,13 +66,12 @@ func (b *Batch) NextChunk() []kafka.Message {
 func (b *Batch) Publish(ctx context.Context) error {
 	for b.HasNext() {
 		var err error
-		var count int64
 		tags := map[string]string{
 			"what": "error",
 		}
 
 		chunk := b.NextChunk()
-		count = int64(len(chunk))
+		count := int64(len(chunk))
 
 		for attempts := 0; attempts < MaxRetries; attempts++ {
 			err = FromContext(ctx).WriteMessages(ctx, chunk...)

--- a/lib/kafkalib/batch.go
+++ b/lib/kafkalib/batch.go
@@ -75,7 +75,6 @@ func (b *Batch) Publish(ctx context.Context) error {
 		count = int64(len(chunk))
 
 		for attempts := 0; attempts < MaxRetries; attempts++ {
-
 			err = FromContext(ctx).WriteMessages(ctx, chunk...)
 			if err == nil {
 				tags["what"] = "success"

--- a/lib/kafkalib/batch.go
+++ b/lib/kafkalib/batch.go
@@ -71,9 +71,11 @@ func (b *Batch) Publish(ctx context.Context) error {
 			"what": "error",
 		}
 
+		chunk := b.NextChunk()
+		count = int64(len(chunk))
+
 		for attempts := 0; attempts < MaxRetries; attempts++ {
-			chunk := b.NextChunk()
-			count = int64(len(chunk))
+
 			err = FromContext(ctx).WriteMessages(ctx, chunk...)
 			if err == nil {
 				tags["what"] = "success"


### PR DESCRIPTION
If sending a batch fails we are sending the next batch on the next attempt rather than the batch that failed.