### PR TITLE
[postgres] Move `fields.go` to `sources/postgres/transformer`

### DIFF
--- a/sources/postgres/transformer/fields.go
+++ b/sources/postgres/transformer/fields.go
@@ -1,4 +1,4 @@
-package debezium
+package transformer
 
 import (
 	"github.com/artie-labs/transfer/lib/debezium"

--- a/sources/postgres/transformer/fields_test.go
+++ b/sources/postgres/transformer/fields_test.go
@@ -1,4 +1,4 @@
-package debezium
+package transformer
 
 import (
 	"testing"

--- a/sources/postgres/transformer/transformer.go
+++ b/sources/postgres/transformer/transformer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/artie-labs/reader/lib"
 	"github.com/artie-labs/reader/lib/mtr"
 	"github.com/artie-labs/reader/lib/postgres"
-	pgDebezium "github.com/artie-labs/reader/lib/postgres/debezium"
 )
 
 type DebeziumTransformer struct {
@@ -97,7 +96,7 @@ func (m *DebeziumTransformer) createPayload(row map[string]interface{}) (util.Sc
 
 	schema := debezium.Schema{
 		FieldsObject: []debezium.FieldsObject{{
-			Fields:     pgDebezium.ColumnsToFields(m.table.Columns),
+			Fields:     ColumnsToFields(m.table.Columns),
 			Optional:   false,
 			FieldLabel: cdc.After,
 		}},

--- a/sources/postgres/transformer/values_test.go
+++ b/sources/postgres/transformer/values_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/artie-labs/reader/lib/postgres/debezium"
 	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
@@ -77,7 +76,7 @@ func TestParseValue(t *testing.T) {
 		} else {
 			assert.NoError(t, actualErr, tc.name)
 			if tc.numericValue {
-				val, err := debezium.ColumnToField(tc.col).DecodeDecimal(fmt.Sprint(actualValue))
+				val, err := ColumnToField(tc.col).DecodeDecimal(fmt.Sprint(actualValue))
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedValue, val.String(), tc.name)
 			} else {


### PR DESCRIPTION
This kills the `lib/postgres/debezium` package.