### PR TITLE
[postgres] Always use inclusive upper bound for scans

### DIFF
--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -86,7 +86,7 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		pgx.Identifier{args.Schema, args.TableName}.Sanitize(),
 		// WHERE row(pk) > row(123)
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), lowerBoundComparison, strings.Join(startingValues, ","),
-		// AND NOT row(pk) < row(123)
+		// AND NOT row(pk) > row(123)
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), strings.Join(endingValues, ","),
 		// ORDER BY
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","),

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -79,14 +79,14 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		lowerBoundComparison = ">="
 	}
 
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE row(%s) %s row(%s) AND NOT row(%s) > row(%s) ORDER BY %s LIMIT %d`,
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE row(%s) %s row(%s) AND row(%s) <= row(%s) ORDER BY %s LIMIT %d`,
 		// SELECT
 		strings.Join(castedColumns, ","),
 		// FROM
 		pgx.Identifier{args.Schema, args.TableName}.Sanitize(),
 		// WHERE row(pk) > row(123)
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), lowerBoundComparison, strings.Join(startingValues, ","),
-		// AND NOT row(pk) > row(123)
+		// AND row(pk) <= row(123)
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), strings.Join(endingValues, ","),
 		// ORDER BY
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","),

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -30,7 +30,6 @@ type scanner struct {
 	// mutable
 	primaryKeys *primary_key.Keys
 	isFirstRow  bool
-	isLastRow   bool
 	done        bool
 }
 
@@ -47,7 +46,6 @@ func (t *Table) NewScanner(db *sql.DB, batchSize uint, errorRetries int) (scanne
 		retryCfg:    retryCfg,
 		primaryKeys: t.PrimaryKeys.Clone(),
 		isFirstRow:  true,
-		isLastRow:   false,
 		done:        false,
 	}, nil
 }
@@ -58,7 +56,6 @@ type scanTableQueryArgs struct {
 	PrimaryKeys         *primary_key.Keys
 	Columns             []schema.Column
 	InclusiveLowerBound bool
-	InclusiveUpperBound bool
 	Limit               uint
 }
 
@@ -82,12 +79,7 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		lowerBoundComparison = ">="
 	}
 
-	upperBoundComparsion := ">="
-	if args.InclusiveUpperBound {
-		upperBoundComparsion = ">"
-	}
-
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE row(%s) %s row(%s) AND NOT row(%s) %s row(%s) ORDER BY %s LIMIT %d`,
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE row(%s) %s row(%s) AND NOT row(%s) > row(%s) ORDER BY %s LIMIT %d`,
 		// SELECT
 		strings.Join(castedColumns, ","),
 		// FROM
@@ -95,7 +87,7 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		// WHERE row(pk) > row(123)
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), lowerBoundComparison, strings.Join(startingValues, ","),
 		// AND NOT row(pk) < row(123)
-		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), upperBoundComparsion, strings.Join(endingValues, ","),
+		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","), strings.Join(endingValues, ","),
 		// ORDER BY
 		strings.Join(QuotedIdentifiers(args.PrimaryKeys.Keys()), ","),
 		// LIMIT
@@ -174,7 +166,6 @@ func (s *scanner) scan() ([]map[string]interface{}, error) {
 		PrimaryKeys:         s.primaryKeys,
 		Columns:             s.table.Columns,
 		InclusiveLowerBound: s.isFirstRow,
-		InclusiveUpperBound: !s.isLastRow,
 		Limit:               s.batchSize,
 	})
 	if err != nil {
@@ -287,7 +278,5 @@ func (s *scanner) Next() ([]map[string]interface{}, error) {
 		return nil, nil
 	}
 	s.isFirstRow = false
-	// The reason why lastRow exists is because in the past, we had queries only return partial results but it wasn't fully done
-	s.isLastRow = s.batchSize > uint(len(rows))
 	return rows, nil
 }

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -86,22 +86,39 @@ func TestScanTableQuery(t *testing.T) {
 	primaryKeys.Upsert("a", ptr.ToString("1"), ptr.ToString("4"))
 	primaryKeys.Upsert("b", ptr.ToString("2"), ptr.ToString("5"))
 	primaryKeys.Upsert("c", ptr.ToString("3"), ptr.ToString("6"))
+	cols := []schema.Column{
+		{Name: "a", Type: schema.Int64},
+		{Name: "b", Type: schema.Int64},
+		{Name: "c", Type: schema.Int64},
+		{Name: "e", Type: schema.Text},
+		{Name: "f", Type: schema.Int64},
+		{Name: "g", Type: schema.TextThatRequiresEscaping}, // Requires casting
+	}
 
-	query, err := scanTableQuery(scanTableQueryArgs{
-		Schema:              "schema",
-		TableName:           "table",
-		PrimaryKeys:         primaryKeys,
-		InclusiveLowerBound: true,
-		Limit:               1,
-		Columns: []schema.Column{
-			{Name: "a", Type: schema.Int64},
-			{Name: "b", Type: schema.Int64},
-			{Name: "c", Type: schema.Int64},
-			{Name: "e", Type: schema.Text},
-			{Name: "f", Type: schema.Int64},
-			{Name: "g", Type: schema.TextThatRequiresEscaping}, // Requires casting
-		},
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, `SELECT "a","b","c","e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") >= row(1,2,3) AND NOT row("a","b","c") > row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
+	{
+		// inclusive lower bound
+		query, err := scanTableQuery(scanTableQueryArgs{
+			Schema:              "schema",
+			TableName:           "table",
+			PrimaryKeys:         primaryKeys,
+			InclusiveLowerBound: true,
+			Limit:               1,
+			Columns:             cols,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, `SELECT "a","b","c","e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") >= row(1,2,3) AND row("a","b","c") <= row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
+	}
+	{
+		// exclusive lower bound
+		query, err := scanTableQuery(scanTableQueryArgs{
+			Schema:              "schema",
+			TableName:           "table",
+			PrimaryKeys:         primaryKeys,
+			InclusiveLowerBound: false,
+			Limit:               1,
+			Columns:             cols,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, `SELECT "a","b","c","e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") > row(1,2,3) AND row("a","b","c") <= row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
+	}
 }

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -92,7 +92,6 @@ func TestScanTableQuery(t *testing.T) {
 		TableName:           "table",
 		PrimaryKeys:         primaryKeys,
 		InclusiveLowerBound: true,
-		InclusiveUpperBound: true,
 		Limit:               1,
 		Columns: []schema.Column{
 			{Name: "a", Type: schema.Int64},


### PR DESCRIPTION
Currently we use an inclusive upper bound for the scan except in the situation where the previous scan returned a non-zero amount of rows yet fewer rows than the batch size. In this case we do one final scan but this time we do not use an inclusive upper bound, which theoretically means that we're not getting back the very last row. In practice this isn't actually an issue because the scan which returned an amount of rows smaller than the batch size will have returned the last row, so we'll always get it back.

This code was originally introduced here: https://github.com/artie-labs/custom-snapshots/pull/1/files#diff-63a7de3e0e433472f281806bac7775b97ff1a41449e5cefa4b125ed196a4fc2aR133