### PR TITLE
[postgres] Pull fields out of `ParseValue`

### DIFF
--- a/lib/postgres/parse_test.go
+++ b/lib/postgres/parse_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
 
-	pgDebezium "github.com/artie-labs/reader/lib/postgres/debezium"
 	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
@@ -96,12 +95,9 @@ func TestParse(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		fields := pgDebezium.NewFields()
-		dataType, opts := schema.ParseColumnDataType(tc.colKind, nil, nil, tc.udtName)
-		fields.AddField(tc.colName, dataType, opts)
+		dataType, _ := schema.ParseColumnDataType(tc.colKind, nil, nil, tc.udtName)
 
-		value, err := ParseValue(fields, ParseValueArgs{
-			ColName:      tc.colName,
+		value, err := ParseValue(dataType, ParseValueArgs{
 			ValueWrapper: tc.value,
 			ParseTime:    tc.parseTime,
 		})
@@ -114,8 +110,7 @@ func TestParse(t *testing.T) {
 
 			// if there are no errors, let's iterate over this a few times to make sure it's deterministic.
 			for i := 0; i < 5; i++ {
-				value, err = ParseValue(fields, ParseValueArgs{
-					ColName:      tc.colName,
+				value, err = ParseValue(dataType, ParseValueArgs{
 					ValueWrapper: value,
 					ParseTime:    tc.parseTime,
 				})

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -162,8 +162,7 @@ func (s *scanner) scan(errorAttempts int) ([]map[string]interface{}, error) {
 		row := make(map[string]ValueWrapper)
 		for k, v := range values {
 			colName := columns[k]
-			value, err := ParseValue(s.table.Fields, ParseValueArgs{
-				ColName: colName,
+			value, err := ParseValue(s.table.Fields.GetDataType(colName), ParseValueArgs{
 				ValueWrapper: ValueWrapper{
 					Value: v,
 				},
@@ -182,8 +181,7 @@ func (s *scanner) scan(errorAttempts int) ([]map[string]interface{}, error) {
 
 	// Update the starting key so that the next scan will pick off where we last left off.
 	for _, pk := range s.primaryKeys.Keys() {
-		val, err := ParseValue(s.table.Fields, ParseValueArgs{
-			ColName:      pk,
+		val, err := ParseValue(s.table.Fields.GetDataType(pk), ParseValueArgs{
 			ValueWrapper: lastRow[pk],
 			ParseTime:    true,
 		})

--- a/lib/postgres/table.go
+++ b/lib/postgres/table.go
@@ -79,9 +79,9 @@ func (t *Table) findStartAndEndPrimaryKeys(db *sql.DB) error {
 
 	for idx, bound := range primaryKeysBounds {
 		colName := keys[idx]
+		dataType := t.Fields.GetDataType(colName)
 
-		minVal, err := ParseValue(t.Fields, ParseValueArgs{
-			ColName:      colName,
+		minVal, err := ParseValue(dataType, ParseValueArgs{
 			ValueWrapper: ValueWrapper{Value: bound.Min},
 			ParseTime:    true,
 		})
@@ -89,8 +89,7 @@ func (t *Table) findStartAndEndPrimaryKeys(db *sql.DB) error {
 			return err
 		}
 
-		maxVal, err := ParseValue(t.Fields, ParseValueArgs{
-			ColName:      colName,
+		maxVal, err := ParseValue(dataType, ParseValueArgs{
 			ValueWrapper: ValueWrapper{Value: bound.Max},
 			ParseTime:    true,
 		})


### PR DESCRIPTION
The only think we needed `ColName` for was to look up the `DataType` using `fields`, instead we can just pass the `DataType` to `ParseValue` directly.