### PR TITLE
[postgres] Store `Column` structs on table

### DIFF
--- a/lib/postgres/message_test.go
+++ b/lib/postgres/message_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/reader/config"
+	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
 type ErrorRowIterator struct{}
@@ -43,7 +44,7 @@ func TestMessageBuilder(t *testing.T) {
 		Name:   "table",
 		Schema: "schema",
 	})
-	table.Columns = []string{"a"}
+	table.Columns = []schema.Column{{Name: "a", Type: schema.Int16}}
 	table.ColumnsCastedForScanning = []string{"a"}
 	table.PrimaryKeys.Upsert("a", ptr.ToString("1"), ptr.ToString("4"))
 

--- a/lib/postgres/message_test.go
+++ b/lib/postgres/message_test.go
@@ -44,7 +44,6 @@ func TestMessageBuilder(t *testing.T) {
 		Schema: "schema",
 	})
 	table.Columns = []schema.Column{{Name: "a", Type: schema.Int16}}
-	table.ColumnsCastedForScanning = []string{"a"}
 	table.PrimaryKeys.Upsert("a", ptr.ToString("1"), ptr.ToString("4"))
 
 	// test zero batches

--- a/lib/postgres/message_test.go
+++ b/lib/postgres/message_test.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/telemetry/metrics"
-
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/ptr"
+	"github.com/artie-labs/transfer/lib/telemetry/metrics"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/reader/config"

--- a/lib/postgres/message_test.go
+++ b/lib/postgres/message_test.go
@@ -2,8 +2,9 @@ package postgres
 
 import (
 	"fmt"
-	"github.com/artie-labs/transfer/lib/telemetry/metrics"
 	"testing"
+
+	"github.com/artie-labs/transfer/lib/telemetry/metrics"
 
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	"github.com/artie-labs/transfer/lib/ptr"
@@ -42,7 +43,7 @@ func TestMessageBuilder(t *testing.T) {
 		Name:   "table",
 		Schema: "schema",
 	})
-	table.OriginalColumns = []string{"a"}
+	table.Columns = []string{"a"}
 	table.ColumnsCastedForScanning = []string{"a"}
 	table.PrimaryKeys.Upsert("a", ptr.ToString("1"), ptr.ToString("4"))
 

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -63,7 +63,7 @@ func (s *scanner) scan(errorAttempts int) ([]map[string]interface{}, error) {
 		Schema:        s.table.Schema,
 		TableName:     s.table.Name,
 		PrimaryKeys:   s.table.PrimaryKeys.Keys(),
-		ColumnsToScan: s.table.ColumnsCastedForScanning,
+		ColumnsToScan: s.table.ColumnsCastedForScanning(),
 
 		FirstWhere:   firstWhereClause,
 		StartingKeys: startKeys,

--- a/lib/postgres/table.go
+++ b/lib/postgres/table.go
@@ -74,7 +74,7 @@ func (t *Table) findStartAndEndPrimaryKeys(db *sql.DB) error {
 	for _, primaryKey := range keys {
 		index := slices.IndexFunc(t.Columns, func(c schema.Column) bool { return c.Name == primaryKey })
 		if index < 0 {
-			return fmt.Errorf("failed to find primary key from original columns, key: %s, originalColumns: %v, index: %d", primaryKey, t.Columns, index)
+			return fmt.Errorf("failed to find primary key from original columns, key: %s, columns: %v", primaryKey, t.Columns)
 		}
 		col := t.Columns[index]
 		castedPrimaryKeys = append(castedPrimaryKeys, castColumn(col.Name, col.Type))


### PR DESCRIPTION
Rename `OriginalColumns` to `Columns` and store the full `Column` struct instead of just the name. Also kill `ColumnsCastedForScanning` and determine on the fly when needed.