### PR TITLE
Consolidate postgres schema code

### DIFF
--- a/lib/postgres/columns.go
+++ b/lib/postgres/columns.go
@@ -4,17 +4,13 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"strings"
 
+	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/jackc/pgx/v5"
-
-	"github.com/artie-labs/reader/lib/postgres/debezium"
-	"github.com/artie-labs/reader/lib/postgres/queries"
-	"github.com/artie-labs/transfer/lib/ptr"
 )
 
 func (t *Table) RetrieveColumns(db *sql.DB) error {
-	describeQuery, describeArgs := queries.DescribeTableQuery(queries.DescribeTableArgs{
+	describeQuery, describeArgs := schema.DescribeTableQuery(schema.DescribeTableArgs{
 		Name:   t.Name,
 		Schema: t.Schema,
 	})
@@ -35,8 +31,8 @@ func (t *Table) RetrieveColumns(db *sql.DB) error {
 			return err
 		}
 
-		dataType, opts := colKindToDataType(colKind, numericPrecision, numericScale, udtName)
-		if dataType == debezium.InvalidDataType {
+		dataType, opts := schema.ColKindToDataType(colKind, numericPrecision, numericScale, udtName)
+		if dataType == schema.InvalidDataType {
 			slog.Warn("Column type did not get mapped in our message schema, so it will not be automatically created by transfer",
 				slog.String("colName", colName),
 				slog.String("colKind", colKind),
@@ -67,102 +63,30 @@ func (t *Table) RetrieveColumns(db *sql.DB) error {
 	return t.FindStartAndEndPrimaryKeys(db)
 }
 
-func colKindToDataType(colKind string, precision, scale, udtName *string) (debezium.DataType, *debezium.Opts) {
-	colKind = strings.ToLower(colKind)
-	switch colKind {
-	case "point":
-		return debezium.Point, nil
-	case "real", "double precision":
-		return debezium.Float, nil
-	case "smallint":
-		return debezium.Int16, nil
-	case "integer":
-		return debezium.Int32, nil
-	case "bigint", "oid":
-		return debezium.Int64, nil
-	case "array":
-		return debezium.Array, nil
-	case "bit":
-		return debezium.Bit, nil
-	case "boolean":
-		return debezium.Boolean, nil
-	case "date":
-		return debezium.Date, nil
-	case "uuid":
-		return debezium.UUID, nil
-	case "user-defined":
-		if udtName != nil && *udtName == "hstore" {
-			return debezium.HStore, nil
-		} else if udtName != nil && *udtName == "geometry" {
-			return debezium.Geometry, nil
-		} else if udtName != nil && *udtName == "geography" {
-			return debezium.Geography, nil
-		} else {
-			return debezium.UserDefinedText, nil
-		}
-	case "interval":
-		return debezium.Interval, nil
-	case "time with time zone", "time without time zone":
-		return debezium.Time, nil
-	case "money":
-		return debezium.Money, &debezium.Opts{
-			Scale: ptr.ToString("2"),
-		}
-	case "character varying", "text":
-		return debezium.Text, nil
-	case "character":
-		return debezium.TextThatRequiresEscaping, nil
-	case "json", "jsonb":
-		return debezium.JSON, nil
-	case "timestamp without time zone", "timestamp with time zone":
-		return debezium.Timestamp, nil
-	default:
-		if strings.Contains(colKind, "numeric") {
-			if precision == nil && scale == nil {
-				return debezium.VariableNumeric, nil
-			} else {
-				return debezium.Numeric, &debezium.Opts{
-					Scale:     scale,
-					Precision: precision,
-				}
-			}
-		}
-
-		for _, textBasedCol := range debezium.TextBasedColumns {
-			// char (m) or character
-			if strings.Contains(colKind, textBasedCol) {
-				return debezium.TextThatRequiresEscaping, nil
-			}
-		}
-	}
-
-	return debezium.InvalidDataType, nil
-}
-
 // castColumn will take a colName and return the escaped version of what we should be using to call Postgres.
-func castColumn(rawColName string, colKind debezium.DataType) string {
+func castColumn(rawColName string, colKind schema.DataType) string {
 	colName := pgx.Identifier{rawColName}.Sanitize()
 	switch colKind {
-	case debezium.InvalidDataType:
+	case schema.InvalidDataType:
 		return colName
-	case debezium.Money, debezium.TextThatRequiresEscaping:
+	case schema.Money, schema.TextThatRequiresEscaping:
 		return fmt.Sprintf("%s::text", colName)
-	case debezium.Time, debezium.Interval:
+	case schema.Time, schema.Interval:
 		// We want to extract(epoch from interval) will emit this in ms
 		// However, Debezium wants this in macro seconds, so we are multiplying this by 1000.
 		// We need to use CAST, because regular ::int makes this into a bytes array.
 		// extract from epoch outputs in seconds, default multiplier to ms.
 		multiplier := 1000
-		if colKind == debezium.Interval {
+		if colKind == schema.Interval {
 			// ms to macro seconds.
 			multiplier = 1000 * 1000
 		}
 
 		return fmt.Sprintf(`cast(extract(epoch from %s)*%d as bigint) as "%s"`, colName, multiplier, rawColName)
-	case debezium.Array:
+	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, rawColName)
-	case debezium.Int16, debezium.Int32, debezium.Int64, debezium.UUID, debezium.UserDefinedText,
-		debezium.VariableNumeric, debezium.Numeric, debezium.Text, debezium.Boolean, debezium.Date, debezium.Timestamp, debezium.HStore, debezium.JSON, debezium.Bit:
+	case schema.Int16, schema.Int32, schema.Int64, schema.UUID, schema.UserDefinedText,
+		schema.VariableNumeric, schema.Numeric, schema.Text, schema.Boolean, schema.Date, schema.Timestamp, schema.HStore, schema.JSON, schema.Bit:
 		// These are all the columns that do not need to be escaped.
 		return colName
 	default:

--- a/lib/postgres/columns_test.go
+++ b/lib/postgres/columns_test.go
@@ -3,136 +3,15 @@ package postgres
 import (
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/artie-labs/reader/lib/postgres/debezium"
+	"github.com/artie-labs/reader/lib/postgres/schema"
 )
-
-func TestColKindToDataType(t *testing.T) {
-	type _testCase struct {
-		name      string
-		colKind   string
-		precision *string
-		scale     *string
-		udtName   *string
-
-		expectedDataType debezium.DataType
-		expectedOpts     *debezium.Opts
-	}
-
-	var testCases = []_testCase{
-		{
-			name:             "array",
-			colKind:          "ARRAY",
-			expectedDataType: debezium.Array,
-		},
-		{
-			name:             "character varying",
-			colKind:          "character varying",
-			expectedDataType: debezium.Text,
-		},
-		{
-			name:             "bit",
-			colKind:          "bit",
-			expectedDataType: debezium.Bit,
-		},
-		{
-			name:             "bool",
-			colKind:          "boolean",
-			expectedDataType: debezium.Boolean,
-		},
-		{
-			name:             "interval",
-			colKind:          "interval",
-			expectedDataType: debezium.Interval,
-		},
-		{
-			name:             "time with time zone",
-			colKind:          "time with time zone",
-			expectedDataType: debezium.Time,
-		},
-		{
-			name:             "time without time zone",
-			colKind:          "time without time zone",
-			expectedDataType: debezium.Time,
-		},
-		{
-			name:             "date",
-			colKind:          "date",
-			expectedDataType: debezium.Date,
-		},
-		{
-			name:             "char_text",
-			colKind:          "character",
-			expectedDataType: debezium.TextThatRequiresEscaping,
-		},
-		{
-			name:             "numeric",
-			colKind:          "numeric",
-			expectedDataType: debezium.VariableNumeric,
-		},
-		{
-			name:             "numeric - with scale + precision",
-			colKind:          "numeric",
-			scale:            ptr.ToString("2"),
-			precision:        ptr.ToString("3"),
-			expectedDataType: debezium.Numeric,
-			expectedOpts: &debezium.Opts{
-				Scale:     ptr.ToString("2"),
-				Precision: ptr.ToString("3"),
-			},
-		},
-		{
-			name:             "variable numeric",
-			colKind:          "variable numeric",
-			expectedDataType: debezium.VariableNumeric,
-		},
-		{
-			name:             "money",
-			colKind:          "money",
-			expectedDataType: debezium.Money,
-			expectedOpts: &debezium.Opts{
-				Scale: ptr.ToString("2"), // money always has a scale of 2
-			},
-		},
-		{
-			name:             "hstore",
-			colKind:          "user-defined",
-			udtName:          ptr.ToString("hstore"),
-			expectedDataType: debezium.HStore,
-		},
-		{
-			name:             "geometry",
-			colKind:          "user-defined",
-			udtName:          ptr.ToString("geometry"),
-			expectedDataType: debezium.Geometry,
-		},
-		{
-			name:             "geography",
-			colKind:          "user-defined",
-			udtName:          ptr.ToString("geography"),
-			expectedDataType: debezium.Geography,
-		},
-		{
-			name:             "user-defined text",
-			colKind:          "user-defined",
-			udtName:          ptr.ToString("foo"),
-			expectedDataType: debezium.UserDefinedText,
-		},
-	}
-
-	for _, testCase := range testCases {
-		dataType, opts := colKindToDataType(testCase.colKind, testCase.precision, testCase.scale, testCase.udtName)
-		assert.Equal(t, testCase.expectedDataType, dataType, testCase.name)
-		assert.Equal(t, testCase.expectedOpts, opts, testCase.name)
-	}
-}
 
 func TestCastColumn(t *testing.T) {
 	type _testCase struct {
 		name     string
-		dataType debezium.DataType
+		dataType schema.DataType
 
 		expected string
 	}
@@ -140,52 +19,52 @@ func TestCastColumn(t *testing.T) {
 	var testCases = []_testCase{
 		{
 			name:     "array",
-			dataType: debezium.Array,
+			dataType: schema.Array,
 			expected: `ARRAY_TO_JSON("foo")::TEXT as "foo"`,
 		},
 		{
 			name:     "text",
-			dataType: debezium.Text,
+			dataType: schema.Text,
 			expected: `"foo"`,
 		},
 		{
 			name:     "numeric",
-			dataType: debezium.Numeric,
+			dataType: schema.Numeric,
 			expected: `"foo"`,
 		},
 		{
 			name:     "bit",
-			dataType: debezium.Bit,
+			dataType: schema.Bit,
 			expected: `"foo"`,
 		},
 		{
 			name:     "bool",
-			dataType: debezium.Boolean,
+			dataType: schema.Boolean,
 			expected: `"foo"`,
 		},
 		{
 			name:     "interval",
-			dataType: debezium.Interval,
+			dataType: schema.Interval,
 			expected: `cast(extract(epoch from "foo")*1000000 as bigint) as "foo"`,
 		},
 		{
 			name:     "time",
-			dataType: debezium.Time,
+			dataType: schema.Time,
 			expected: `cast(extract(epoch from "foo")*1000 as bigint) as "foo"`,
 		},
 		{
 			name:     "date",
-			dataType: debezium.Date,
+			dataType: schema.Date,
 			expected: `"foo"`,
 		},
 		{
 			name:     "char_text",
-			dataType: debezium.TextThatRequiresEscaping,
+			dataType: schema.TextThatRequiresEscaping,
 			expected: `"foo"::text`,
 		},
 		{
 			name:     "variable numeric",
-			dataType: debezium.VariableNumeric,
+			dataType: schema.VariableNumeric,
 			expected: `"foo"`,
 		},
 	}

--- a/lib/postgres/debezium/data_type.go
+++ b/lib/postgres/debezium/data_type.go
@@ -1,53 +1,8 @@
 package debezium
 
 import (
+	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/transfer/lib/debezium"
-)
-
-type DataType int
-
-var (
-	TextBasedColumns = []string{
-		"xml",
-		"cidr",
-		"macaddr",
-		"macaddr8",
-		"inet",
-		"int4range",
-		"int8range",
-		"numrange",
-		"daterange",
-		"tsrange",
-		"tstzrange",
-	}
-)
-
-const (
-	InvalidDataType DataType = iota
-	VariableNumeric
-	Money
-	Numeric
-	Bit
-	Boolean
-	TextThatRequiresEscaping
-	Text
-	Interval
-	Array
-	HStore
-	Float
-	Int16
-	Int32
-	Int64
-	UUID
-	UserDefinedText
-	JSON
-	Timestamp
-	Time
-	Date
-	// PostGIS
-	Point
-	Geometry
-	Geography
 )
 
 type Result struct {
@@ -55,91 +10,91 @@ type Result struct {
 	Type         string
 }
 
-func (d DataType) ToDebeziumType() Result {
+func ToDebeziumType(d schema.DataType) Result {
 	switch d {
-	case Geography:
+	case schema.Geography:
 		return Result{
 			DebeziumType: string(debezium.GeographyType),
 			Type:         "struct",
 		}
-	case Geometry:
+	case schema.Geometry:
 		return Result{
 			DebeziumType: string(debezium.GeometryType),
 			Type:         "struct",
 		}
-	case Point:
+	case schema.Point:
 		return Result{
 			DebeziumType: string(debezium.GeometryPointType),
 			Type:         "struct",
 		}
-	case VariableNumeric:
+	case schema.VariableNumeric:
 		return Result{
 			DebeziumType: string(debezium.KafkaVariableNumericType),
 			Type:         "struct",
 		}
-	case Money, Numeric:
+	case schema.Money, schema.Numeric:
 		return Result{
 			DebeziumType: string(debezium.KafkaDecimalType),
 		}
-	case Boolean, Bit:
+	case schema.Boolean, schema.Bit:
 		return Result{
 			Type: "boolean",
 		}
-	case Text, UserDefinedText, TextThatRequiresEscaping:
+	case schema.Text, schema.UserDefinedText, schema.TextThatRequiresEscaping:
 		return Result{
 			Type: "string",
 		}
-	case Interval:
+	case schema.Interval:
 		return Result{
 			DebeziumType: "io.debezium.time.MicroDuration",
 			Type:         "int64",
 		}
-	case Array:
+	case schema.Array:
 		return Result{
 			Type: "array",
 		}
-	case Float:
+	case schema.Float:
 		return Result{
 			Type: "float",
 		}
-	case Int16:
+	case schema.Int16:
 		return Result{
 			Type: "int16",
 		}
-	case Int32:
+	case schema.Int32:
 		return Result{
 			Type: "int32",
 		}
-	case Int64:
+	case schema.Int64:
 		return Result{
 			Type: "int64",
 		}
-	case UUID:
+	case schema.UUID:
 		return Result{
 			DebeziumType: "io.debezium.data.Uuid",
 			Type:         "string",
 		}
-	case JSON:
+	case schema.JSON:
 		return Result{
 			DebeziumType: "io.debezium.data.Json",
 			Type:         "string",
 		}
-	case Time:
+	case schema.Time:
 		return Result{
 			DebeziumType: string(debezium.Time),
 			Type:         "int32",
 		}
-	case Date:
+	case schema.Date:
 		return Result{
 			DebeziumType: string(debezium.Date),
 			Type:         "int32",
 		}
-	case HStore:
+	case schema.HStore:
 		return Result{
 			DebeziumType: "",
 			Type:         "map",
 		}
-	case Timestamp:
+	case schema.Timestamp:
 		return Result{
 			DebeziumType: string(debezium.Timestamp),
 			// NOTE: We are returning string here because we want the right layout to be used by our Typing library

--- a/lib/postgres/debezium/fields.go
+++ b/lib/postgres/debezium/fields.go
@@ -1,6 +1,7 @@
 package debezium
 
 import (
+	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/transfer/lib/cdc"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/debezium"
@@ -9,12 +10,12 @@ import (
 
 type Fields struct {
 	fields              []debezium.Field
-	fieldKeyToDataTypes map[string]DataType
+	fieldKeyToDataTypes map[string]schema.DataType
 }
 
 func NewFields() *Fields {
 	return &Fields{
-		fieldKeyToDataTypes: make(map[string]DataType),
+		fieldKeyToDataTypes: make(map[string]schema.DataType),
 	}
 }
 
@@ -38,22 +39,17 @@ func (f *Fields) GetField(fieldName string) (debezium.Field, bool) {
 	return debezium.Field{}, false
 }
 
-func (f *Fields) GetDataType(fieldName string) DataType {
+func (f *Fields) GetDataType(fieldName string) schema.DataType {
 	dataType, isOk := f.fieldKeyToDataTypes[fieldName]
 	if !isOk {
-		return InvalidDataType
+		return schema.InvalidDataType
 	}
 
 	return dataType
 }
 
-type Opts struct {
-	Scale     *string
-	Precision *string
-}
-
-func (f *Fields) AddField(colName string, dataType DataType, opts *Opts) {
-	res := dataType.ToDebeziumType()
+func (f *Fields) AddField(colName string, dataType schema.DataType, opts *schema.Opts) {
+	res := ToDebeziumType(dataType)
 	field := debezium.Field{
 		FieldName:    colName,
 		Type:         res.Type,

--- a/lib/postgres/debezium/fields_test.go
+++ b/lib/postgres/debezium/fields_test.go
@@ -3,6 +3,7 @@ package debezium
 import (
 	"testing"
 
+	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
@@ -12,8 +13,8 @@ func TestFields_AddField(t *testing.T) {
 	type _testCase struct {
 		name     string
 		colName  string
-		dataType DataType
-		opts     *Opts
+		dataType schema.DataType
+		opts     *schema.Opts
 
 		expected debezium.Field
 	}
@@ -22,7 +23,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "array",
 			colName:  "foo",
-			dataType: Array,
+			dataType: schema.Array,
 			expected: debezium.Field{
 				Type:      "array",
 				FieldName: "foo",
@@ -31,7 +32,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "text",
 			colName:  "group",
-			dataType: Text,
+			dataType: schema.Text,
 			expected: debezium.Field{
 				Type:      "string",
 				FieldName: "group",
@@ -40,7 +41,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "numeric",
 			colName:  "numeric_col",
-			dataType: VariableNumeric,
+			dataType: schema.VariableNumeric,
 			expected: debezium.Field{
 				Type:         "struct",
 				FieldName:    "numeric_col",
@@ -50,8 +51,8 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "numeric - with scale + precision",
 			colName:  "numeric_col",
-			dataType: Numeric,
-			opts: &Opts{
+			dataType: schema.Numeric,
+			opts: &schema.Opts{
 				Scale:     ptr.ToString("2"),
 				Precision: ptr.ToString("10"),
 			},
@@ -65,7 +66,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "bit",
 			colName:  "bit_col",
-			dataType: Bit,
+			dataType: schema.Bit,
 			expected: debezium.Field{
 				Type:      "boolean",
 				FieldName: "bit_col",
@@ -74,7 +75,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "bool",
 			colName:  "bool_col",
-			dataType: Boolean,
+			dataType: schema.Boolean,
 			expected: debezium.Field{
 				Type:      "boolean",
 				FieldName: "bool_col",
@@ -83,7 +84,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "interval",
 			colName:  "interval_coL",
-			dataType: Interval,
+			dataType: schema.Interval,
 			expected: debezium.Field{
 				Type:         "int64",
 				FieldName:    "interval_coL",
@@ -93,7 +94,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "time",
 			colName:  "time",
-			dataType: Time,
+			dataType: schema.Time,
 			expected: debezium.Field{
 				Type:         "int32",
 				FieldName:    "time",
@@ -103,7 +104,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "date",
 			colName:  "date_col",
-			dataType: Date,
+			dataType: schema.Date,
 			expected: debezium.Field{
 				Type:         "int32",
 				FieldName:    "date_col",
@@ -113,7 +114,7 @@ func TestFields_AddField(t *testing.T) {
 		{
 			name:     "char_text",
 			colName:  "char_text_col",
-			dataType: TextThatRequiresEscaping,
+			dataType: schema.TextThatRequiresEscaping,
 			expected: debezium.Field{
 				Type:      "string",
 				FieldName: "char_text_col",

--- a/lib/postgres/debezium/values.go
+++ b/lib/postgres/debezium/values.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/artie-labs/reader/lib/debezium"
+	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/reader/lib/stringutil"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 )
@@ -19,7 +20,7 @@ func ParseValue(key string, value interface{}, fields *Fields) (interface{}, err
 	var err error
 	dt := fields.GetDataType(key)
 	switch dt {
-	case Timestamp:
+	case schema.Timestamp:
 		valTime, isOk := value.(time.Time)
 		if isOk {
 			if valTime.Year() > 9999 || valTime.Year() < 0 {
@@ -29,14 +30,14 @@ func ParseValue(key string, value interface{}, fields *Fields) (interface{}, err
 				return nil, nil
 			}
 		}
-	case Date:
+	case schema.Date:
 		value, err = debezium.ToDebeziumDate(value)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse date for key %s: %w", key, err)
 		}
 
-	case Numeric, Money:
-		if dt == Money {
+	case schema.Numeric, schema.Money:
+		if dt == schema.Money {
 			value = stringutil.ParseMoneyIntoString(fmt.Sprint(value))
 		}
 
@@ -54,7 +55,7 @@ func ParseValue(key string, value interface{}, fields *Fields) (interface{}, err
 		if err != nil {
 			return nil, fmt.Errorf("failed to encode decimal to b64 for key %s: %w", key, err)
 		}
-	case VariableNumeric:
+	case schema.VariableNumeric:
 		encodedValue, err := debezium.EncodeDecimalToBase64(fmt.Sprint(value), debezium.GetScale(fmt.Sprint(value)))
 		if err != nil {
 			return util.SchemaEventPayload{}, fmt.Errorf("failed to encode decimal to b64 for key %s: %w", key, err)

--- a/lib/postgres/debezium/values_test.go
+++ b/lib/postgres/debezium/values_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
 )
@@ -21,21 +22,21 @@ func TestParseValue(t *testing.T) {
 	}
 
 	dateFields := NewFields()
-	dateFields.AddField("date_col", Date, nil)
+	dateFields.AddField("date_col", schema.Date, nil)
 
 	numericFields := NewFields()
-	numericFields.AddField("numeric_col", Numeric, &Opts{
+	numericFields.AddField("numeric_col", schema.Numeric, &schema.Opts{
 		Scale:     ptr.ToString("2"),
 		Precision: ptr.ToString("5"),
 	})
 
 	moneyFields := NewFields()
-	moneyFields.AddField("money_col", Money, &Opts{
+	moneyFields.AddField("money_col", schema.Money, &schema.Opts{
 		Scale: ptr.ToString("2"),
 	})
 
 	varNumericFields := NewFields()
-	varNumericFields.AddField("variable_numeric_col", VariableNumeric, nil)
+	varNumericFields.AddField("variable_numeric_col", schema.VariableNumeric, nil)
 
 	tcs := []_tc{
 		{

--- a/lib/postgres/parse_test.go
+++ b/lib/postgres/parse_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	pgDebezium "github.com/artie-labs/reader/lib/postgres/debezium"
+	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
 func TestParse(t *testing.T) {
@@ -96,7 +97,7 @@ func TestParse(t *testing.T) {
 
 	for _, tc := range tcs {
 		fields := pgDebezium.NewFields()
-		dataType, opts := colKindToDataType(tc.colKind, nil, nil, tc.udtName)
+		dataType, opts := schema.ColKindToDataType(tc.colKind, nil, nil, tc.udtName)
 		fields.AddField(tc.colName, dataType, opts)
 
 		value, err := ParseValue(fields, ParseValueArgs{

--- a/lib/postgres/queries/queries.go
+++ b/lib/postgres/queries/queries.go
@@ -7,20 +7,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-type DescribeTableArgs struct {
-	Name   string
-	Schema string
-}
-
-const describeTableQuery = `
-SELECT column_name, data_type, numeric_precision, numeric_scale, udt_name
-FROM information_schema.columns
-WHERE table_name = $1 AND table_schema = $2`
-
-func DescribeTableQuery(args DescribeTableArgs) (string, []any) {
-	return strings.TrimSpace(describeTableQuery), []any{args.Name, args.Schema}
-}
-
 func quotedIdentifiers(ids []string) []string {
 	quoted := make([]string, len(ids))
 	for idx := range ids {

--- a/lib/postgres/queries/queries_test.go
+++ b/lib/postgres/queries/queries_test.go
@@ -6,25 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDescribeTableQuery(t *testing.T) {
-	{
-		query, args := DescribeTableQuery(DescribeTableArgs{
-			Name:   "name",
-			Schema: "schema",
-		})
-		assert.Equal(t, "SELECT column_name, data_type, numeric_precision, numeric_scale, udt_name\nFROM information_schema.columns\nWHERE table_name = $1 AND table_schema = $2", query)
-		assert.Equal(t, []any{"name", "schema"}, args)
-	}
-	// test quotes in table name or schema are left alone
-	{
-		_, args := DescribeTableQuery(DescribeTableArgs{
-			Name:   `na"me`,
-			Schema: `s'ch"em'a`,
-		})
-		assert.Equal(t, []any{`na"me`, `s'ch"em'a`}, args)
-	}
-}
-
 func TestQuotedIdentifiers(t *testing.T) {
 	assert.Equal(t, []string{`"a"`, `"bb""bb"`, `"c"`}, quotedIdentifiers([]string{"a", `bb"bb`, "c"}))
 }

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -1,0 +1,144 @@
+package schema
+
+import (
+	"strings"
+
+	"github.com/artie-labs/transfer/lib/ptr"
+)
+
+type DataType int
+
+var (
+	TextBasedColumns = []string{
+		"xml",
+		"cidr",
+		"macaddr",
+		"macaddr8",
+		"inet",
+		"int4range",
+		"int8range",
+		"numrange",
+		"daterange",
+		"tsrange",
+		"tstzrange",
+	}
+)
+
+const (
+	InvalidDataType DataType = iota
+	VariableNumeric
+	Money
+	Numeric
+	Bit
+	Boolean
+	TextThatRequiresEscaping
+	Text
+	Interval
+	Array
+	HStore
+	Float
+	Int16
+	Int32
+	Int64
+	UUID
+	UserDefinedText
+	JSON
+	Timestamp
+	Time
+	Date
+	// PostGIS
+	Point
+	Geometry
+	Geography
+)
+
+type Opts struct {
+	Scale     *string
+	Precision *string
+}
+
+type DescribeTableArgs struct {
+	Name   string
+	Schema string
+}
+
+const describeTableQuery = `
+SELECT column_name, data_type, numeric_precision, numeric_scale, udt_name
+FROM information_schema.columns
+WHERE table_name = $1 AND table_schema = $2`
+
+func DescribeTableQuery(args DescribeTableArgs) (string, []any) {
+	return strings.TrimSpace(describeTableQuery), []any{args.Name, args.Schema}
+}
+
+func ColKindToDataType(colKind string, precision, scale, udtName *string) (DataType, *Opts) {
+	colKind = strings.ToLower(colKind)
+	switch colKind {
+	case "point":
+		return Point, nil
+	case "real", "double precision":
+		return Float, nil
+	case "smallint":
+		return Int16, nil
+	case "integer":
+		return Int32, nil
+	case "bigint", "oid":
+		return Int64, nil
+	case "array":
+		return Array, nil
+	case "bit":
+		return Bit, nil
+	case "boolean":
+		return Boolean, nil
+	case "date":
+		return Date, nil
+	case "uuid":
+		return UUID, nil
+	case "user-defined":
+		if udtName != nil && *udtName == "hstore" {
+			return HStore, nil
+		} else if udtName != nil && *udtName == "geometry" {
+			return Geometry, nil
+		} else if udtName != nil && *udtName == "geography" {
+			return Geography, nil
+		} else {
+			return UserDefinedText, nil
+		}
+	case "interval":
+		return Interval, nil
+	case "time with time zone", "time without time zone":
+		return Time, nil
+	case "money":
+		return Money, &Opts{
+			Scale: ptr.ToString("2"),
+		}
+	case "character varying", "text":
+		return Text, nil
+	case "character":
+		return TextThatRequiresEscaping, nil
+	case "json", "jsonb":
+		return JSON, nil
+	case "timestamp without time zone", "timestamp with time zone":
+		return Timestamp, nil
+	default:
+		if strings.Contains(colKind, "numeric") {
+			if precision == nil && scale == nil {
+				return VariableNumeric, nil
+			} else {
+				return Numeric, &Opts{
+					Scale:     scale,
+					Precision: precision,
+				}
+			}
+		}
+
+		for _, textBasedCol := range TextBasedColumns {
+			// char (m) or character
+			if strings.Contains(colKind, textBasedCol) {
+				return TextThatRequiresEscaping, nil
+			}
+		}
+	}
+
+	return InvalidDataType, nil
+}

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -1,0 +1,147 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescribeTableQuery(t *testing.T) {
+	{
+		query, args := DescribeTableQuery(DescribeTableArgs{
+			Name:   "name",
+			Schema: "schema",
+		})
+		assert.Equal(t, "SELECT column_name, data_type, numeric_precision, numeric_scale, udt_name\nFROM information_schema.columns\nWHERE table_name = $1 AND table_schema = $2", query)
+		assert.Equal(t, []any{"name", "schema"}, args)
+	}
+	// test quotes in table name or schema are left alone
+	{
+		_, args := DescribeTableQuery(DescribeTableArgs{
+			Name:   `na"me`,
+			Schema: `s'ch"em'a`,
+		})
+		assert.Equal(t, []any{`na"me`, `s'ch"em'a`}, args)
+	}
+}
+
+func TestColKindToDataType(t *testing.T) {
+	type _testCase struct {
+		name      string
+		colKind   string
+		precision *string
+		scale     *string
+		udtName   *string
+
+		expectedDataType DataType
+		expectedOpts     *Opts
+	}
+
+	var testCases = []_testCase{
+		{
+			name:             "array",
+			colKind:          "ARRAY",
+			expectedDataType: Array,
+		},
+		{
+			name:             "character varying",
+			colKind:          "character varying",
+			expectedDataType: Text,
+		},
+		{
+			name:             "bit",
+			colKind:          "bit",
+			expectedDataType: Bit,
+		},
+		{
+			name:             "bool",
+			colKind:          "boolean",
+			expectedDataType: Boolean,
+		},
+		{
+			name:             "interval",
+			colKind:          "interval",
+			expectedDataType: Interval,
+		},
+		{
+			name:             "time with time zone",
+			colKind:          "time with time zone",
+			expectedDataType: Time,
+		},
+		{
+			name:             "time without time zone",
+			colKind:          "time without time zone",
+			expectedDataType: Time,
+		},
+		{
+			name:             "date",
+			colKind:          "date",
+			expectedDataType: Date,
+		},
+		{
+			name:             "char_text",
+			colKind:          "character",
+			expectedDataType: TextThatRequiresEscaping,
+		},
+		{
+			name:             "numeric",
+			colKind:          "numeric",
+			expectedDataType: VariableNumeric,
+		},
+		{
+			name:             "numeric - with scale + precision",
+			colKind:          "numeric",
+			scale:            ptr.ToString("2"),
+			precision:        ptr.ToString("3"),
+			expectedDataType: Numeric,
+			expectedOpts: &Opts{
+				Scale:     ptr.ToString("2"),
+				Precision: ptr.ToString("3"),
+			},
+		},
+		{
+			name:             "variable numeric",
+			colKind:          "variable numeric",
+			expectedDataType: VariableNumeric,
+		},
+		{
+			name:             "money",
+			colKind:          "money",
+			expectedDataType: Money,
+			expectedOpts: &Opts{
+				Scale: ptr.ToString("2"), // money always has a scale of 2
+			},
+		},
+		{
+			name:             "hstore",
+			colKind:          "user-defined",
+			udtName:          ptr.ToString("hstore"),
+			expectedDataType: HStore,
+		},
+		{
+			name:             "geometry",
+			colKind:          "user-defined",
+			udtName:          ptr.ToString("geometry"),
+			expectedDataType: Geometry,
+		},
+		{
+			name:             "geography",
+			colKind:          "user-defined",
+			udtName:          ptr.ToString("geography"),
+			expectedDataType: Geography,
+		},
+		{
+			name:             "user-defined text",
+			colKind:          "user-defined",
+			udtName:          ptr.ToString("foo"),
+			expectedDataType: UserDefinedText,
+		},
+	}
+
+	for _, testCase := range testCases {
+		dataType, opts := ColKindToDataType(testCase.colKind, testCase.precision, testCase.scale, testCase.udtName)
+		assert.Equal(t, testCase.expectedDataType, dataType, testCase.name)
+		assert.Equal(t, testCase.expectedOpts, opts, testCase.name)
+	}
+}


### PR DESCRIPTION
This creates a new package `lib/postgres/schema` that contains the postgres data types and queries for describing postgres tables. The idea is that the `schema` package should not know about anything `debezium` related and also be stateless.

This PR just moves things around, there are no code changes.