### PR TITLE
[rdbms] Change primary_key `Upsert` to `UpdateStartingValue`

### DIFF
--- a/lib/mysql/scanner/scanner.go
+++ b/lib/mysql/scanner/scanner.go
@@ -123,9 +123,9 @@ func (s *scanner) scan() ([]map[string]interface{}, error) {
 	// Update the starting key so that the next scan will pick off where we last left off.
 	lastRow := rowsData[len(rowsData)-1]
 	for _, pk := range s.primaryKeys.Keys() {
-		value := lastRow[pk]
-		valueStr := fmt.Sprint(value)
-		s.primaryKeys.Upsert(pk, &valueStr, nil)
+		if err := s.primaryKeys.UpdateStartingValue(pk, lastRow[pk]); err != nil {
+			return nil, err
+		}
 	}
 
 	return rowsData, nil

--- a/lib/mysql/schema/schema.go
+++ b/lib/mysql/schema/schema.go
@@ -274,8 +274,8 @@ func getPrimaryKeyValues(db *sql.DB, table string, primaryKeys []Column, descend
 }
 
 type Bounds struct {
-	Min interface{}
-	Max interface{}
+	Min any
+	Max any
 }
 
 func GetPrimaryKeysBounds(db *sql.DB, table string, primaryKeys []Column) ([]Bounds, error) {

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/artie-labs/transfer/lib/retry"
 	"github.com/jackc/pgx/v5"
 
@@ -244,7 +243,9 @@ func (s *scanner) scan() ([]map[string]interface{}, error) {
 			return nil, err
 		}
 
-		s.primaryKeys.Upsert(pk, ptr.ToString(val.String()), nil)
+		if err := s.primaryKeys.UpdateStartingValue(pk, val.String()); err != nil {
+			return nil, err
+		}
 	}
 
 	var parsedRows []map[string]interface{}

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/reader/lib/postgres/schema"
@@ -76,7 +75,9 @@ func TestKeysToValueList(t *testing.T) {
 		assert.Equal(t, []string{"4", "'z'", "'2001-01-02 03:04:05'"}, values)
 	}
 	{
-		primaryKeys.Upsert("d", ptr.ToString("1"), ptr.ToString("4"))
+		primaryKeys := primary_key.NewKeys(
+			append(primaryKeys.KeysList(), primary_key.Key{Name: "d", StartingValue: "1", EndingValue: "4"}),
+		)
 		_, err := keysToValueList(primaryKeys, cols, true)
 		assert.ErrorContains(t, err, "primary key d not found in columns")
 	}

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -258,8 +258,8 @@ func getPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column,
 }
 
 type Bounds struct {
-	Min interface{}
-	Max interface{}
+	Min any
+	Max any
 }
 
 func GetPrimaryKeysBounds(db *sql.DB, schema, table string, primaryKeys []Column, cast func(c Column) string) ([]Bounds, error) {

--- a/lib/rdbms/primary_key/primary_key.go
+++ b/lib/rdbms/primary_key/primary_key.go
@@ -2,6 +2,6 @@ package primary_key
 
 type Key struct {
 	Name          string
-	StartingValue interface{}
-	EndingValue   interface{}
+	StartingValue any
+	EndingValue   any
 }

--- a/lib/rdbms/primary_key/primary_keys.go
+++ b/lib/rdbms/primary_key/primary_keys.go
@@ -66,7 +66,7 @@ func (k *Keys) Clone() *Keys {
 func (k *Keys) UpdateStartingValue(keyName string, startingVal any) error {
 	idx := slices.IndexFunc(k.keys, func(x Key) bool { return x.Name == keyName })
 	if idx < 0 {
-		return fmt.Errorf("could not find key named %s", keyName)
+		return fmt.Errorf("no key named %s", keyName)
 	}
 
 	k.keys[idx].StartingValue = startingVal

--- a/lib/rdbms/primary_key/primary_keys.go
+++ b/lib/rdbms/primary_key/primary_keys.go
@@ -7,19 +7,13 @@ import (
 )
 
 type Keys struct {
-	keys   []Key
-	keyMap map[string]bool
+	keys []Key
 }
 
 func NewKeys(keys []Key) *Keys {
-	result := &Keys{
-		keyMap: make(map[string]bool),
-		keys:   slices.Clone(keys),
+	return &Keys{
+		keys: slices.Clone(keys),
 	}
-	for _, key := range result.keys {
-		result.keyMap[key.Name] = true
-	}
-	return result
 }
 
 func (k *Keys) LoadValues(startingValues, endingValues []string) error {
@@ -65,49 +59,18 @@ func (k *Keys) LoadValues(startingValues, endingValues []string) error {
 	return nil
 }
 
-func (k *Keys) Length() int {
-	if k == nil {
-		return 0
-	}
-
-	return len(k.keys)
-}
-
 func (k *Keys) Clone() *Keys {
 	return NewKeys(k.keys)
 }
 
-func (k *Keys) Upsert(keyName string, startingVal *string, endingVal *string) {
-	_, isOk := k.keyMap[keyName]
-	if isOk {
-		for index := range k.keys {
-			if k.keys[index].Name == keyName {
-				if startingVal != nil {
-					k.keys[index].StartingValue = *startingVal
-				}
-
-				if endingVal != nil {
-					k.keys[index].EndingValue = *endingVal
-				}
-				break
-			}
-		}
-	} else {
-		key := Key{
-			Name: keyName,
-		}
-
-		if startingVal != nil {
-			key.StartingValue = *startingVal
-		}
-
-		if endingVal != nil {
-			key.EndingValue = *endingVal
-		}
-
-		k.keys = append(k.keys, key)
-		k.keyMap[key.Name] = true
+func (k *Keys) UpdateStartingValue(keyName string, startingVal any) error {
+	idx := slices.IndexFunc(k.keys, func(x Key) bool { return x.Name == keyName })
+	if idx < 0 {
+		return fmt.Errorf("could not find key named %s", keyName)
 	}
+
+	k.keys[idx].StartingValue = startingVal
+	return nil
 }
 
 func (k *Keys) Keys() []string {

--- a/lib/rdbms/primary_key/primary_keys_test.go
+++ b/lib/rdbms/primary_key/primary_keys_test.go
@@ -85,7 +85,7 @@ func TestPrimaryKeys_LoadValues(t *testing.T) {
 			assert.Error(t, err, testCase.name)
 		} else {
 			assert.NoError(t, err, testCase.name)
-			assert.Equal(t, testCase.expectedKeys, testCase.keys, testCase.name)
+			assert.Equal(t, testCase.expectedKeys, pk.KeysList(), testCase.name)
 		}
 
 	}

--- a/lib/rdbms/primary_key/primary_keys_test.go
+++ b/lib/rdbms/primary_key/primary_keys_test.go
@@ -3,7 +3,6 @@ package primary_key
 import (
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,66 +11,11 @@ func TestNewKeys(t *testing.T) {
 	{
 		keysArray := []Key{{Name: "foo", StartingValue: 20}, {Name: "bar"}}
 		keys := NewKeys(keysArray)
-		keys.Upsert("foo", ptr.ToString("new starting value"), nil)
+		keys.UpdateStartingValue("foo", "new starting value")
 		assert.Equal(t, "foo", keys.keys[0].Name)
 		assert.Equal(t, "new starting value", keys.keys[0].StartingValue)
 		assert.Equal(t, "foo", keysArray[0].Name)
 		assert.Equal(t, 20, keysArray[0].StartingValue)
-	}
-}
-
-func TestPrimaryKeys_Length(t *testing.T) {
-	type _tc struct {
-		name           string
-		keys           *Keys
-		expectedLength int
-	}
-
-	tcs := []_tc{
-		{
-			name:           "Nil Keys",
-			keys:           nil,
-			expectedLength: 0,
-		},
-		{
-			name: "Empty Keys",
-			keys: &Keys{
-				keys:   []Key{},
-				keyMap: map[string]bool{},
-			},
-			expectedLength: 0,
-		},
-		{
-			name: "Single Key",
-			keys: &Keys{
-				keys: []Key{
-					{Name: "Key1", StartingValue: "Start1", EndingValue: "End1"},
-				},
-				keyMap: map[string]bool{
-					"Key1": true,
-				},
-			},
-			expectedLength: 1,
-		},
-		{
-			name: "Multiple Keys",
-			keys: &Keys{
-				keys: []Key{
-					{Name: "Key1", StartingValue: "Start1", EndingValue: "End1"},
-					{Name: "Key2", StartingValue: "Start2", EndingValue: "End2"},
-				},
-				keyMap: map[string]bool{
-					"Key1": true,
-					"Key2": true,
-				},
-			},
-			expectedLength: 2,
-		},
-	}
-
-	for _, tc := range tcs {
-		actualLength := tc.keys.Length()
-		assert.Equal(t, tc.expectedLength, actualLength, tc.name)
 	}
 }
 
@@ -134,12 +78,7 @@ func TestPrimaryKeys_LoadValues(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-
-		pk := NewKeys([]Key{})
-		pk.keys = testCase.keys
-		for _, key := range testCase.keys {
-			pk.keyMap[key.Name] = true
-		}
+		pk := NewKeys(testCase.keys)
 
 		err := pk.LoadValues(testCase.startingValues, testCase.endingValues)
 		if testCase.expectedErr {
@@ -152,67 +91,40 @@ func TestPrimaryKeys_LoadValues(t *testing.T) {
 	}
 }
 
-func TestKeys_Upsert(t *testing.T) {
+func TestKeys_UpdateStartingValue(t *testing.T) {
 	type _tc struct {
 		name        string
 		keys        *Keys
 		keyName     string
-		startingVal *string
-		endingVal   *string
+		startingVal any
 
 		expectedKeys []Key
+		expectedErr  string
 	}
 
 	startVal2 := "Start2"
-	endVal2 := "End2"
 
 	tcs := []_tc{
 		{
-			name: "Insert new key",
+			name: "Key doesn't exist",
 			keys: &Keys{
 				keys: []Key{
 					{Name: "Key1", StartingValue: "Start1", EndingValue: "End1"},
-				},
-				keyMap: map[string]bool{
-					"Key1": true,
 				},
 			},
 			keyName:     "Key2",
-			startingVal: &startVal2,
-			endingVal:   &endVal2,
-			expectedKeys: []Key{
-				{Name: "Key1", StartingValue: "Start1", EndingValue: "End1"},
-				{Name: "Key2", StartingValue: "Start2", EndingValue: "End2"},
-			},
+			startingVal: startVal2,
+			expectedErr: "boo",
 		},
 		{
-			name: "Update existing key (ending value only)",
+			name: "Update existing key",
 			keys: &Keys{
 				keys: []Key{
 					{Name: "Key1", StartingValue: "Start1", EndingValue: "End1"},
-				},
-				keyMap: map[string]bool{
-					"Key1": true,
-				},
-			},
-			keyName:   "Key1",
-			endingVal: &endVal2,
-			expectedKeys: []Key{
-				{Name: "Key1", StartingValue: "Start1", EndingValue: "End2"},
-			},
-		},
-		{
-			name: "Update existing key (starting value only)",
-			keys: &Keys{
-				keys: []Key{
-					{Name: "Key1", StartingValue: "Start1", EndingValue: "End1"},
-				},
-				keyMap: map[string]bool{
-					"Key1": true,
 				},
 			},
 			keyName:     "Key1",
-			startingVal: &startVal2,
+			startingVal: startVal2,
 			expectedKeys: []Key{
 				{Name: "Key1", StartingValue: "Start2", EndingValue: "End1"},
 			},
@@ -220,8 +132,13 @@ func TestKeys_Upsert(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc.keys.Upsert(tc.keyName, tc.startingVal, tc.endingVal)
-		assert.Equal(t, tc.expectedKeys, tc.keys.keys, tc.name)
+		err := tc.keys.UpdateStartingValue(tc.keyName, tc.startingVal)
+		if tc.expectedErr != "" {
+			assert.Error(t, err, tc.expectedErr)
+		} else {
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedKeys, tc.keys.keys, tc.name)
+		}
 	}
 }
 
@@ -231,33 +148,23 @@ func TestKeys_Clone(t *testing.T) {
 		keys := NewKeys([]Key{})
 		keys2 := keys.Clone()
 		assert.Equal(t, keys.keys, keys2.keys)
-		assert.Equal(t, keys.keyMap, keys2.keyMap)
 	}
 	// non-empty keys
 	{
-		keys := NewKeys([]Key{})
-		a := "a"
-		b := "b"
-		keys.Upsert("foo", &a, &b)
+		keys := NewKeys([]Key{{Name: "foo", StartingValue: "a", EndingValue: nil}})
 		keys2 := keys.Clone()
 		assert.Equal(t, keys.keys, keys2.keys)
-		assert.Equal(t, keys.keyMap, keys2.keyMap)
-		assert.Equal(t, []Key{{"foo", "a", "b"}}, keys2.keys)
-		assert.Equal(t, map[string]bool{"foo": true}, keys2.keyMap)
+		assert.Equal(t, []Key{{"foo", "a", nil}}, keys2.keys)
 	}
 	// cloning actually makes a clone and doesn't reuse pointers to keys
 	{
 		keys := NewKeys([]Key{{Name: "foo", StartingValue: 20}, {Name: "bar", StartingValue: 0}})
 		clonedKeys := keys.Clone()
-		clonedKeys.Upsert("foo", ptr.ToString("new starting value"), nil)
+		clonedKeys.UpdateStartingValue("foo", "new starting value")
 		assert.Equal(t, "foo", keys.keys[0].Name)
 		assert.Equal(t, 20, keys.keys[0].StartingValue)
 		assert.Equal(t, "foo", clonedKeys.keys[0].Name)
 		assert.Equal(t, "new starting value", clonedKeys.keys[0].StartingValue)
-
-		keys.Upsert("foo", nil, ptr.ToString("new ending value"))
-		assert.Equal(t, "new ending value", keys.keys[0].EndingValue)
-		assert.Nil(t, clonedKeys.keys[0].EndingValue)
 	}
 }
 
@@ -269,28 +176,29 @@ func TestKeys_IsExausted(t *testing.T) {
 	}
 	// one key, different starting and ending values
 	{
-		keys := NewKeys([]Key{})
-		keys.Upsert("foo", ptr.ToString("a"), ptr.ToString("b"))
+		keys := NewKeys([]Key{{Name: "foo", StartingValue: "a", EndingValue: "b"}})
 		assert.False(t, keys.IsExhausted())
 	}
 	// one key, same starting and ending values
 	{
-		keys := NewKeys([]Key{})
-		keys.Upsert("foo", ptr.ToString("a"), ptr.ToString("a"))
+		keys := NewKeys([]Key{{Name: "foo", StartingValue: "a", EndingValue: "a"}})
 		assert.True(t, keys.IsExhausted())
 	}
 	// two keys, different starting and ending values for one
 	{
-		keys := NewKeys([]Key{})
-		keys.Upsert("foo", ptr.ToString("a"), ptr.ToString("a"))
-		keys.Upsert("bar", ptr.ToString(""), ptr.ToString("b"))
+		keys := NewKeys([]Key{
+			{Name: "foo", StartingValue: "a", EndingValue: "a"},
+			{Name: "bar", StartingValue: nil, EndingValue: "a"},
+		})
 		assert.False(t, keys.IsExhausted())
 	}
-	// two keys, same starting and ending values for both
+	// three keys, same starting and ending values for all
 	{
-		keys := NewKeys([]Key{})
-		keys.Upsert("foo", ptr.ToString("a"), ptr.ToString("a"))
-		keys.Upsert("bar", ptr.ToString(""), ptr.ToString(""))
+		keys := NewKeys([]Key{
+			{Name: "foo", StartingValue: "a", EndingValue: "a"},
+			{Name: "bar", StartingValue: 2, EndingValue: 2},
+			{Name: "baz", StartingValue: nil, EndingValue: nil},
+		})
 		assert.True(t, keys.IsExhausted())
 	}
 }

--- a/lib/rdbms/primary_key/primary_keys_test.go
+++ b/lib/rdbms/primary_key/primary_keys_test.go
@@ -11,7 +11,7 @@ func TestNewKeys(t *testing.T) {
 	{
 		keysArray := []Key{{Name: "foo", StartingValue: 20}, {Name: "bar"}}
 		keys := NewKeys(keysArray)
-		keys.UpdateStartingValue("foo", "new starting value")
+		assert.NoError(t, keys.UpdateStartingValue("foo", "new starting value"))
 		assert.Equal(t, "foo", keys.keys[0].Name)
 		assert.Equal(t, "new starting value", keys.keys[0].StartingValue)
 		assert.Equal(t, "foo", keysArray[0].Name)
@@ -114,7 +114,7 @@ func TestKeys_UpdateStartingValue(t *testing.T) {
 			},
 			keyName:     "Key2",
 			startingVal: startVal2,
-			expectedErr: "boo",
+			expectedErr: "no key named Key2",
 		},
 		{
 			name: "Update existing key",
@@ -134,7 +134,7 @@ func TestKeys_UpdateStartingValue(t *testing.T) {
 	for _, tc := range tcs {
 		err := tc.keys.UpdateStartingValue(tc.keyName, tc.startingVal)
 		if tc.expectedErr != "" {
-			assert.Error(t, err, tc.expectedErr)
+			assert.ErrorContains(t, err, tc.expectedErr, tc.name)
 		} else {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedKeys, tc.keys.keys, tc.name)


### PR DESCRIPTION
Now that we're initializing the `Keys` struct with all the keys we don't have to ever add new keys, and we never modify the ending value so no need to pass it in.