### PR TITLE
Move postgres scanning logic out of table iterator

### DIFF
--- a/lib/postgres/iterator.go
+++ b/lib/postgres/iterator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/artie-labs/transfer/lib/size"
 )
 
-const DefaultErrorRetries = 10
+const defaultErrorRetries = 10
 
 type TableIterator struct {
 	statsD        *mtr.Client
@@ -48,7 +48,7 @@ func LoadTable(db *sql.DB, table *config.PostgreSQLTable, statsD *mtr.Client, ma
 		statsD:        statsD,
 		maxRowSize:    maxRowSize,
 		postgresTable: postgresTable,
-		scanner:       NewScanner(db, postgresTable, table.GetLimit(), DefaultErrorRetries),
+		scanner:       NewScanner(db, postgresTable, table.GetLimit(), defaultErrorRetries),
 	}, nil
 }
 

--- a/lib/postgres/iterator.go
+++ b/lib/postgres/iterator.go
@@ -48,7 +48,7 @@ func LoadTable(db *sql.DB, table *config.PostgreSQLTable, statsD *mtr.Client, ma
 		statsD:        statsD,
 		maxRowSize:    maxRowSize,
 		postgresTable: postgresTable,
-		scanner:       NewScanner(db, postgresTable, table.GetLimit(), defaultErrorRetries),
+		scanner:       postgresTable.NewScanner(db, table.GetLimit(), defaultErrorRetries),
 	}, nil
 }
 

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -44,7 +44,7 @@ func NewScanningArgs(primaryKeys *primary_key.Keys, limit uint, errorRetries int
 	}
 }
 
-func (t *Table) StartScanning(db *sql.DB, scanningArgs ScanningArgs) ([]map[string]interface{}, error) {
+func (t *Table) startScanning(db *sql.DB, scanningArgs ScanningArgs) ([]map[string]interface{}, error) {
 	firstWhereClause := queries.GreaterThan
 	if scanningArgs.IsFirstRow {
 		firstWhereClause = queries.GreaterThanEqualTo
@@ -82,7 +82,7 @@ func (t *Table) StartScanning(db *sql.DB, scanningArgs ScanningArgs) ([]map[stri
 			slog.Info(fmt.Sprintf("We still have %v attempts", attempts), slog.Int("sleepMs", sleepMs), slog.Any("err", err))
 			scanningArgs.errorAttempts += 1
 			time.Sleep(time.Duration(sleepMs) * time.Millisecond)
-			return t.StartScanning(db, scanningArgs)
+			return t.startScanning(db, scanningArgs)
 		}
 
 		return nil, err
@@ -155,4 +155,49 @@ func (t *Table) StartScanning(db *sql.DB, scanningArgs ScanningArgs) ([]map[stri
 	}
 
 	return parsedRows, nil
+}
+
+type scanner struct {
+	db            *sql.DB
+	postgresTable *Table
+	batchSize     uint
+	firstRow      bool
+	lastRow       bool
+	done          bool
+	errorRetries  int
+}
+
+func NewScanner(db *sql.DB, postgresTable *Table, batchSize uint, errorRetries int) scanner {
+	return scanner{
+		db:            db,
+		postgresTable: postgresTable,
+		batchSize:     batchSize,
+		errorRetries:  errorRetries,
+		firstRow:      true,
+		lastRow:       false,
+		done:          false,
+	}
+}
+func (s *scanner) HasNext() bool {
+	return !s.done
+}
+
+func (s *scanner) Next() ([]map[string]interface{}, error) {
+	if !s.HasNext() {
+		return nil, fmt.Errorf("no more rows to scan")
+	}
+	rows, err := s.postgresTable.startScanning(s.db,
+		NewScanningArgs(s.postgresTable.PrimaryKeys, s.batchSize, s.errorRetries, s.firstRow, s.lastRow),
+	)
+	if err != nil {
+		return nil, err
+	} else if len(rows) == 0 {
+		slog.Info("Finished scanning", slog.String("table", s.postgresTable.Name))
+		s.done = true
+		return nil, nil
+	}
+	s.firstRow = false
+	// The reason why lastRow exists is because in the past, we had queries only return partial results but it wasn't fully done
+	s.lastRow = s.batchSize > uint(len(rows))
+	return rows, nil
 }

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -192,6 +192,7 @@ func (s *scanner) Next() ([]map[string]interface{}, error) {
 		NewScanningArgs(s.table.PrimaryKeys, s.batchSize, s.errorRetries, s.firstRow, s.lastRow),
 	)
 	if err != nil {
+		s.done = true
 		return nil, err
 	} else if len(rows) == 0 {
 		slog.Info("Finished scanning", slog.String("table", s.table.Name))

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -157,6 +157,18 @@ func (t *Table) startScanning(db *sql.DB, scanningArgs ScanningArgs) ([]map[stri
 	return parsedRows, nil
 }
 
+func (t *Table) NewScanner(db *sql.DB, batchSize uint, errorRetries int) scanner {
+	return scanner{
+		db:            db,
+		postgresTable: t,
+		batchSize:     batchSize,
+		errorRetries:  errorRetries,
+		firstRow:      true,
+		lastRow:       false,
+		done:          false,
+	}
+}
+
 type scanner struct {
 	db            *sql.DB
 	postgresTable *Table
@@ -167,17 +179,6 @@ type scanner struct {
 	errorRetries  int
 }
 
-func NewScanner(db *sql.DB, postgresTable *Table, batchSize uint, errorRetries int) scanner {
-	return scanner{
-		db:            db,
-		postgresTable: postgresTable,
-		batchSize:     batchSize,
-		errorRetries:  errorRetries,
-		firstRow:      true,
-		lastRow:       false,
-		done:          false,
-	}
-}
 func (s *scanner) HasNext() bool {
 	return !s.done
 }

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -159,24 +159,25 @@ func (t *Table) startScanning(db *sql.DB, scanningArgs ScanningArgs) ([]map[stri
 
 func (t *Table) NewScanner(db *sql.DB, batchSize uint, errorRetries int) scanner {
 	return scanner{
-		db:            db,
-		postgresTable: t,
-		batchSize:     batchSize,
-		errorRetries:  errorRetries,
-		firstRow:      true,
-		lastRow:       false,
-		done:          false,
+		db:           db,
+		table:        t,
+		batchSize:    batchSize,
+		errorRetries: errorRetries,
+		firstRow:     true,
+		lastRow:      false,
+		done:         false,
 	}
 }
 
 type scanner struct {
-	db            *sql.DB
-	postgresTable *Table
-	batchSize     uint
-	firstRow      bool
-	lastRow       bool
-	done          bool
-	errorRetries  int
+	db           *sql.DB
+	table        *Table
+	batchSize    uint
+	errorRetries int
+
+	firstRow bool
+	lastRow  bool
+	done     bool
 }
 
 func (s *scanner) HasNext() bool {
@@ -187,13 +188,13 @@ func (s *scanner) Next() ([]map[string]interface{}, error) {
 	if !s.HasNext() {
 		return nil, fmt.Errorf("no more rows to scan")
 	}
-	rows, err := s.postgresTable.startScanning(s.db,
-		NewScanningArgs(s.postgresTable.PrimaryKeys, s.batchSize, s.errorRetries, s.firstRow, s.lastRow),
+	rows, err := s.table.startScanning(s.db,
+		NewScanningArgs(s.table.PrimaryKeys, s.batchSize, s.errorRetries, s.firstRow, s.lastRow),
 	)
 	if err != nil {
 		return nil, err
 	} else if len(rows) == 0 {
-		slog.Info("Finished scanning", slog.String("table", s.postgresTable.Name))
+		slog.Info("Finished scanning", slog.String("table", s.table.Name))
 		s.done = true
 		return nil, nil
 	}


### PR DESCRIPTION
The iterator shouldn't need to be concerned with `firstRow`, `lastRow`, or `done`, those should be the responsibility of the scanner. It's likely we can clean up the actual scanning code a bit after this, but I'm going to clean things up in stages.

This separates scanning the table from encoding the table as Debezium payloads.