### PR TITLE
[postgres] Kill `TextThatRequiresEscaping`

### DIFF
--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -14,7 +14,7 @@ func castColumn(col schema.Column) string {
 	switch col.Type {
 	case schema.InvalidDataType:
 		return colName
-	case schema.TextThatRequiresCasting:
+	case schema.Inet:
 		return fmt.Sprintf("%s::text", colName)
 	case schema.Time, schema.Interval:
 		// We want to extract(epoch from interval) will emit this in ms

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -14,7 +14,7 @@ func castColumn(col schema.Column) string {
 	switch col.Type {
 	case schema.InvalidDataType:
 		return colName
-	case schema.TextThatRequiresEscaping:
+	case schema.TextThatRequiresCasting:
 		return fmt.Sprintf("%s::text", colName)
 	case schema.Time, schema.Interval:
 		// We want to extract(epoch from interval) will emit this in ms

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -59,7 +59,7 @@ func TestCastColumn(t *testing.T) {
 		},
 		{
 			name:     "char_text",
-			dataType: schema.TextThatRequiresEscaping,
+			dataType: schema.TextThatRequiresCasting,
 			expected: `"foo"::text`,
 		},
 		{

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -58,7 +58,7 @@ func TestCastColumn(t *testing.T) {
 			expected: `"foo"`,
 		},
 		{
-			name:     "char_text",
+			name:     "inet",
 			dataType: schema.TextThatRequiresCasting,
 			expected: `"foo"::text`,
 		},

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -59,7 +59,7 @@ func TestCastColumn(t *testing.T) {
 		},
 		{
 			name:     "inet",
-			dataType: schema.TextThatRequiresCasting,
+			dataType: schema.Inet,
 			expected: `"foo"::text`,
 		},
 		{

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -82,7 +82,7 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	case schema.VariableNumeric,
 		schema.Money,
 		schema.Numeric,
-		schema.TextThatRequiresEscaping,
+		schema.TextThatRequiresCasting,
 		schema.Text,
 		schema.HStore,
 		schema.UUID,

--- a/lib/postgres/scan.go
+++ b/lib/postgres/scan.go
@@ -82,7 +82,7 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	case schema.VariableNumeric,
 		schema.Money,
 		schema.Numeric,
-		schema.TextThatRequiresCasting,
+		schema.Inet,
 		schema.Text,
 		schema.HStore,
 		schema.UUID,

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -21,7 +21,7 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"Numeric", schema.Numeric, true},
 		{"Bit", schema.Bit, false},
 		{"Boolean", schema.Boolean, false},
-		{"TextThatRequiresEscaping", schema.TextThatRequiresEscaping, true},
+		{"TextThatRequiresEscaping", schema.TextThatRequiresCasting, true},
 		{"Text", schema.Text, true},
 		{"Interval", schema.Interval, false},
 		{"Array", schema.Array, false},
@@ -92,7 +92,7 @@ func TestScanTableQuery(t *testing.T) {
 		{Name: "c", Type: schema.Int64},
 		{Name: "e", Type: schema.Text},
 		{Name: "f", Type: schema.Int64},
-		{Name: "g", Type: schema.TextThatRequiresEscaping}, // Requires casting
+		{Name: "g", Type: schema.TextThatRequiresCasting}, // Requires casting
 	}
 
 	{

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -21,7 +21,7 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"Numeric", schema.Numeric, true},
 		{"Bit", schema.Bit, false},
 		{"Boolean", schema.Boolean, false},
-		{"TextThatRequiresCasting", schema.Inet, true},
+		{"Inet", schema.Inet, true},
 		{"Text", schema.Text, true},
 		{"Interval", schema.Interval, false},
 		{"Array", schema.Array, false},
@@ -92,7 +92,7 @@ func TestScanTableQuery(t *testing.T) {
 		{Name: "c", Type: schema.Int64},
 		{Name: "e", Type: schema.Text},
 		{Name: "f", Type: schema.Int64},
-		{Name: "g", Type: schema.Inet},
+		{Name: "127.0.0.1", Type: schema.Inet},
 	}
 
 	{
@@ -106,7 +106,7 @@ func TestScanTableQuery(t *testing.T) {
 			Columns:             cols,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, `SELECT "a","b","c","e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") >= row(1,2,3) AND row("a","b","c") <= row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
+		assert.Equal(t, `SELECT "a","b","c","e","f","127.0.0.1"::text FROM "schema"."table" WHERE row("a","b","c") >= row(1,2,3) AND row("a","b","c") <= row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
 	}
 	{
 		// exclusive lower bound
@@ -119,6 +119,6 @@ func TestScanTableQuery(t *testing.T) {
 			Columns:             cols,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, `SELECT "a","b","c","e","f","g"::text FROM "schema"."table" WHERE row("a","b","c") > row(1,2,3) AND row("a","b","c") <= row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
+		assert.Equal(t, `SELECT "a","b","c","e","f","127.0.0.1"::text FROM "schema"."table" WHERE row("a","b","c") > row(1,2,3) AND row("a","b","c") <= row(4,5,6) ORDER BY "a","b","c" LIMIT 1`, query)
 	}
 }

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -21,7 +21,7 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"Numeric", schema.Numeric, true},
 		{"Bit", schema.Bit, false},
 		{"Boolean", schema.Boolean, false},
-		{"TextThatRequiresEscaping", schema.TextThatRequiresCasting, true},
+		{"TextThatRequiresCasting", schema.TextThatRequiresCasting, true},
 		{"Text", schema.Text, true},
 		{"Interval", schema.Interval, false},
 		{"Array", schema.Array, false},
@@ -92,7 +92,7 @@ func TestScanTableQuery(t *testing.T) {
 		{Name: "c", Type: schema.Int64},
 		{Name: "e", Type: schema.Text},
 		{Name: "f", Type: schema.Int64},
-		{Name: "g", Type: schema.TextThatRequiresCasting}, // Requires casting
+		{Name: "g", Type: schema.TextThatRequiresCasting},
 	}
 
 	{

--- a/lib/postgres/scan_test.go
+++ b/lib/postgres/scan_test.go
@@ -21,7 +21,7 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"Numeric", schema.Numeric, true},
 		{"Bit", schema.Bit, false},
 		{"Boolean", schema.Boolean, false},
-		{"TextThatRequiresCasting", schema.TextThatRequiresCasting, true},
+		{"TextThatRequiresCasting", schema.Inet, true},
 		{"Text", schema.Text, true},
 		{"Interval", schema.Interval, false},
 		{"Array", schema.Array, false},
@@ -92,7 +92,7 @@ func TestScanTableQuery(t *testing.T) {
 		{Name: "c", Type: schema.Int64},
 		{Name: "e", Type: schema.Text},
 		{Name: "f", Type: schema.Int64},
-		{Name: "g", Type: schema.TextThatRequiresCasting},
+		{Name: "g", Type: schema.Inet},
 	}
 
 	{

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -19,7 +19,7 @@ const (
 	Numeric
 	Bit
 	Boolean
-	TextThatRequiresCasting
+	Inet
 	Text
 	Interval
 	Array
@@ -131,10 +131,11 @@ func ParseColumnDataType(colKind string, precision, scale, udtName *string) (Dat
 		return Money, &Opts{
 			Scale: ptr.ToString("2"),
 		}
-	case "character varying", "text", "character", "xml", "cidr", "macaddr", "macaddr8":
+	case "character varying", "text", "character", "xml", "cidr", "macaddr", "macaddr8",
+		"int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
 		return Text, nil
-	case "inet", "int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
-		return TextThatRequiresCasting, nil
+	case "inet":
+		return Inet, nil
 	case "json", "jsonb":
 		return JSON, nil
 	case "timestamp without time zone", "timestamp with time zone":

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -12,22 +12,6 @@ import (
 
 type DataType int
 
-var (
-	TextBasedColumns = []string{
-		"xml",
-		"cidr",
-		"macaddr",
-		"macaddr8",
-		"inet",
-		"int4range",
-		"int8range",
-		"numrange",
-		"daterange",
-		"tsrange",
-		"tstzrange",
-	}
-)
-
 const (
 	InvalidDataType DataType = iota
 	VariableNumeric
@@ -35,7 +19,7 @@ const (
 	Numeric
 	Bit
 	Boolean
-	TextThatRequiresEscaping
+	TextThatRequiresCasting
 	Text
 	Interval
 	Array
@@ -147,14 +131,14 @@ func ParseColumnDataType(colKind string, precision, scale, udtName *string) (Dat
 		return Money, &Opts{
 			Scale: ptr.ToString("2"),
 		}
-	case "character varying", "text":
+	case "character varying", "text", "character", "xml", "cidr", "macaddr", "macaddr8":
 		return Text, nil
-	case "character":
-		return TextThatRequiresEscaping, nil
 	case "json", "jsonb":
 		return JSON, nil
 	case "timestamp without time zone", "timestamp with time zone":
 		return Timestamp, nil
+	case "inet", "int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
+		return TextThatRequiresCasting, nil
 	default:
 		if strings.Contains(colKind, "numeric") {
 			if precision == nil && scale == nil {
@@ -164,13 +148,6 @@ func ParseColumnDataType(colKind string, precision, scale, udtName *string) (Dat
 					Scale:     scale,
 					Precision: precision,
 				}
-			}
-		}
-
-		for _, textBasedCol := range TextBasedColumns {
-			// char (m) or character
-			if strings.Contains(colKind, textBasedCol) {
-				return TextThatRequiresEscaping, nil
 			}
 		}
 	}

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -133,12 +133,12 @@ func ParseColumnDataType(colKind string, precision, scale, udtName *string) (Dat
 		}
 	case "character varying", "text", "character", "xml", "cidr", "macaddr", "macaddr8":
 		return Text, nil
+	case "inet", "int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
+		return TextThatRequiresCasting, nil
 	case "json", "jsonb":
 		return JSON, nil
 	case "timestamp without time zone", "timestamp with time zone":
 		return Timestamp, nil
-	case "inet", "int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
-		return TextThatRequiresCasting, nil
 	default:
 		if strings.Contains(colKind, "numeric") {
 			if precision == nil && scale == nil {

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -69,7 +69,7 @@ func TestParseColumnDataType(t *testing.T) {
 		{
 			name:             "inet",
 			colKind:          "inet",
-			expectedDataType: TextThatRequiresCasting,
+			expectedDataType: Inet,
 		},
 		{
 			name:             "numeric",

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -64,7 +64,12 @@ func TestParseColumnDataType(t *testing.T) {
 		{
 			name:             "char_text",
 			colKind:          "character",
-			expectedDataType: TextThatRequiresEscaping,
+			expectedDataType: Text,
+		},
+		{
+			name:             "inet",
+			colKind:          "inet",
+			expectedDataType: TextThatRequiresCasting,
 		},
 		{
 			name:             "numeric",

--- a/sources/postgres/adapter/fields.go
+++ b/sources/postgres/adapter/fields.go
@@ -41,7 +41,7 @@ func toDebeziumType(d schema.DataType) Result {
 		return Result{
 			Type: "boolean",
 		}
-	case schema.Text, schema.UserDefinedText, schema.TextThatRequiresEscaping:
+	case schema.Text, schema.UserDefinedText, schema.TextThatRequiresCasting:
 		return Result{
 			Type: "string",
 		}

--- a/sources/postgres/adapter/fields.go
+++ b/sources/postgres/adapter/fields.go
@@ -41,7 +41,7 @@ func toDebeziumType(d schema.DataType) Result {
 		return Result{
 			Type: "boolean",
 		}
-	case schema.Text, schema.UserDefinedText, schema.TextThatRequiresCasting:
+	case schema.Text, schema.UserDefinedText, schema.Inet:
 		return Result{
 			Type: "string",
 		}

--- a/sources/postgres/adapter/fields_test.go
+++ b/sources/postgres/adapter/fields_test.go
@@ -115,7 +115,7 @@ func TestColumnToField(t *testing.T) {
 		{
 			name:     "inet",
 			colName:  "inet_col",
-			dataType: schema.TextThatRequiresCasting,
+			dataType: schema.Inet,
 			expected: debezium.Field{
 				Type:      "string",
 				FieldName: "inet_col",

--- a/sources/postgres/adapter/fields_test.go
+++ b/sources/postgres/adapter/fields_test.go
@@ -113,12 +113,12 @@ func TestColumnToField(t *testing.T) {
 			},
 		},
 		{
-			name:     "char_text",
-			colName:  "char_text_col",
+			name:     "inet",
+			colName:  "inet_col",
 			dataType: schema.TextThatRequiresCasting,
 			expected: debezium.Field{
 				Type:      "string",
-				FieldName: "char_text_col",
+				FieldName: "inet_col",
 			},
 		},
 	}

--- a/sources/postgres/adapter/fields_test.go
+++ b/sources/postgres/adapter/fields_test.go
@@ -115,7 +115,7 @@ func TestColumnToField(t *testing.T) {
 		{
 			name:     "char_text",
 			colName:  "char_text_col",
-			dataType: schema.TextThatRequiresEscaping,
+			dataType: schema.TextThatRequiresCasting,
 			expected: debezium.Field{
 				Type:      "string",
 				FieldName: "char_text_col",

--- a/sources/postgres/integration_test/main.go
+++ b/sources/postgres/integration_test/main.go
@@ -7,10 +7,12 @@ import (
 	"log/slog"
 	"maps"
 	"math/rand/v2"
+	"os"
 	"strings"
 
 	"github.com/artie-labs/transfer/lib/cdc/util"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/lmittmann/tint"
 
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib"
@@ -29,6 +31,8 @@ var pgConfig = config.PostgreSQL{
 }
 
 func main() {
+	slog.SetDefault(slog.New(tint.NewHandler(os.Stderr, &tint.Options{Level: slog.LevelInfo})))
+
 	db, err := sql.Open("pgx", pgConfig.ToDSN())
 	if err != nil {
 		logger.Fatal("Could not connect to Postgres", slog.Any("err", err))


### PR DESCRIPTION
We test all of these types in our integration test and with the exception of `inet` removing the `::text` casting produces the same output.

Removing the `::text` casting from `inet` changes the value from `192.168.1.5/32` to `192.168.1.5`.