### PR TITLE
[postgres] Move `KeysToValueList` calls to `scanTableQuery`

### DIFF
--- a/lib/postgres/primary_key/primary_keys.go
+++ b/lib/postgres/primary_key/primary_keys.go
@@ -3,14 +3,6 @@ package primary_key
 import (
 	"fmt"
 	"strings"
-
-	"github.com/artie-labs/transfer/lib/cdc"
-	"github.com/artie-labs/transfer/lib/cdc/util"
-	"github.com/artie-labs/transfer/lib/debezium"
-	"github.com/artie-labs/transfer/lib/typing"
-
-	pgDebezium "github.com/artie-labs/reader/lib/postgres/debezium"
-	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
 type Keys struct {
@@ -113,38 +105,6 @@ func (k *Keys) Keys() []string {
 	return keysToReturn
 }
 
-// TODO: This function should just fold into the column escape function.
-func (k *Keys) KeysToValueList(columns []schema.Column, end bool) []string {
-	optionalSchema := getOptionalSchema(columns)
-
-	var valuesToReturn []string
-	for _, pk := range k.keys {
-		val := pk.StartingValue
-		if end {
-			val = pk.EndingValue
-		}
-
-		kindDetails := typing.ParseValue(typing.Settings{}, pk.Name, optionalSchema, val)
-		switch kindDetails.Kind {
-		case typing.String.Kind, typing.Struct.Kind, typing.ETime.Kind:
-			valuesToReturn = append(valuesToReturn, fmt.Sprintf(`'%s'`, val))
-		default:
-			valuesToReturn = append(valuesToReturn, val)
-		}
-	}
-
-	return valuesToReturn
-}
-
-func getOptionalSchema(columns []schema.Column) map[string]typing.KindDetails {
-	schemaEvtPayload := &util.SchemaEventPayload{
-		Schema: debezium.Schema{
-			FieldsObject: []debezium.FieldsObject{{
-				Fields:     pgDebezium.ColumnsToFields(columns),
-				Optional:   false,
-				FieldLabel: cdc.After,
-			}},
-		},
-	}
-	return schemaEvtPayload.GetOptionalSchema()
+func (k *Keys) KeysList() []Key {
+	return k.keys
 }

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -68,11 +68,9 @@ type scanTableQueryArgs struct {
 	Columns     []schema.Column
 
 	// First where clause
-	FirstWhere   Comparison
-	StartingKeys []string
+	FirstWhere Comparison
 	// Second where clause
 	SecondWhere Comparison
-	EndingKeys  []string
 
 	Limit uint
 }

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -17,14 +17,12 @@ func TestScanTableQuery(t *testing.T) {
 	primaryKeys.Upsert("c", ptr.ToString("3"), ptr.ToString("6"))
 
 	query := scanTableQuery(scanTableQueryArgs{
-		Schema:       "schema",
-		TableName:    "table",
-		PrimaryKeys:  primaryKeys,
-		FirstWhere:   GreaterThanEqualTo,
-		StartingKeys: []string{"1", "2", "3"},
-		SecondWhere:  GreaterThan,
-		EndingKeys:   []string{"4", "5", "6"},
-		Limit:        1,
+		Schema:      "schema",
+		TableName:   "table",
+		PrimaryKeys: primaryKeys,
+		FirstWhere:  GreaterThanEqualTo,
+		SecondWhere: GreaterThan,
+		Limit:       1,
 		Columns: []schema.Column{
 			{Name: "a", Type: schema.Int64},
 			{Name: "b", Type: schema.Int64},

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -5,25 +5,34 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/artie-labs/reader/lib/postgres/primary_key"
 	"github.com/artie-labs/reader/lib/postgres/schema"
+	"github.com/artie-labs/transfer/lib/ptr"
 )
 
 func TestScanTableQuery(t *testing.T) {
+	primaryKeys := primary_key.NewKeys()
+	primaryKeys.Upsert("a", ptr.ToString("1"), ptr.ToString("4"))
+	primaryKeys.Upsert("b", ptr.ToString("2"), ptr.ToString("5"))
+	primaryKeys.Upsert("c", ptr.ToString("3"), ptr.ToString("6"))
+
 	query := scanTableQuery(scanTableQueryArgs{
 		Schema:       "schema",
 		TableName:    "table",
-		PrimaryKeys:  []string{"a", "b", "c"},
+		PrimaryKeys:  primaryKeys,
 		FirstWhere:   GreaterThanEqualTo,
 		StartingKeys: []string{"1", "2", "3"},
 		SecondWhere:  GreaterThan,
 		EndingKeys:   []string{"4", "5", "6"},
-		OrderBy:      []string{"order"},
 		Limit:        1,
 		Columns: []schema.Column{
+			{Name: "a", Type: schema.Int64},
+			{Name: "b", Type: schema.Int64},
+			{Name: "c", Type: schema.Int64},
 			{Name: "e", Type: schema.Text},
 			{Name: "f", Type: schema.Int64},
 			{Name: "g", Type: schema.Money}, // money will be cast
 		},
 	})
-	assert.Equal(t, `SELECT "e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") >= row(1,2,3) AND NOT row("a","b","c") > row(4,5,6) ORDER BY "order" LIMIT 1`, query)
+	assert.Equal(t, `SELECT "a","b","c","e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") >= row(1,2,3) AND NOT row("a","b","c") > row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
 }


### PR DESCRIPTION
`KeysToValueList ` is postgres specific where as the rest of the primary key code is database agnostic and can be shared with mysql. Will move it to `lib/rdbms` after this.