### PR TITLE
[postgres] Remove redundant pk `fmt.Sprint()` calls

### DIFF
--- a/lib/postgres/parse.go
+++ b/lib/postgres/parse.go
@@ -27,10 +27,6 @@ type ValueWrapper struct {
 	parsed bool
 }
 
-func (v *ValueWrapper) String() string {
-	return fmt.Sprint(v.Value)
-}
-
 func NewValueWrapper(value any) ValueWrapper {
 	return ValueWrapper{
 		Value:  value,

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -73,11 +73,10 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		return "", err
 	}
 
-	keyNames := make([]string, len(args.PrimaryKeys))
+	quotedKeyNames := make([]string, len(args.PrimaryKeys))
 	for i, key := range args.PrimaryKeys {
-		keyNames[i] = key.Name
+		quotedKeyNames[i] = pgx.Identifier{key.Name}.Sanitize()
 	}
-	quotedKeyNames := QuotedIdentifiers(keyNames)
 
 	lowerBoundComparison := ">"
 	if args.InclusiveLowerBound {

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -64,11 +64,11 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		castedColumns[idx] = castColumn(col)
 	}
 
-	startingValues, err := keysToValueList(args.PrimaryKeys, args.Columns, false)
+	startingValues, err := keysToValueList(args.PrimaryKeys.Keys(), args.Columns, false)
 	if err != nil {
 		return "", err
 	}
-	endingValues, err := keysToValueList(args.PrimaryKeys, args.Columns, true)
+	endingValues, err := keysToValueList(args.PrimaryKeys.Keys(), args.Columns, true)
 	if err != nil {
 		return "", err
 	}
@@ -130,9 +130,9 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	}
 }
 
-func keysToValueList(k *primary_key.Keys, columns []schema.Column, end bool) ([]string, error) {
+func keysToValueList(keys []primary_key.Key, columns []schema.Column, end bool) ([]string, error) {
 	var valuesToReturn []string
-	for _, pk := range k.Keys() {
+	for _, pk := range keys {
 		val := pk.StartingValue
 		if end {
 			val = pk.EndingValue
@@ -245,7 +245,7 @@ func (s *scanner) scan() ([]map[string]any, error) {
 			return nil, err
 		}
 
-		if err := s.primaryKeys.UpdateStartingValue(pk.Name, val.String()); err != nil {
+		if err := s.primaryKeys.UpdateStartingValue(pk.Name, val.Value); err != nil {
 			return nil, err
 		}
 	}

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -137,7 +137,7 @@ func _scan(s *scan.Scanner[*Table], primaryKeys *primary_key.Keys, isFirstRow bo
 	query, err := scanTableQuery(scanTableQueryArgs{
 		Schema:              s.Table.Schema,
 		TableName:           s.Table.Name,
-    PrimaryKeys:         primaryKeys.Keys(),
+		PrimaryKeys:         primaryKeys.Keys(),
 		Columns:             s.Table.Columns,
 		InclusiveLowerBound: isFirstRow,
 		Limit:               s.BatchSize,

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -52,11 +52,11 @@ func TestShouldQuoteValue(t *testing.T) {
 }
 
 func TestKeysToValueList(t *testing.T) {
-	primaryKeys := primary_key.NewKeys([]primary_key.Key{
+	primaryKeys := []primary_key.Key{
 		{Name: "a", StartingValue: "1", EndingValue: "4"},
 		{Name: "b", StartingValue: "a", EndingValue: "z"},
 		{Name: "c", StartingValue: "2000-01-02 03:04:05", EndingValue: "2001-01-02 03:04:05"},
-	})
+	}
 
 	cols := []schema.Column{
 		{Name: "a", Type: schema.Int64},
@@ -75,9 +75,7 @@ func TestKeysToValueList(t *testing.T) {
 		assert.Equal(t, []string{"4", "'z'", "'2001-01-02 03:04:05'"}, values)
 	}
 	{
-		primaryKeys := primary_key.NewKeys(
-			append(primaryKeys.Keys(), primary_key.Key{Name: "d", StartingValue: "1", EndingValue: "4"}),
-		)
+		primaryKeys := append(primaryKeys, primary_key.Key{Name: "d", StartingValue: "1", EndingValue: "4"})
 		_, err := keysToValueList(primaryKeys, cols, true)
 		assert.ErrorContains(t, err, "primary key d not found in columns")
 	}

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -82,11 +82,11 @@ func TestKeysToValueList(t *testing.T) {
 }
 
 func TestScanTableQuery(t *testing.T) {
-	primaryKeys := primary_key.NewKeys([]primary_key.Key{
+	primaryKeys := []primary_key.Key{
 		{Name: "a", StartingValue: "1", EndingValue: "4"},
 		{Name: "b", StartingValue: "2", EndingValue: "5"},
 		{Name: "c", StartingValue: "3", EndingValue: "6"},
-	})
+	}
 	cols := []schema.Column{
 		{Name: "a", Type: schema.Int64},
 		{Name: "b", Type: schema.Int64},

--- a/lib/postgres/table.go
+++ b/lib/postgres/table.go
@@ -92,8 +92,8 @@ func (t *Table) findStartAndEndPrimaryKeys(db *sql.DB) error {
 
 		t.PrimaryKeys[idx] = primary_key.Key{
 			Name:          col.Name,
-			StartingValue: minVal.String(),
-			EndingValue:   maxVal.String(),
+			StartingValue: minVal.Value,
+			EndingValue:   maxVal.Value,
 		}
 	}
 


### PR DESCRIPTION
We're already doing a `fmt.Sprint()` for primary key values here: https://github.com/artie-labs/reader/pull/197/files#diff-eb76bea08e483c31dcfdd81272705c460694b4cc6fb60a396854c96d676dd9adR155 when we build the scan query, so we don't need to do so when building and updating primary keys.