### PR TITLE
Add a stateless postgres describe table function

### DIFF
--- a/lib/postgres/parse_test.go
+++ b/lib/postgres/parse_test.go
@@ -97,7 +97,7 @@ func TestParse(t *testing.T) {
 
 	for _, tc := range tcs {
 		fields := pgDebezium.NewFields()
-		dataType, opts := schema.ColKindToDataType(tc.colKind, nil, nil, tc.udtName)
+		dataType, opts := schema.ParseColumnDataType(tc.colKind, nil, nil, tc.udtName)
 		fields.AddField(tc.colName, dataType, opts)
 
 		value, err := ParseValue(fields, ParseValueArgs{

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -77,6 +77,7 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to run query: %s: %w", query, err)
 	}
+	defer rows.Close()
 
 	var cols []Column
 	for rows.Next() {

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -81,18 +81,18 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 	var cols []Column
 	for rows.Next() {
 		var colName string
-		var colKind string
+		var colType string
 		var numericPrecision *string
 		var numericScale *string
 		var udtName *string
-		err = rows.Scan(&colName, &colKind, &numericPrecision, &numericScale, &udtName)
+		err = rows.Scan(&colName, &colType, &numericPrecision, &numericScale, &udtName)
 		if err != nil {
 			return nil, err
 		}
 
-		dataType, opts := ParseColumnDataType(colKind, numericPrecision, numericScale, udtName)
+		dataType, opts := ParseColumnDataType(colType, numericPrecision, numericScale, udtName)
 		if dataType == InvalidDataType {
-			slog.Warn("Unable to identify column type", slog.String("colName", colName), slog.String("colType", colKind))
+			slog.Warn("Unable to identify column type", slog.String("colName", colName), slog.String("colType", colType))
 		}
 
 		cols = append(cols, Column{

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -1,6 +1,9 @@
 package schema
 
 import (
+	"database/sql"
+	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/ptr"
@@ -57,21 +60,51 @@ type Opts struct {
 	Precision *string
 }
 
-type DescribeTableArgs struct {
-	Name   string
-	Schema string
+type Column struct {
+	Name string
+	Type DataType
+	Opts *Opts
 }
 
 const describeTableQuery = `
 SELECT column_name, data_type, numeric_precision, numeric_scale, udt_name
 FROM information_schema.columns
-WHERE table_name = $1 AND table_schema = $2`
+WHERE table_schema = $1 AND table_name = $2`
 
-func DescribeTableQuery(args DescribeTableArgs) (string, []any) {
-	return strings.TrimSpace(describeTableQuery), []any{args.Name, args.Schema}
+func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
+	query := strings.TrimSpace(describeTableQuery)
+	rows, err := db.Query(query, _schema, table)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run query: %s, err: %w", query, err)
+	}
+
+	var cols []Column
+	for rows.Next() {
+		var colName string
+		var colKind string
+		var numericPrecision *string
+		var numericScale *string
+		var udtName *string
+		err = rows.Scan(&colName, &colKind, &numericPrecision, &numericScale, &udtName)
+		if err != nil {
+			return nil, err
+		}
+
+		dataType, opts := ParseColumnDataType(colKind, numericPrecision, numericScale, udtName)
+		if dataType == InvalidDataType {
+			slog.Warn("Unable to identify column type", slog.String("colName", colName), slog.String("colType", colKind))
+		}
+
+		cols = append(cols, Column{
+			Name: colName,
+			Type: dataType,
+			Opts: opts,
+		})
+	}
+	return cols, nil
 }
 
-func ColKindToDataType(colKind string, precision, scale, udtName *string) (DataType, *Opts) {
+func ParseColumnDataType(colKind string, precision, scale, udtName *string) (DataType, *Opts) {
 	colKind = strings.ToLower(colKind)
 	switch colKind {
 	case "point":

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -75,7 +75,7 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 	query := strings.TrimSpace(describeTableQuery)
 	rows, err := db.Query(query, _schema, table)
 	if err != nil {
-		return nil, fmt.Errorf("failed to run query: %s, err: %w", query, err)
+		return nil, fmt.Errorf("failed to run query: %s: %w", query, err)
 	}
 
 	var cols []Column

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -7,26 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDescribeTableQuery(t *testing.T) {
-	{
-		query, args := DescribeTableQuery(DescribeTableArgs{
-			Name:   "name",
-			Schema: "schema",
-		})
-		assert.Equal(t, "SELECT column_name, data_type, numeric_precision, numeric_scale, udt_name\nFROM information_schema.columns\nWHERE table_name = $1 AND table_schema = $2", query)
-		assert.Equal(t, []any{"name", "schema"}, args)
-	}
-	// test quotes in table name or schema are left alone
-	{
-		_, args := DescribeTableQuery(DescribeTableArgs{
-			Name:   `na"me`,
-			Schema: `s'ch"em'a`,
-		})
-		assert.Equal(t, []any{`na"me`, `s'ch"em'a`}, args)
-	}
-}
-
-func TestColKindToDataType(t *testing.T) {
+func TestParseColumnDataType(t *testing.T) {
 	type _testCase struct {
 		name      string
 		colKind   string
@@ -140,7 +121,7 @@ func TestColKindToDataType(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		dataType, opts := ColKindToDataType(testCase.colKind, testCase.precision, testCase.scale, testCase.udtName)
+		dataType, opts := ParseColumnDataType(testCase.colKind, testCase.precision, testCase.scale, testCase.udtName)
 		assert.Equal(t, testCase.expectedDataType, dataType, testCase.name)
 		assert.Equal(t, testCase.expectedOpts, opts, testCase.name)
 	}


### PR DESCRIPTION
Splits out the stateless part of describing a postgres table + determining the column types from adding fields to our stateful `Table` struct.