### PR TITLE
[postgres] Fix bug with handling empty tables

### DIFF
--- a/lib/postgres/errors.go
+++ b/lib/postgres/errors.go
@@ -1,9 +1,10 @@
 package postgres
 
-func NoRowsError(err error) bool {
-	if err != nil {
-		return err.Error() == "sql: no rows in result set"
-	}
+import (
+	"database/sql"
+	"errors"
+)
 
-	return false
+func NoRowsError(err error) bool {
+	return errors.Is(err, sql.ErrNoRows)
 }

--- a/lib/postgres/errors_test.go
+++ b/lib/postgres/errors_test.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"database/sql"
 	"fmt"
 	"testing"
 
@@ -22,7 +23,7 @@ func TestNoRowsError(t *testing.T) {
 		},
 		{
 			name:     "Test Case 2: no rows error",
-			err:      fmt.Errorf("sql: no rows in result set"),
+			err:      sql.ErrNoRows,
 			expected: true,
 		},
 		{


### PR DESCRIPTION
Because we're wrapping errors the final error is never exactly `"sql: no rows in result set"`, so when a table is empty we aren't detecting it properly:
```
Feb 17 19:12:43.681 ERR Failed to run postgresql snapshot err="failed to load configuration for table user_games: failed to retrieve bounds for primary keys: failed to retrieve lower bounds for primary keys: sql: no rows in result set"
exit status 1
```
Using `errors.Is` checks the underlying error and fixes this bug.