### PR TITLE
Cleanup postgres table iterator

### DIFF
--- a/lib/postgres/iterator.go
+++ b/lib/postgres/iterator.go
@@ -18,7 +18,7 @@ const DefaultErrorRetries = 10
 
 type TableIterator struct {
 	db            *sql.DB
-	limit         uint
+	batchSize     uint
 	statsD        *mtr.Client
 	maxRowSize    uint64
 	postgresTable *Table
@@ -28,29 +28,29 @@ type TableIterator struct {
 }
 
 func LoadTable(db *sql.DB, table *config.PostgreSQLTable, statsD *mtr.Client, maxRowSize uint64) (TableIterator, error) {
-	slog.Info("Loading configuration for table", slog.String("table", table.Name), slog.Any("limitSize", table.GetLimit()))
+	slog.Info("Loading configuration for table", slog.String("table", table.Name))
 
 	postgresTable := NewTable(table)
-	err := postgresTable.RetrieveColumns(db)
-	if err != nil {
+	if err := postgresTable.RetrieveColumns(db); err != nil {
 		if NoRowsError(err) {
 			slog.Info("Table does not contain any rows, skipping...", slog.String("table", table.Name))
-			return TableIterator{}, nil
+			return TableIterator{done: true}, nil
 		} else {
-			return TableIterator{}, fmt.Errorf("failed to validate postgres: %w", err)
+			return TableIterator{done: true}, fmt.Errorf("failed to validate postgres: %w", err)
 		}
 	}
 
 	slog.Info("Scanning table",
-		slog.String("topicSuffix", postgresTable.TopicSuffix()),
 		slog.String("tableName", postgresTable.Name),
 		slog.String("schemaName", postgresTable.Schema),
+		slog.String("topicSuffix", postgresTable.TopicSuffix()),
 		slog.Any("primaryKeyColumns", postgresTable.PrimaryKeys.Keys()),
+		slog.Any("batchSize", table.GetLimit()),
 	)
 
 	return TableIterator{
 		db:            db,
-		limit:         table.GetLimit(),
+		batchSize:     table.GetLimit(),
 		statsD:        statsD,
 		maxRowSize:    maxRowSize,
 		postgresTable: postgresTable,
@@ -62,23 +62,35 @@ func (i *TableIterator) HasNext() bool {
 	return !i.done
 }
 
-func (i *TableIterator) statsDTags() map[string]string {
-	return map[string]string{
-		"table":  strings.ReplaceAll(i.postgresTable.Name, `"`, ``),
-		"schema": i.postgresTable.Schema,
+func (i *TableIterator) recordMetrics(start time.Time) {
+	if i.statsD != nil {
+		(*i.statsD).Timing("scanned_and_parsed", time.Since(start), map[string]string{
+			"table":  strings.ReplaceAll(i.postgresTable.Name, `"`, ``),
+			"schema": i.postgresTable.Schema,
+		})
 	}
 }
 
 func (i *TableIterator) Next() ([]lib.RawMessage, error) {
-	var rows []map[string]interface{}
+	if i.done {
+		return nil, fmt.Errorf("cannot call Next() on a closed iterator")
+	}
+
 	rows, err := i.postgresTable.StartScanning(i.db,
-		NewScanningArgs(i.postgresTable.PrimaryKeys, i.limit, DefaultErrorRetries, i.firstRow, i.lastRow))
+		NewScanningArgs(i.postgresTable.PrimaryKeys, i.batchSize, DefaultErrorRetries, i.firstRow, i.lastRow))
 	if err != nil {
 		return nil, fmt.Errorf("failed to scan postgres: %w", err)
+	} else if len(rows) == 0 {
+		slog.Info("Finished scanning", slog.String("table", i.postgresTable.Name))
+		i.done = true
+		return make([]lib.RawMessage, 0), nil
 	}
 
 	i.firstRow = false
-	var msgs []lib.RawMessage
+	// If the number of rows returned is less than the batch size, we've reached the end of the table
+	i.lastRow = i.batchSize > uint(len(rows))
+
+	var result []lib.RawMessage
 	for _, row := range rows {
 		start := time.Now()
 		partitionKeyMap := make(map[string]interface{})
@@ -99,33 +111,16 @@ func (i *TableIterator) Next() ([]lib.RawMessage, error) {
 			Fields:    i.postgresTable.Config.Fields,
 			RowData:   row,
 		})
-
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate payload: %w", err)
 		}
 
-		msgs = append(msgs, lib.RawMessage{
+		result = append(result, lib.RawMessage{
 			TopicSuffix:  i.postgresTable.TopicSuffix(),
 			PartitionKey: partitionKeyMap,
 			Payload:      payload,
 		})
-		if i.statsD != nil {
-			(*i.statsD).Timing("scanned_and_parsed", time.Since(start), i.statsDTags())
-		}
+		i.recordMetrics(start)
 	}
-
-	// TODO: This should really be re-written and tested thoroughly
-	// It's super confusing to read.
-	if i.limit > uint(len(rows)) {
-		if len(rows) == 0 {
-			slog.Info("Finished scanning, exiting...", slog.Int("rows", len(rows)))
-			i.done = true
-		} else {
-			i.lastRow = true
-		}
-	} else {
-		i.lastRow = false
-	}
-
-	return msgs, nil
+	return result, nil
 }

--- a/lib/postgres/iterator.go
+++ b/lib/postgres/iterator.go
@@ -88,6 +88,7 @@ func (i *TableIterator) Next() ([]lib.RawMessage, error) {
 
 	i.firstRow = false
 	// If the number of rows returned is less than the batch size, we've reached the end of the table
+	// TODO: Can we just exit in this case?
 	i.lastRow = i.batchSize > uint(len(rows))
 
 	var result []lib.RawMessage

--- a/lib/postgres/iterator.go
+++ b/lib/postgres/iterator.go
@@ -73,7 +73,7 @@ func (i *TableIterator) recordMetrics(start time.Time) {
 
 func (i *TableIterator) Next() ([]lib.RawMessage, error) {
 	if !i.HasNext() {
-		return nil, nil
+		return make([]lib.RawMessage, 0), nil
 	}
 
 	rows, err := i.postgresTable.StartScanning(i.db,


### PR DESCRIPTION
- Rename `limit` to `batchSize`
- Exit early when we get back an empty array of rows
- Guard against calling `Next()` on an iterator that's already completed
- Return a closed iterator when scanning a table without any rows