### PR TITLE
[postgres] Kill extra query for table columns

### DIFF
--- a/lib/postgres/columns.go
+++ b/lib/postgres/columns.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (t *Table) RetrieveColumns(db *sql.DB) error {
+func (t *Table) PopulateColumns(db *sql.DB) error {
 	cols, err := schema.DescribeTable(db, t.Schema, t.Name)
 	if err != nil {
 		return fmt.Errorf("failed to describe table %s.%s: %w", t.Schema, t.Name, err)

--- a/lib/postgres/columns.go
+++ b/lib/postgres/columns.go
@@ -16,14 +16,7 @@ func (t *Table) PopulateColumns(db *sql.DB) error {
 	}
 
 	for _, col := range cols {
-		if col.Type == schema.InvalidDataType {
-			slog.Warn("Column type did not get mapped in our message schema, so it will not be automatically created by transfer",
-				slog.String("colName", col.Name),
-			)
-		} else {
-			t.Fields.AddField(col.Name, col.Type, col.Opts)
-		}
-
+		t.Fields.AddField(col.Name, col.Type, col.Opts)
 		// Add to original columns before mutation
 		t.OriginalColumns = append(t.OriginalColumns, col.Name)
 		t.ColumnsCastedForScanning = append(t.ColumnsCastedForScanning, castColumn(col.Name, col.Type))

--- a/lib/postgres/columns.go
+++ b/lib/postgres/columns.go
@@ -20,27 +20,13 @@ func (t *Table) RetrieveColumns(db *sql.DB) error {
 			slog.Warn("Column type did not get mapped in our message schema, so it will not be automatically created by transfer",
 				slog.String("colName", col.Name),
 			)
-		} else {
-			t.Fields.AddField(col.Name, col.Type, col.Opts)
+			continue
 		}
-	}
 
-	query := fmt.Sprintf("SELECT * FROM %s LIMIT 1", pgx.Identifier{t.Schema, t.Name}.Sanitize())
-	rows, err := db.Query(query)
-	if err != nil {
-		return fmt.Errorf("failed to query, query: %v, err: %w", query, err)
-	}
-
-	columns, err := rows.Columns()
-	if err != nil {
-		return err
-	}
-
-	for _, column := range columns {
+		t.Fields.AddField(col.Name, col.Type, col.Opts)
 		// Add to original columns before mutation
-		t.OriginalColumns = append(t.OriginalColumns, column)
-		columnKind := t.Fields.GetDataType(column)
-		t.ColumnsCastedForScanning = append(t.ColumnsCastedForScanning, castColumn(column, columnKind))
+		t.OriginalColumns = append(t.OriginalColumns, col.Name)
+		t.ColumnsCastedForScanning = append(t.ColumnsCastedForScanning, castColumn(col.Name, col.Type))
 	}
 
 	return t.FindStartAndEndPrimaryKeys(db)

--- a/lib/postgres/columns.go
+++ b/lib/postgres/columns.go
@@ -20,10 +20,10 @@ func (t *Table) RetrieveColumns(db *sql.DB) error {
 			slog.Warn("Column type did not get mapped in our message schema, so it will not be automatically created by transfer",
 				slog.String("colName", col.Name),
 			)
-			continue
+		} else {
+			t.Fields.AddField(col.Name, col.Type, col.Opts)
 		}
 
-		t.Fields.AddField(col.Name, col.Type, col.Opts)
 		// Add to original columns before mutation
 		t.OriginalColumns = append(t.OriginalColumns, col.Name)
 		t.ColumnsCastedForScanning = append(t.ColumnsCastedForScanning, castColumn(col.Name, col.Type))

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -94,7 +94,7 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 
 		dataType, opts := ParseColumnDataType(colType, numericPrecision, numericScale, udtName)
 		if dataType == InvalidDataType {
-			slog.Warn("Unable to identify column type", slog.String("colName", colName), slog.String("colType", colType))
+			return nil, fmt.Errorf("unable to identify type for column %s: %s", colName, colType)
 		}
 
 		cols = append(cols, Column{

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -94,7 +94,7 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 
 		dataType, opts := ParseColumnDataType(colType, numericPrecision, numericScale, udtName)
 		if dataType == InvalidDataType {
-			return nil, fmt.Errorf("unable to identify type for column %s: %s", colName, colType)
+			return nil, fmt.Errorf("unable to identify type on table %s.%s for column %s: %s", _schema, table, colName, colType)
 		}
 
 		cols = append(cols, Column{

--- a/sources/postgres/snapshot.go
+++ b/sources/postgres/snapshot.go
@@ -44,7 +44,7 @@ func (s *Source) Run(ctx context.Context, writer kafkalib.BatchWriter, statsD mt
 
 		slog.Info("Loading configuration for table", slog.String("table", tableCfg.Name))
 		table := postgres.NewTable(tableCfg)
-		if err := table.RetrieveColumns(s.db); err != nil {
+		if err := table.PopulateColumns(s.db); err != nil {
 			if postgres.NoRowsError(err) {
 				slog.Info("Table does not contain any rows, skipping...", slog.String("table", table.Name))
 				continue


### PR DESCRIPTION
I don't think we need to query for columns again since we already have them from when we described the table.