### PR TITLE
Move RawMessage out of kafkalib

### DIFF
--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"time"
 
-	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/size"
 	"github.com/segmentio/kafka-go"
 
@@ -48,13 +47,7 @@ func (w *BatchWriter) reload() error {
 	return nil
 }
 
-type RawMessage struct {
-	TopicSuffix  string
-	PartitionKey map[string]interface{}
-	Payload      util.SchemaEventPayload
-}
-
-func buildKafkaMessages(cfg *config.Kafka, msgs []RawMessage) ([]kafka.Message, error) {
+func buildKafkaMessages(cfg *config.Kafka, msgs []lib.RawMessage) ([]kafka.Message, error) {
 	result := make([]kafka.Message, len(msgs))
 	for i, msg := range msgs {
 		topic := fmt.Sprintf("%s.%s", cfg.TopicPrefix, msg.TopicSuffix)
@@ -67,7 +60,7 @@ func buildKafkaMessages(cfg *config.Kafka, msgs []RawMessage) ([]kafka.Message, 
 	return result, nil
 }
 
-func (k *BatchWriter) Write(rawMsgs []RawMessage) error {
+func (k *BatchWriter) Write(rawMsgs []lib.RawMessage) error {
 	msgs, err := buildKafkaMessages(&k.cfg, rawMsgs)
 	if err != nil {
 		return fmt.Errorf("failed to build to kafka messages: %w", err)

--- a/lib/postgres/iterator.go
+++ b/lib/postgres/iterator.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/artie-labs/reader/config"
-	"github.com/artie-labs/reader/lib/kafkalib"
+	"github.com/artie-labs/reader/lib"
 	"github.com/artie-labs/reader/lib/mtr"
 	"github.com/artie-labs/reader/lib/postgres/debezium"
 	"github.com/artie-labs/transfer/lib/size"
@@ -69,7 +69,7 @@ func (i *TableIterator) statsDTags() map[string]string {
 	}
 }
 
-func (i *TableIterator) Next() ([]kafkalib.RawMessage, error) {
+func (i *TableIterator) Next() ([]lib.RawMessage, error) {
 	var rows []map[string]interface{}
 	rows, err := i.postgresTable.StartScanning(i.db,
 		NewScanningArgs(i.postgresTable.PrimaryKeys, i.limit, DefaultErrorRetries, i.firstRow, i.lastRow))
@@ -78,7 +78,7 @@ func (i *TableIterator) Next() ([]kafkalib.RawMessage, error) {
 	}
 
 	i.firstRow = false
-	var msgs []kafkalib.RawMessage
+	var msgs []lib.RawMessage
 	for _, row := range rows {
 		start := time.Now()
 		partitionKeyMap := make(map[string]interface{})
@@ -104,7 +104,7 @@ func (i *TableIterator) Next() ([]kafkalib.RawMessage, error) {
 			return nil, fmt.Errorf("failed to generate payload: %w", err)
 		}
 
-		msgs = append(msgs, kafkalib.RawMessage{
+		msgs = append(msgs, lib.RawMessage{
 			TopicSuffix:  i.postgresTable.TopicSuffix(),
 			PartitionKey: partitionKeyMap,
 			Payload:      payload,

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,0 +1,9 @@
+package lib
+
+import "github.com/artie-labs/transfer/lib/cdc/util"
+
+type RawMessage struct {
+	TopicSuffix  string
+	PartitionKey map[string]interface{}
+	Payload      util.SchemaEventPayload
+}


### PR DESCRIPTION
That way `lib/kafkalib` and `lib/postgres` do not need to know about each other.