### PR TITLE
[postgres] Convert `time.Time` values to string at query time

### DIFF
--- a/lib/postgres/parse.go
+++ b/lib/postgres/parse.go
@@ -10,11 +10,9 @@ import (
 
 	"github.com/artie-labs/reader/lib/postgres/parse"
 	"github.com/artie-labs/reader/lib/postgres/schema"
-	"github.com/artie-labs/reader/lib/timeutil"
 )
 
 type ParseValueArgs struct {
-	ParseTime    bool
 	ValueWrapper ValueWrapper
 }
 
@@ -135,11 +133,6 @@ func ParseValue(colKind schema.DataType, args ParseValueArgs) (ValueWrapper, err
 
 		return NewValueWrapper(stringSlice), nil
 	default:
-		// This is needed because we need to cast the time.Time object into a string for pagination.
-		if args.ParseTime {
-			return NewValueWrapper(timeutil.ParseValue(args.Value())), nil
-		}
-
 		// We don't care about anything other than arrays.
 		// Return parsed = false since we didn't actually parse it.
 		return ValueWrapper{

--- a/lib/postgres/parse_test.go
+++ b/lib/postgres/parse_test.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"testing"
-	"time"
 
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/stretchr/testify/assert"
@@ -15,7 +14,6 @@ func TestParse(t *testing.T) {
 		colName       string
 		colKind       string
 		udtName       *string
-		parseTime     bool
 		value         ValueWrapper
 		expectErr     bool
 		expectedValue any
@@ -64,15 +62,6 @@ func TestParse(t *testing.T) {
 			expectedValue: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
 		},
 		{
-			colName: "parse time",
-			colKind: "timestamp without time zone",
-			value: ValueWrapper{
-				Value: time.Date(1993, 1, 1, 0, 0, 0, 0, time.UTC),
-			},
-			parseTime:     true,
-			expectedValue: "1993-01-01T00:00:00Z",
-		},
-		{
 			colName: "json",
 			colKind: "json",
 			value: ValueWrapper{
@@ -99,7 +88,6 @@ func TestParse(t *testing.T) {
 
 		value, err := ParseValue(dataType, ParseValueArgs{
 			ValueWrapper: tc.value,
-			ParseTime:    tc.parseTime,
 		})
 
 		if tc.expectErr {
@@ -112,7 +100,6 @@ func TestParse(t *testing.T) {
 			for i := 0; i < 5; i++ {
 				value, err = ParseValue(dataType, ParseValueArgs{
 					ValueWrapper: value,
-					ParseTime:    tc.parseTime,
 				})
 
 				assert.NoError(t, err, tc.colName)

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -102,6 +102,7 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 
 func keysToValueList(keys []primary_key.Key, columns []schema.Column) ([]string, []string, error) {
 	convertToString := func(value any) string {
+		// This is needed because we need to cast the time.Time object into a string for pagination.
 		return fmt.Sprint(timeutil.ParseValue(value))
 	}
 

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -173,14 +173,14 @@ func _scan(s *scan.Scanner[*Table], primaryKeys *primary_key.Keys, isFirstRow bo
 		scanArgs[i] = &values[i]
 	}
 
-	var rowsData []map[string]ValueWrapper
+	var rowsData []map[string]any
 	for rows.Next() {
 		err = rows.Scan(scanArgs...)
 		if err != nil {
 			return nil, err
 		}
 
-		row := make(map[string]ValueWrapper)
+		row := make(map[string]any)
 		for idx, v := range values {
 			col := s.Table.Columns[idx]
 
@@ -193,7 +193,7 @@ func _scan(s *scan.Scanner[*Table], primaryKeys *primary_key.Keys, isFirstRow bo
 				return nil, err
 			}
 
-			row[col.Name] = value
+			row[col.Name] = value.Value
 		}
 		rowsData = append(rowsData, row)
 	}
@@ -205,32 +205,10 @@ func _scan(s *scan.Scanner[*Table], primaryKeys *primary_key.Keys, isFirstRow bo
 	// Update the starting key so that the next scan will pick off where we last left off.
 	lastRow := rowsData[len(rowsData)-1]
 	for _, pk := range primaryKeys.Keys() {
-		col, err := s.Table.GetColumnByName(pk.Name)
-		if err != nil {
-			return nil, err
-		}
-
-		val, err := ParseValue(col.Type, ParseValueArgs{
-			ValueWrapper: lastRow[pk.Name],
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		if err := primaryKeys.UpdateStartingValue(pk.Name, val.Value); err != nil {
+		if err := primaryKeys.UpdateStartingValue(pk.Name, lastRow[pk.Name]); err != nil {
 			return nil, err
 		}
 	}
 
-	var parsedRows []map[string]any
-	for _, row := range rowsData {
-		parsedRow := make(map[string]any)
-		for key, value := range row {
-			parsedRow[key] = value.Value
-		}
-
-		parsedRows = append(parsedRows, parsedRow)
-	}
-
-	return parsedRows, nil
+	return rowsData, nil
 }

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -103,7 +103,7 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 func keysToValueList(keys []primary_key.Key, columns []schema.Column) ([]string, []string, error) {
 	convertToString := func(value any) string {
 		// This is needed because we need to cast the time.Time object into a string for pagination.
-		return fmt.Sprint(timeutil.ParseValue(value))
+		return fmt.Sprint(timeutil.ConvertTimeToString(value))
 	}
 
 	var startValues []string

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/reader/lib/rdbms/primary_key"
 	"github.com/artie-labs/reader/lib/rdbms/scan"
+	"github.com/artie-labs/reader/lib/timeutil"
 )
 
 func (t *Table) NewScanner(db *sql.DB, cfg scan.ScannerConfig) (scan.Scanner[*Table], error) {
@@ -100,6 +101,10 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 }
 
 func keysToValueList(keys []primary_key.Key, columns []schema.Column) ([]string, []string, error) {
+	convertToString := func(value any) string {
+		return fmt.Sprint(timeutil.ParseValue(value))
+	}
+
 	var startValues []string
 	var endValues []string
 	for _, pk := range keys {
@@ -113,8 +118,8 @@ func keysToValueList(keys []primary_key.Key, columns []schema.Column) ([]string,
 			return nil, nil, err
 		}
 
-		startVal := fmt.Sprint(pk.StartingValue)
-		endVal := fmt.Sprint(pk.EndingValue)
+		startVal := convertToString(pk.StartingValue)
+		endVal := convertToString(pk.EndingValue)
 
 		if shouldQuote {
 			startVal = QuoteLiteral(startVal)
@@ -206,7 +211,6 @@ func _scan(s *scan.Scanner[*Table], primaryKeys *primary_key.Keys, isFirstRow bo
 
 		val, err := ParseValue(col.Type, ParseValueArgs{
 			ValueWrapper: lastRow[pk.Name],
-			ParseTime:    true,
 		})
 		if err != nil {
 			return nil, err

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -56,24 +57,26 @@ func TestKeysToValueList(t *testing.T) {
 		{Name: "a", StartingValue: "1", EndingValue: "4"},
 		{Name: "b", StartingValue: "a", EndingValue: "z"},
 		{Name: "c", StartingValue: "2000-01-02 03:04:05", EndingValue: "2001-01-02 03:04:05"},
+		{Name: "d", StartingValue: time.Date(1993, 1, 1, 0, 0, 0, 0, time.UTC), EndingValue: time.Date(1994, 1, 1, 0, 0, 0, 0, time.UTC)},
 	}
 
 	cols := []schema.Column{
 		{Name: "a", Type: schema.Int64},
 		{Name: "b", Type: schema.Text},
 		{Name: "c", Type: schema.Timestamp},
+		{Name: "d", Type: schema.Timestamp},
 	}
 
 	{
 		startValues, endValues, err := keysToValueList(primaryKeys, cols)
 		assert.NoError(t, err)
-		assert.Equal(t, []string{"1", "'a'", "'2000-01-02 03:04:05'"}, startValues)
-		assert.Equal(t, []string{"4", "'z'", "'2001-01-02 03:04:05'"}, endValues)
+		assert.Equal(t, []string{"1", "'a'", "'2000-01-02 03:04:05'", "'1993-01-01T00:00:00Z'"}, startValues)
+		assert.Equal(t, []string{"4", "'z'", "'2001-01-02 03:04:05'", "'1994-01-01T00:00:00Z'"}, endValues)
 	}
 	{
-		primaryKeys := append(primaryKeys, primary_key.Key{Name: "d", StartingValue: "1", EndingValue: "4"})
+		primaryKeys := append(primaryKeys, primary_key.Key{Name: "foo", StartingValue: "1", EndingValue: "4"})
 		_, _, err := keysToValueList(primaryKeys, cols)
-		assert.ErrorContains(t, err, "primary key d not found in columns")
+		assert.ErrorContains(t, err, "primary key foo not found in columns")
 	}
 }
 

--- a/lib/postgres/table.go
+++ b/lib/postgres/table.go
@@ -84,7 +84,6 @@ func (t *Table) findStartAndEndPrimaryKeys(db *sql.DB) error {
 
 		minVal, err := ParseValue(col.Type, ParseValueArgs{
 			ValueWrapper: ValueWrapper{Value: bounds.Min},
-			ParseTime:    true,
 		})
 		if err != nil {
 			return err
@@ -92,7 +91,6 @@ func (t *Table) findStartAndEndPrimaryKeys(db *sql.DB) error {
 
 		maxVal, err := ParseValue(col.Type, ParseValueArgs{
 			ValueWrapper: ValueWrapper{Value: bounds.Max},
-			ParseTime:    true,
 		})
 		if err != nil {
 			return err

--- a/lib/timeutil/parse.go
+++ b/lib/timeutil/parse.go
@@ -2,9 +2,9 @@ package timeutil
 
 import "time"
 
-// ParseValue - will check if the type is time.Time, if so, it will return it in a string format
+// ConvertTimeToString - will check if the type is time.Time, if so, it will return it in a string format
 // Else it will not doing anything. This is a special case for our row based pagination.
-func ParseValue(val any) any {
+func ConvertTimeToString(val any) any {
 	timeVal, isTime := val.(time.Time)
 	if isTime {
 		return timeVal.Format(time.RFC3339)


### PR DESCRIPTION
Instead of converting primary key time.Time` values to strings when we store them in the `primary_key.Keys` we can just convert them to strings when we need to use them to build the scanning query. 