### PR TITLE
[postgres] Modify `shouldQuoteValue` to check types directly

### DIFF
--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -107,10 +107,6 @@ func shouldQuoteValue(col schema.Column) (bool, error) {
 	switch col.Type {
 	case schema.InvalidDataType:
 		return false, fmt.Errorf("invalid data type")
-	case schema.Money, schema.Numeric:
-		// TODO: Returning true for these to maintain parity with existing code, but double check this
-		slog.Warn("Could not determine data type for column", slog.String("colName", col.Name))
-		return true, nil
 	case schema.Float,
 		schema.Int16,
 		schema.Int32,
@@ -121,6 +117,8 @@ func shouldQuoteValue(col schema.Column) (bool, error) {
 		schema.Array:    // TODO: Double check this
 		return false, nil
 	case schema.VariableNumeric,
+		schema.Money,
+		schema.Numeric,
 		schema.TextThatRequiresEscaping,
 		schema.Text,
 		schema.HStore,

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -14,40 +14,43 @@ func TestShouldQuoteValue(t *testing.T) {
 	tests := []struct {
 		name     string
 		col      schema.Column
-		value    string
 		expected bool
 	}{
-		{"InvalidDataType", schema.Column{Type: schema.InvalidDataType}, "invalid", true},
-		{"VariableNumeric", schema.Column{Type: schema.VariableNumeric}, "var_numeric", true},
-		{"Money", schema.Column{Type: schema.Money}, "1.00", true},
-		{"Numeric", schema.Column{Type: schema.Numeric}, "1.23", true},
-		{"Bit", schema.Column{Type: schema.Bit}, "1", false},
-		{"Boolean", schema.Column{Type: schema.Boolean}, "true", false},
-		{"TextThatRequiresEscaping", schema.Column{Type: schema.TextThatRequiresEscaping}, "select", true},
-		{"Text", schema.Column{Type: schema.Text}, "foo", true},
-		{"Interval", schema.Column{Type: schema.Interval}, "", false},
-		{"Array", schema.Column{Type: schema.Array}, "", false},
-		{"HStore", schema.Column{Type: schema.HStore}, "", true},
-		{"Float", schema.Column{Type: schema.Float}, "12.34", false},
-		{"Int16", schema.Column{Type: schema.Int16}, "12", false},
-		{"Int32", schema.Column{Type: schema.Int32}, "12", false},
-		{"Int64", schema.Column{Type: schema.Int64}, "12", false},
-		{"UUID", schema.Column{Type: schema.UUID}, "7152e149-65b9-44ae-aec0-5685777204e8", true},
-		{"UserDefinedText", schema.Column{Type: schema.UserDefinedText}, "foo", true},
-		{"JSON", schema.Column{Type: schema.JSON}, "{}", true},
-		{"Timestamp", schema.Column{Type: schema.Timestamp}, "2000-01-02 03:04:05", true},
-		{"Time", schema.Column{Type: schema.Time}, "03:04:05", true},
-		{"Date", schema.Column{Type: schema.Date}, "2000-01-02", true},
+		{"VariableNumeric", schema.Column{Type: schema.VariableNumeric}, true},
+		{"Money", schema.Column{Type: schema.Money}, true},
+		{"Numeric", schema.Column{Type: schema.Numeric}, true},
+		{"Bit", schema.Column{Type: schema.Bit}, false},
+		{"Boolean", schema.Column{Type: schema.Boolean}, false},
+		{"TextThatRequiresEscaping", schema.Column{Type: schema.TextThatRequiresEscaping}, true},
+		{"Text", schema.Column{Type: schema.Text}, true},
+		{"Interval", schema.Column{Type: schema.Interval}, false},
+		{"Array", schema.Column{Type: schema.Array}, false},
+		{"HStore", schema.Column{Type: schema.HStore}, true},
+		{"Float", schema.Column{Type: schema.Float}, false},
+		{"Int16", schema.Column{Type: schema.Int16}, false},
+		{"Int32", schema.Column{Type: schema.Int32}, false},
+		{"Int64", schema.Column{Type: schema.Int64}, false},
+		{"UUID", schema.Column{Type: schema.UUID}, true},
+		{"UserDefinedText", schema.Column{Type: schema.UserDefinedText}, true},
+		{"JSON", schema.Column{Type: schema.JSON}, true},
+		{"Timestamp", schema.Column{Type: schema.Timestamp}, true},
+		{"Time", schema.Column{Type: schema.Time}, true},
+		{"Date", schema.Column{Type: schema.Date}, true},
 		// PostGIS
-		{"Point", schema.Column{Type: schema.Point}, "", true},
-		{"Geometry", schema.Column{Type: schema.Geometry}, "", true},
-		{"Geography", schema.Column{Type: schema.Geography}, "", true},
+		{"Point", schema.Column{Type: schema.Point}, true},
+		{"Geometry", schema.Column{Type: schema.Geometry}, true},
+		{"Geography", schema.Column{Type: schema.Geography}, true},
 	}
 
 	for _, tc := range tests {
 		tc.col.Name = tc.name
-		assert.Equal(t, tc.expected, shouldQuoteValue(tc.col, tc.value), tc.name)
+		result, err := shouldQuoteValue(tc.col)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.expected, result, tc.name)
 	}
+
+	_, err := shouldQuoteValue(schema.Column{Type: schema.InvalidDataType})
+	assert.ErrorContains(t, err, "invalid data type")
 }
 
 func TestKeysToValueList(t *testing.T) {


### PR DESCRIPTION
Based on https://github.com/artie-labs/reader/pull/145 I determined that the `val` passed to `shouldQuoteValue` is extraneous. Instead of the complexity of:
- converting a `Column` to a `Field`
- converting the `Field` to a `KindDetails`
  - For the decimals the existing behavior https://github.com/artie-labs/transfer/blob/cdf82a6e5b2ff966aeb1e1468fd149dc27417c21/lib/debezium/schema.go#L92 checks that we can parse the scale and if not returns in invalid type, however since we quoted invalid types and also quote decimal types this doesn't actually matter.
- switching on `KindDetails`

we can just do a simple switch on the `Column`'s `DataType`. I already have tests for all of the Postgres `DataType`s so we can be sure that this change preserves the existing behavior. 