### PR TITLE
Clean up Kafka batch writer

### DIFF
--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -1,0 +1,41 @@
+package iterator
+
+type ArrayIterator[T any] interface {
+	HasNext() bool
+	Next() []T
+}
+
+func Collect[T any](iter ArrayIterator[T]) []T {
+	result := make([]T, 0)
+	for iter.HasNext() {
+		result = append(result, iter.Next()...)
+	}
+	return result
+}
+
+type batchIterator[T any] struct {
+	items []T
+	index int
+	n     int
+}
+
+func NewBatchIterator[T any](items []T, n int) *batchIterator[T] {
+	return &batchIterator[T]{
+		items: items,
+		index: 0,
+		n:     n,
+	}
+}
+
+func (i *batchIterator[T]) HasNext() bool {
+	return i.index < len(i.items)
+}
+
+func (i *batchIterator[T]) Next() []T {
+	if !i.HasNext() {
+		return make([]T, 0)
+	}
+	result := i.items[i.index:min(i.index+i.n, len(i.items))]
+	i.index += i.n
+	return result
+}

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -1,18 +1,5 @@
 package iterator
 
-type ArrayIterator[T any] interface {
-	HasNext() bool
-	Next() []T
-}
-
-func Collect[T any](iter ArrayIterator[T]) []T {
-	result := make([]T, 0)
-	for iter.HasNext() {
-		result = append(result, iter.Next()...)
-	}
-	return result
-}
-
 type batchIterator[T any] struct {
 	items []T
 	index int

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -6,11 +6,11 @@ type batchIterator[T any] struct {
 	step  int
 }
 
-func NewBatchIterator[T any](items []T, n int) *batchIterator[T] {
+func NewBatchIterator[T any](items []T, step int) *batchIterator[T] {
 	return &batchIterator[T]{
 		items: items,
 		index: 0,
-		step:  max(n, 1),
+		step:  max(step, 1),
 	}
 }
 

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -10,7 +10,7 @@ func NewBatchIterator[T any](items []T, n int) *batchIterator[T] {
 	return &batchIterator[T]{
 		items: items,
 		index: 0,
-		n:     n,
+		n:     max(n, 1),
 	}
 }
 
@@ -22,7 +22,8 @@ func (i *batchIterator[T]) Next() []T {
 	if !i.HasNext() {
 		return make([]T, 0)
 	}
-	result := i.items[i.index:min(i.index+i.n, len(i.items))]
-	i.index += i.n
+	end := min(i.index+i.n, len(i.items))
+	result := i.items[i.index:end]
+	i.index = end
 	return result
 }

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -3,14 +3,14 @@ package iterator
 type batchIterator[T any] struct {
 	items []T
 	index int
-	n     int
+	step  int
 }
 
 func NewBatchIterator[T any](items []T, n int) *batchIterator[T] {
 	return &batchIterator[T]{
 		items: items,
 		index: 0,
-		n:     max(n, 1),
+		step:  max(n, 1),
 	}
 }
 
@@ -20,9 +20,9 @@ func (i *batchIterator[T]) HasNext() bool {
 
 func (i *batchIterator[T]) Next() []T {
 	if !i.HasNext() {
-		return make([]T, 0)
+		return nil
 	}
-	end := min(i.index+i.n, len(i.items))
+	end := min(i.index+i.step, len(i.items))
 	result := i.items[i.index:end]
 	i.index = end
 	return result

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -6,16 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type NoopIterator[T int] struct{}
-
-func (m NoopIterator[T]) HasNext() bool {
-	return false
-}
-
-func (m NoopIterator[T]) Next() []int {
-	panic("should not be called")
-}
-
 func TestBatchIterator(t *testing.T) {
 	iter := NewBatchIterator([]int{1, 2, 3, 4, 5}, 2)
 	assert.True(t, iter.HasNext())
@@ -34,22 +24,4 @@ func TestBatchIterator(t *testing.T) {
 		assert.Equal(t, []int{5}, iter.Next())
 	}
 	assert.False(t, iter.HasNext())
-}
-
-func TestCollect(t *testing.T) {
-	// happy path
-	{
-		iter := NewBatchIterator([]int{1, 2, 3, 4, 5}, 3)
-		assert.Equal(t, []int{1, 2, 3, 4, 5}, Collect(iter))
-	}
-	// empty - one chunk that is empty
-	{
-		iter := NewBatchIterator([]int{}, 3)
-		assert.Empty(t, Collect(iter))
-	}
-	// empty - zero chunks
-	{
-		iter := NoopIterator[int]{}
-		assert.Empty(t, Collect(iter))
-	}
 }

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -1,0 +1,55 @@
+package iterator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type NoopIterator[T int] struct{}
+
+func (m NoopIterator[T]) HasNext() bool {
+	return false
+}
+
+func (m NoopIterator[T]) Next() []int {
+	panic("should not be called")
+}
+
+func TestBatchIterator(t *testing.T) {
+	iter := NewBatchIterator([]int{1, 2, 3, 4, 5}, 2)
+	assert.True(t, iter.HasNext())
+	{
+		items := iter.Next()
+		assert.Equal(t, []int{1, 2}, items)
+		assert.Equal(t, 2, iter.index)
+	}
+	assert.True(t, iter.HasNext())
+	{
+		assert.Equal(t, []int{3, 4}, iter.Next())
+		assert.Equal(t, 4, iter.index)
+	}
+	assert.True(t, iter.HasNext())
+	{
+		assert.Equal(t, []int{5}, iter.Next())
+	}
+	assert.False(t, iter.HasNext())
+}
+
+func TestCollect(t *testing.T) {
+	// happy path
+	{
+		iter := NewBatchIterator([]int{1, 2, 3, 4, 5}, 3)
+		assert.Equal(t, []int{1, 2, 3, 4, 5}, Collect(iter))
+	}
+	// empty - one chunk that is empty
+	{
+		iter := NewBatchIterator([]int{}, 3)
+		assert.Empty(t, Collect(iter))
+	}
+	// empty - zero chunks
+	{
+		iter := NoopIterator[int]{}
+		assert.Empty(t, Collect(iter))
+	}
+}

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -7,21 +7,64 @@ import (
 )
 
 func TestBatchIterator(t *testing.T) {
-	iter := NewBatchIterator([]int{1, 2, 3, 4, 5}, 2)
-	assert.True(t, iter.HasNext())
+	// length of items is 0
 	{
-		items := iter.Next()
-		assert.Equal(t, []int{1, 2}, items)
-		assert.Equal(t, 2, iter.index)
+		iter := NewBatchIterator([]int{}, 2)
+		assert.False(t, iter.HasNext())
 	}
-	assert.True(t, iter.HasNext())
+	// length of items is 1
 	{
-		assert.Equal(t, []int{3, 4}, iter.Next())
-		assert.Equal(t, 4, iter.index)
+		iter := NewBatchIterator([]int{1}, 2)
+		assert.True(t, iter.HasNext())
+		{
+			items := iter.Next()
+			assert.Equal(t, []int{1}, items)
+			assert.Equal(t, 1, iter.index)
+		}
+		assert.False(t, iter.HasNext())
 	}
-	assert.True(t, iter.HasNext())
+	// n is 0
 	{
-		assert.Equal(t, []int{5}, iter.Next())
+		iter := NewBatchIterator([]int{1, 2}, 0)
+		assert.True(t, iter.HasNext())
+		assert.Equal(t, []int{1}, iter.Next())
+		assert.Equal(t, []int{2}, iter.Next())
+		assert.False(t, iter.HasNext())
 	}
-	assert.False(t, iter.HasNext())
+	// length of items is a multiple of n
+	{
+		iter := NewBatchIterator([]int{1, 2, 3, 4}, 2)
+		assert.True(t, iter.HasNext())
+		{
+			items := iter.Next()
+			assert.Equal(t, []int{1, 2}, items)
+			assert.Equal(t, 2, iter.index)
+		}
+		assert.True(t, iter.HasNext())
+		{
+			assert.Equal(t, []int{3, 4}, iter.Next())
+			assert.Equal(t, 4, iter.index)
+		}
+		assert.False(t, iter.HasNext())
+	}
+	// length of items is not a multiple of n
+	{
+		iter := NewBatchIterator([]int{1, 2, 3, 4, 5}, 2)
+		assert.True(t, iter.HasNext())
+		{
+			items := iter.Next()
+			assert.Equal(t, []int{1, 2}, items)
+			assert.Equal(t, 2, iter.index)
+		}
+		assert.True(t, iter.HasNext())
+		{
+			assert.Equal(t, []int{3, 4}, iter.Next())
+			assert.Equal(t, 4, iter.index)
+		}
+		assert.True(t, iter.HasNext())
+		{
+			assert.Equal(t, []int{5}, iter.Next())
+		}
+		assert.False(t, iter.HasNext())
+	}
 }

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib"
+	"github.com/artie-labs/reader/lib/iterator"
 )
 
 const (
@@ -19,27 +20,25 @@ const (
 )
 
 type BatchWriter struct {
-	*kafka.Writer
-
-	ctx context.Context
-	cfg config.Kafka
+	writer *kafka.Writer
+	cfg    config.Kafka
 }
 
 func NewBatchWriter(ctx context.Context, cfg config.Kafka, writer *kafka.Writer) BatchWriter {
-	return BatchWriter{writer, ctx, cfg}
+	return BatchWriter{writer, cfg}
 }
 
-func (w *BatchWriter) reload() error {
-	if err := w.Writer.Close(); err != nil {
+func (w *BatchWriter) reload(ctx context.Context) error {
+	if err := w.writer.Close(); err != nil {
 		return err
 	}
 
-	writer, err := NewWriter(w.ctx, w.cfg)
+	writer, err := NewWriter(ctx, w.cfg)
 	if err != nil {
 		return err
 	}
 
-	w.Writer = writer
+	w.writer = writer
 	return nil
 }
 
@@ -56,28 +55,30 @@ func buildKafkaMessages(cfg *config.Kafka, msgs []lib.RawMessage) ([]kafka.Messa
 	return result, nil
 }
 
-func (w *BatchWriter) Write(rawMsgs []lib.RawMessage) error {
+func (w *BatchWriter) WriteRawMessages(ctx context.Context, rawMsgs []lib.RawMessage) error {
 	msgs, err := buildKafkaMessages(&w.cfg, rawMsgs)
 	if err != nil {
 		return fmt.Errorf("failed to build to kafka messages: %w", err)
 	}
+	return w.WriteMessages(ctx, msgs)
+}
 
+func (w *BatchWriter) WriteMessages(ctx context.Context, msgs []kafka.Message) error {
 	chunkSize := w.cfg.GetPublishSize()
-
-	b := NewBatch(msgs, chunkSize)
-	if batchErr := b.IsValid(); batchErr != nil {
-		if IsBatchEmptyErr(batchErr) {
-			return nil
-		}
-
-		return fmt.Errorf("batch is not valid: %w", batchErr)
+	if chunkSize < 1 {
+		return fmt.Errorf("chunk size is too small")
 	}
 
-	for b.HasNext() {
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	iter := iterator.NewBatchIterator(msgs, int(chunkSize))
+	for iter.HasNext() {
 		var kafkaErr error
-		chunk := b.NextChunk()
+		chunk := iter.Next()
 		for attempts := 0; attempts < 10; attempts++ {
-			kafkaErr = w.WriteMessages(w.ctx, chunk...)
+			kafkaErr = w.writer.WriteMessages(ctx, chunk...)
 			if kafkaErr == nil {
 				break
 			}
@@ -89,7 +90,7 @@ func (w *BatchWriter) Write(rawMsgs []lib.RawMessage) error {
 			}
 
 			if RetryableError(kafkaErr) {
-				if reloadErr := w.reload(); reloadErr != nil {
+				if reloadErr := w.reload(ctx); reloadErr != nil {
 					slog.Warn("Failed to reload kafka writer", slog.Any("err", reloadErr))
 				}
 			} else {
@@ -115,7 +116,7 @@ type messageIterator interface {
 	Next() ([]lib.RawMessage, error)
 }
 
-func (w *BatchWriter) WriteIterator(iter messageIterator) (int, error) {
+func (w *BatchWriter) WriteIterator(ctx context.Context, iter messageIterator) (int, error) {
 	start := time.Now()
 	var count int
 	for iter.HasNext() {
@@ -124,7 +125,7 @@ func (w *BatchWriter) WriteIterator(iter messageIterator) (int, error) {
 			return 0, fmt.Errorf("failed to iterate over messages, err: %w", err)
 
 		} else if len(msgs) > 0 {
-			if err = w.Write(msgs); err != nil {
+			if err = w.WriteRawMessages(ctx, msgs); err != nil {
 				return 0, fmt.Errorf("failed to write messages to kafka, err: %w", err)
 			}
 			count += len(msgs)

--- a/main.go
+++ b/main.go
@@ -86,7 +86,8 @@ func main() {
 			logger.Fatal("Failed to run dynamodb snapshot", slog.Any("err", err))
 		}
 	case config.SourcePostgreSQL:
-		if err = postgres.Run(ctx, *cfg, statsD, _kafka); err != nil {
+		writer := kafkalib.NewBatchWriter(ctx, *cfg.Kafka, _kafka)
+		if err = postgres.Run(ctx, *cfg, statsD, writer); err != nil {
 			logger.Fatal("Failed to run postgres snapshot", slog.Any("err", err))
 		}
 	}


### PR DESCRIPTION
- Pass context as a parameter
- Add a generic batch iterator and use it instead of `NewBatch`