### PR TITLE
Move `NoRowsError` to `lib/rdbms`

### DIFF
--- a/lib/rdbms/errors.go
+++ b/lib/rdbms/errors.go
@@ -1,10 +1,10 @@
-package postgres
+package rdbms
 
 import (
 	"database/sql"
 	"errors"
 )
 
-func NoRowsError(err error) bool {
+func IsNoRowsErr(err error) bool {
 	return errors.Is(err, sql.ErrNoRows)
 }

--- a/lib/rdbms/errors_test.go
+++ b/lib/rdbms/errors_test.go
@@ -1,4 +1,4 @@
-package postgres
+package rdbms
 
 import (
 	"database/sql"
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNoRowsError(t *testing.T) {
+func TestIsNoRowsErr(t *testing.T) {
 	type _tc struct {
 		name     string
 		err      error
@@ -34,7 +34,7 @@ func TestNoRowsError(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		actualData := NoRowsError(tc.err)
+		actualData := IsNoRowsErr(tc.err)
 		assert.Equal(t, tc.expected, actualData, tc.name)
 	}
 }

--- a/sources/postgres/snapshot.go
+++ b/sources/postgres/snapshot.go
@@ -13,6 +13,7 @@ import (
 	"github.com/artie-labs/reader/lib/kafkalib"
 	"github.com/artie-labs/reader/lib/mtr"
 	"github.com/artie-labs/reader/lib/postgres"
+	"github.com/artie-labs/reader/lib/rdbms"
 	"github.com/artie-labs/reader/sources/postgres/transformer"
 )
 
@@ -46,7 +47,7 @@ func (s *Source) Run(ctx context.Context, writer kafkalib.BatchWriter, statsD mt
 		slog.Info("Loading configuration for table", slog.String("table", tableCfg.Name))
 		table := postgres.NewTable(tableCfg)
 		if err := table.PopulateColumns(s.db); err != nil {
-			if postgres.NoRowsError(err) {
+			if rdbms.IsNoRowsErr(err) {
 				slog.Info("Table does not contain any rows, skipping...", slog.String("table", table.Name))
 				continue
 			} else {


### PR DESCRIPTION
Since `sql.ErrNoRows` isn't Postgres specific we can use it for other SQL database types.