### PR TITLE
Allow primary key values to be any type

### DIFF
--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -156,7 +156,7 @@ func keysToValueList(k *primary_key.Keys, columns []schema.Column, end bool) ([]
 		}
 
 		// TODO: look into storing primary key values as their raw types instead of converting them to strings
-		strVal := val.(string)
+		strVal := fmt.Sprint(val)
 
 		if shouldQuote {
 			valuesToReturn = append(valuesToReturn, fmt.Sprintf(`'%s'`, strVal))

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -155,6 +155,7 @@ func keysToValueList(k *primary_key.Keys, columns []schema.Column, end bool) ([]
 			return nil, err
 		}
 
+		// TODO: look into storing primary key values as their raw types instead of converting them to strings
 		strVal := val.(string)
 
 		if shouldQuote {

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -155,10 +155,12 @@ func keysToValueList(k *primary_key.Keys, columns []schema.Column, end bool) ([]
 			return nil, err
 		}
 
+		strVal := val.(string)
+
 		if shouldQuote {
-			valuesToReturn = append(valuesToReturn, fmt.Sprintf(`'%s'`, val))
+			valuesToReturn = append(valuesToReturn, fmt.Sprintf(`'%s'`, strVal))
 		} else {
-			valuesToReturn = append(valuesToReturn, val)
+			valuesToReturn = append(valuesToReturn, strVal)
 		}
 	}
 	return valuesToReturn, nil

--- a/lib/rdbms/primary_key/primary_key.go
+++ b/lib/rdbms/primary_key/primary_key.go
@@ -2,6 +2,6 @@ package primary_key
 
 type Key struct {
 	Name          string
-	StartingValue string
-	EndingValue   string
+	StartingValue interface{}
+	EndingValue   interface{}
 }


### PR DESCRIPTION
For MySQL we will just use the values returned from the database rather than coercing them to strings like we do for PostgreSQL.