### PR TITLE
Postgres - Composite key value fix

### DIFF
--- a/lib/postgres/queries/queries.go
+++ b/lib/postgres/queries/queries.go
@@ -38,23 +38,17 @@ type SelectTableQueryArgs struct {
 }
 
 func SelectTableQuery(args SelectTableQueryArgs) string {
-	var orderByFragment string
+	var fragments []string
 	for _, orderBy := range args.OrderBy {
-		orderByFragment += pgx.Identifier{orderBy}.Sanitize()
+		fragment := pgx.Identifier{orderBy}.Sanitize()
 		if args.Descending {
-			orderByFragment += " DESC"
+			fragment += " DESC"
 		}
 
-		orderByFragment += ","
+		fragments = append(fragments, fragment)
 	}
-
-	fmt.Println("orderByFragment", orderByFragment)
-
-	orderByFragment = strings.TrimSuffix(orderByFragment, ",")
-
-	// TODO: Make sure keys are being escaped properly
-	return fmt.Sprintf(`SELECT %s FROM %s ORDER BY %s LIMIT 1`,
-		strings.Join(args.Keys, ","), pgx.Identifier{args.Schema, args.TableName}.Sanitize(), orderByFragment)
+	return fmt.Sprintf(`SELECT %s FROM %s ORDER BY %s LIMIT 1`, strings.Join(args.Keys, ","),
+		pgx.Identifier{args.Schema, args.TableName}.Sanitize(), strings.Join(fragments, ","))
 }
 
 type RetrievePrimaryKeysArgs struct {

--- a/lib/postgres/queries/queries.go
+++ b/lib/postgres/queries/queries.go
@@ -38,10 +38,19 @@ type SelectTableQueryArgs struct {
 }
 
 func SelectTableQuery(args SelectTableQueryArgs) string {
-	orderByFragment := strings.Join(quotedIdentifiers(args.OrderBy), ",")
-	if args.Descending {
-		orderByFragment += " DESC"
+	var orderByFragment string
+	for _, orderBy := range args.OrderBy {
+		orderByFragment += pgx.Identifier{orderBy}.Sanitize()
+		if args.Descending {
+			orderByFragment += " DESC"
+		}
+
+		orderByFragment += ","
 	}
+
+	fmt.Println("orderByFragment", orderByFragment)
+
+	orderByFragment = strings.TrimSuffix(orderByFragment, ",")
 
 	// TODO: Make sure keys are being escaped properly
 	return fmt.Sprintf(`SELECT %s FROM %s ORDER BY %s LIMIT 1`,

--- a/lib/postgres/queries/queries_test.go
+++ b/lib/postgres/queries/queries_test.go
@@ -48,7 +48,7 @@ func TestSelectTableQuery(t *testing.T) {
 			OrderBy:    []string{"e", "f", "g"},
 			Descending: true,
 		})
-		assert.Equal(t, `SELECT a,b,c FROM "schema"."table" ORDER BY "e","f","g" DESC LIMIT 1`, query)
+		assert.Equal(t, `SELECT a,b,c FROM "schema"."table" ORDER BY "e" DESC,"f" DESC,"g" DESC LIMIT 1`, query)
 	}
 }
 


### PR DESCRIPTION
# Problem
Our previous approach for retrieving the last entry in a table involved a simple SQL query that selected the primary key and ordered the results in descending order. This method was straightforward for tables with a single primary key but proved inadequate for tables with composite primary keys.

## Before/After Comparison
| Aspect | Before | After |
| --------------- | ------ | ------ |
| Single PK | `SELECT pk FROM table ORDER BY pk DESC LIMIT 1;` | No change required. |
| Composite PK | `sql SELECT pk_1, pk_2 FROM table ORDER BY pk_1, pk_2 DESC LIMIT 1;` | `sql SELECT pk_1, pk_2 FROM table ORDER BY pk_1 DESC, pk_2 DESC LIMIT 1;` |