### PR TITLE
Optimize jitter function

### DIFF
--- a/lib/jitter.go
+++ b/lib/jitter.go
@@ -1,12 +1,12 @@
 package lib
 
 import (
-	"math"
 	"math/rand"
 )
 
 func JitterMs(baseMs, maxMs, attempts int) int {
 	// https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 	// sleep = random_between(0, min(cap, base * 2 ** attempt))
-	return rand.Intn(int(math.Min(float64(maxMs), float64(baseMs)*math.Pow(2, float64(attempts)))))
+	// 2 ** x == 1 << x
+	return rand.Intn(min(maxMs, baseMs*(1<<attempts)))
 }


### PR DESCRIPTION
`2 ** x` is equivalent to `1 << x`, but doesn't require casting to `float64`. Proof https://go.dev/play/p/u2oW25Xes3Z