### PR TITLE
Use a copy of the primary keys when scanning a table

### DIFF
--- a/lib/postgres/primary_key/primary_keys.go
+++ b/lib/postgres/primary_key/primary_keys.go
@@ -55,7 +55,7 @@ func (k *Keys) Length() int {
 	return len(k.keys)
 }
 
-func (k *Keys) Copy() *Keys {
+func (k *Keys) Clone() *Keys {
 	newKeys := NewKeys()
 	for _, key := range k.keys {
 		newKeys.keys = append(newKeys.keys, Key{key.Name, key.StartingValue, key.EndingValue})

--- a/lib/postgres/primary_key/primary_keys.go
+++ b/lib/postgres/primary_key/primary_keys.go
@@ -55,6 +55,17 @@ func (k *Keys) Length() int {
 	return len(k.keys)
 }
 
+func (k *Keys) Copy() *Keys {
+	newKeys := NewKeys()
+	for _, key := range k.keys {
+		newKeys.keys = append(newKeys.keys, Key{key.Name, key.StartingValue, key.EndingValue})
+	}
+	for key, value := range k.keyMap {
+		newKeys.keyMap[key] = value
+	}
+	return newKeys
+}
+
 func (k *Keys) Upsert(keyName string, startingVal *string, endingVal *string) {
 	_, isOk := k.keyMap[keyName]
 	if isOk {

--- a/lib/postgres/primary_key/primary_keys_test.go
+++ b/lib/postgres/primary_key/primary_keys_test.go
@@ -210,3 +210,25 @@ func TestKeys_Upsert(t *testing.T) {
 		assert.Equal(t, tc.expectedKeys, tc.keys.keys, tc.name)
 	}
 }
+
+func TestKeys_Copy(t *testing.T) {
+	// empty keys
+	{
+		keys := NewKeys()
+		keys2 := keys.Copy()
+		assert.Equal(t, keys.keys, keys2.keys)
+		assert.Equal(t, keys.keyMap, keys2.keyMap)
+	}
+	// non-empty keys
+	{
+		keys := NewKeys()
+		a := "a"
+		b := "b"
+		keys.Upsert("foo", &a, &b)
+		keys2 := keys.Copy()
+		assert.Equal(t, keys.keys, keys2.keys)
+		assert.Equal(t, keys.keyMap, keys2.keyMap)
+		assert.Equal(t, []Key{{"foo", a, b}}, keys2.keys)
+		assert.Equal(t, map[string]bool{"foo": true}, keys2.keyMap)
+	}
+}

--- a/lib/postgres/primary_key/primary_keys_test.go
+++ b/lib/postgres/primary_key/primary_keys_test.go
@@ -211,11 +211,11 @@ func TestKeys_Upsert(t *testing.T) {
 	}
 }
 
-func TestKeys_Copy(t *testing.T) {
+func TestKeys_Clone(t *testing.T) {
 	// empty keys
 	{
 		keys := NewKeys()
-		keys2 := keys.Copy()
+		keys2 := keys.Clone()
 		assert.Equal(t, keys.keys, keys2.keys)
 		assert.Equal(t, keys.keyMap, keys2.keyMap)
 	}
@@ -225,7 +225,7 @@ func TestKeys_Copy(t *testing.T) {
 		a := "a"
 		b := "b"
 		keys.Upsert("foo", &a, &b)
-		keys2 := keys.Copy()
+		keys2 := keys.Clone()
 		assert.Equal(t, keys.keys, keys2.keys)
 		assert.Equal(t, keys.keyMap, keys2.keyMap)
 		assert.Equal(t, []Key{{"foo", "a", "b"}}, keys2.keys)

--- a/lib/postgres/primary_key/primary_keys_test.go
+++ b/lib/postgres/primary_key/primary_keys_test.go
@@ -228,7 +228,7 @@ func TestKeys_Copy(t *testing.T) {
 		keys2 := keys.Copy()
 		assert.Equal(t, keys.keys, keys2.keys)
 		assert.Equal(t, keys.keyMap, keys2.keyMap)
-		assert.Equal(t, []Key{{"foo", a, b}}, keys2.keys)
+		assert.Equal(t, []Key{{"foo", "a", "b"}}, keys2.keys)
 		assert.Equal(t, map[string]bool{"foo": true}, keys2.keyMap)
 	}
 }

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -38,7 +38,7 @@ func (t *Table) NewScanner(db *sql.DB, batchSize uint, errorRetries int) scanner
 		table:        t,
 		batchSize:    batchSize,
 		errorRetries: errorRetries,
-		primaryKeys:  t.PrimaryKeys, // TODO: We should be passing in a copy of the primary keys
+		primaryKeys:  t.PrimaryKeys.Copy(),
 		isFirstRow:   true,
 		isLastRow:    false,
 		done:         false,

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -38,7 +38,7 @@ func (t *Table) NewScanner(db *sql.DB, batchSize uint, errorRetries int) scanner
 		table:        t,
 		batchSize:    batchSize,
 		errorRetries: errorRetries,
-		primaryKeys:  t.PrimaryKeys.Copy(),
+		primaryKeys:  t.PrimaryKeys.Clone(),
 		isFirstRow:   true,
 		isLastRow:    false,
 		done:         false,


### PR DESCRIPTION
Scanning a table mutates the primary keys so we shouldn't be directly passing in the table's primary keys.