### PR TITLE
Postgres config improvements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,8 +68,8 @@ const (
 
 type Settings struct {
 	Source     Source      `yaml:"source"`
-	PostgreSQL *PostgreSQL `yaml:"postgresql,omitempty"`
 	DynamoDB   *DynamoDB   `yaml:"dynamodb,omitempty"`
+	PostgreSQL *PostgreSQL `yaml:"postgresql,omitempty"`
 
 	Reporting *Reporting `yaml:"reporting"`
 	Metrics   *Metrics   `yaml:"metrics"`

--- a/config/postgres.go
+++ b/config/postgres.go
@@ -50,7 +50,7 @@ func (p *PostgreSQL) Validate() error {
 	}
 
 	if stringutil.Empty(p.Host, p.GetUsername(), p.Password, p.Database) {
-		return fmt.Errorf("one of the PostgreSQL settings is empty: host, port, username, password, database")
+		return fmt.Errorf("one of the PostgreSQL settings is empty: host, username, password, database")
 	}
 
 	if p.Port == 0 {

--- a/config/postgres_test.go
+++ b/config/postgres_test.go
@@ -15,7 +15,7 @@ func TestPostgreSQL_Validate(t *testing.T) {
 	{
 		// Host, port, username, password, database are empty
 		p := &PostgreSQL{}
-		assert.ErrorContains(t, p.Validate(), "one of the PostgreSQL settings is empty: host, port, username, password, database")
+		assert.ErrorContains(t, p.Validate(), "one of the PostgreSQL settings is empty: host, username, password, database")
 	}
 	{
 		// Tables are empty

--- a/config/postgres_test.go
+++ b/config/postgres_test.go
@@ -6,22 +6,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestPostgresValidate(t *testing.T) {
+func TestPostgreSQL_Validate(t *testing.T) {
 	{
 		// Config is empty
 		var p *PostgreSQL
-		assert.ErrorContains(t, p.Validate(), "postgres config is nil")
+		assert.ErrorContains(t, p.Validate(), "the PostgreSQL config is nil")
 	}
 	{
 		// Host, port, username, password, database are empty
 		p := &PostgreSQL{}
-		assert.ErrorContains(t, p.Validate(), "one of the postgresql settings is empty: host, port, username, password, database")
+		assert.ErrorContains(t, p.Validate(), "one of the PostgreSQL settings is empty: host, port, username, password, database")
 	}
 	{
 		// Tables are empty
 		p := &PostgreSQL{
 			Host:     "host",
-			Port:     "port",
+			Port:     1,
 			Username: "username",
 			Password: "password",
 			Database: "database",
@@ -33,7 +33,7 @@ func TestPostgresValidate(t *testing.T) {
 		// No table name
 		p := &PostgreSQL{
 			Host:     "host",
-			Port:     "port",
+			Port:     1,
 			Username: "username",
 			Password: "password",
 			Database: "database",
@@ -50,7 +50,7 @@ func TestPostgresValidate(t *testing.T) {
 		// No schema name
 		p := &PostgreSQL{
 			Host:     "host",
-			Port:     "port",
+			Port:     1,
 			Username: "username",
 			Password: "password",
 			Database: "database",
@@ -67,7 +67,7 @@ func TestPostgresValidate(t *testing.T) {
 		// Valid
 		p := &PostgreSQL{
 			Host:     "host",
-			Port:     "port",
+			Port:     1,
 			Username: "username",
 			Password: "password",
 			Database: "database",
@@ -79,5 +79,60 @@ func TestPostgresValidate(t *testing.T) {
 			},
 		}
 		assert.NoError(t, p.Validate())
+	}
+}
+
+func TestPostgreSQL_GetUsername(t *testing.T) {
+	{
+		// Username is set, legacy username is not set
+		p := &PostgreSQL{
+			Username: "username",
+		}
+		assert.Equal(t, "username", p.GetUsername())
+	}
+	{
+		// Legacy username is set, username is not set
+		p := &PostgreSQL{
+			LegacyUsername: "legacyUsername",
+		}
+		assert.Equal(t, "legacyUsername", p.GetUsername())
+	}
+	{
+		// Legacy username is set and username is set
+		p := &PostgreSQL{
+			Username:       "username",
+			LegacyUsername: "legacyUsername",
+		}
+		assert.Equal(t, "username", p.GetUsername())
+	}
+}
+
+func TestPostgreSQLTable_GetBatchSize(t *testing.T) {
+	{
+		// Neihter batch size nor limit are set
+		p := &PostgreSQLTable{}
+		assert.Equal(t, uint(5_000), p.GetBatchSize())
+	}
+	{
+		// Batch size is set
+		p := &PostgreSQLTable{
+			BatchSize: 1,
+		}
+		assert.Equal(t, uint(1), p.GetBatchSize())
+	}
+	{
+		// Limit is set
+		p := &PostgreSQLTable{
+			Limit: 1,
+		}
+		assert.Equal(t, uint(1), p.GetBatchSize())
+	}
+	{
+		// Batch size and limit are set
+		p := &PostgreSQLTable{
+			BatchSize: 1,
+			Limit:     2,
+		}
+		assert.Equal(t, uint(1), p.GetBatchSize())
 	}
 }

--- a/config/postgres_test.go
+++ b/config/postgres_test.go
@@ -109,7 +109,7 @@ func TestPostgreSQL_GetUsername(t *testing.T) {
 
 func TestPostgreSQLTable_GetBatchSize(t *testing.T) {
 	{
-		// Neihter batch size nor limit are set
+		// Neither batch size nor limit are set
 		p := &PostgreSQLTable{}
 		assert.Equal(t, uint(5_000), p.GetBatchSize())
 	}

--- a/examples/postgres.yaml
+++ b/examples/postgres.yaml
@@ -3,7 +3,7 @@ source: postgresql
 postgresql:
   host: localhost
   port: 5432
-  userName: postgres
+  username: postgres
   password: postgres
   database: postgres
   tables:

--- a/lib/postgres/columns.go
+++ b/lib/postgres/columns.go
@@ -34,7 +34,7 @@ func (t *Table) RetrieveColumns(db *sql.DB) error {
 		t.Config.UpdateCols(colName, colKind, numericPrecision, numericScale, udtName)
 	}
 
-	query := fmt.Sprintf("SELECT * from %s LIMIT 1", pgx.Identifier{t.Schema, t.Name}.Sanitize())
+	query := fmt.Sprintf("SELECT * FROM %s LIMIT 1", pgx.Identifier{t.Schema, t.Name}.Sanitize())
 	rows, err = db.Query(query)
 	if err != nil {
 		return fmt.Errorf("failed to query, query: %v, err: %w", query, err)

--- a/lib/postgres/context.go
+++ b/lib/postgres/context.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/reader/config"
+	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
 type Connection struct {
 	Host       string
-	Port       string
+	Port       uint16
 	Username   string
 	Password   string
 	Database   string
@@ -19,7 +20,7 @@ func NewConnection(cfg *config.PostgreSQL) *Connection {
 	return &Connection{
 		Host:       cfg.Host,
 		Port:       cfg.Port,
-		Username:   cfg.Username,
+		Username:   stringutil.Override(cfg.Username, cfg.LegacyUsername),
 		Password:   cfg.Password,
 		Database:   cfg.Database,
 		DisableSSL: cfg.DisableSSL,
@@ -27,7 +28,7 @@ func NewConnection(cfg *config.PostgreSQL) *Connection {
 }
 
 func (c *Connection) String() string {
-	connString := fmt.Sprintf("user=%s dbname=%s password=%s port=%s host=%s",
+	connString := fmt.Sprintf("user=%s dbname=%s password=%s port=%d host=%s",
 		c.Username, c.Database, c.Password, c.Port, c.Host)
 
 	if c.DisableSSL {

--- a/lib/postgres/context.go
+++ b/lib/postgres/context.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/artie-labs/reader/config"
-	"github.com/artie-labs/transfer/lib/stringutil"
 )
 
 type Connection struct {
@@ -20,7 +19,7 @@ func NewConnection(cfg *config.PostgreSQL) *Connection {
 	return &Connection{
 		Host:       cfg.Host,
 		Port:       cfg.Port,
-		Username:   stringutil.Override(cfg.Username, cfg.LegacyUsername),
+		Username:   cfg.GetUsername(),
 		Password:   cfg.Password,
 		Database:   cfg.Database,
 		DisableSSL: cfg.DisableSSL,


### PR DESCRIPTION
- `port` is now defined as a `uint16` which aligns perfectly with the TCP/UDP port range of 0 to 65,535
- `userName` renamed to `username` (`userName` is still currently supported as a fallback)
- For table config `limit` renamed to `batchSize` (`limit` is still currently supported as a fallback)