### PR TITLE
[postgres] Add adapter for `DebeziumTransformer`

### DIFF
--- a/sources/postgres/snapshot.go
+++ b/sources/postgres/snapshot.go
@@ -63,7 +63,7 @@ func (s *Source) Run(ctx context.Context, writer kafkalib.BatchWriter, statsD mt
 		)
 
 		scanner := table.NewScanner(s.db, tableCfg.GetBatchSize(), defaultErrorRetries)
-		dbzTransformer := transformer.NewDebeziumTransformer(table, &scanner, statsD)
+		dbzTransformer := transformer.NewDebeziumTransformer(transformer.NewPostgresAdapter(*table), &scanner, statsD)
 		count, err := writer.WriteIterator(ctx, dbzTransformer)
 		if err != nil {
 			return fmt.Errorf("failed to snapshot for table %s: %w", table.Name, err)


### PR DESCRIPTION
This will allow the `DebeziumTransformer ` to be source agnostic so that it can be reused for `MySQL`. For this PR I tried to make as few changes as possible so that it would be easier to review. In the next PR I will move `DebeziumTransformer` to `lib/transformer`.