### PR TITLE
[postgres] Fix `TestShouldQuoteValue` test cases

### DIFF
--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -19,8 +19,8 @@ func TestShouldQuoteValue(t *testing.T) {
 	}{
 		{"InvalidDataType", schema.Column{Type: schema.InvalidDataType}, "invalid", true},
 		{"VariableNumeric", schema.Column{Type: schema.VariableNumeric}, "var_numeric", true},
-		{"Money", schema.Column{Type: schema.Money}, "1.00", true},
-		{"Numeric", schema.Column{Type: schema.Numeric}, "1.23", true},
+		{"Money", schema.Column{Type: schema.Money, Opts: &schema.Opts{Scale: ptr.ToString("2")}}, "1.00", true},
+		{"Numeric", schema.Column{Type: schema.Numeric, Opts: &schema.Opts{Scale: ptr.ToString("2"), Precision: ptr.ToString("2")}}, "1.23", true},
 		{"Bit", schema.Column{Type: schema.Bit}, "1", false},
 		{"Boolean", schema.Column{Type: schema.Boolean}, "true", false},
 		{"TextThatRequiresEscaping", schema.Column{Type: schema.TextThatRequiresEscaping}, "select", true},


### PR DESCRIPTION
When running the test we were getting:
```
WARN Skipping field from optional schema b/c we cannot determine the data type field=Money
WARN Skipping field from optional schema b/c we cannot determine the data type field=Numeric
```
because the columns did not have scale and precision set.