### PR TITLE
[postgres] Change `castColumn` to error for unhandled types

### DIFF
--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -70,7 +70,8 @@ func TestCastColumn(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualEscCol := castColumn(schema.Column{Name: "foo", Type: testCase.dataType})
+		actualEscCol, err := castColumn(schema.Column{Name: "foo", Type: testCase.dataType})
+		assert.NoError(t, err)
 		assert.Equal(t, testCase.expected, actualEscCol, testCase.name)
 	}
 }

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -29,7 +29,11 @@ type scanTableQueryArgs struct {
 func scanTableQuery(args scanTableQueryArgs) (string, error) {
 	castedColumns := make([]string, len(args.Columns))
 	for idx, col := range args.Columns {
-		castedColumns[idx] = castColumn(col)
+		var err error
+		castedColumns[idx], err = castColumn(col)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	startingValues, endingValues, err := keysToValueList(args.PrimaryKeys, args.Columns)

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -134,12 +134,12 @@ func TestParseColumnDataType(t *testing.T) {
 }
 
 func TestBuildPkValuesQuery(t *testing.T) {
-	var cast = func(c Column) string {
-		return pgx.Identifier{c.Name}.Sanitize()
+	var cast = func(c Column) (string, error) {
+		return pgx.Identifier{c.Name}.Sanitize(), nil
 	}
 
 	{
-		query := buildPkValuesQuery(buildPkValuesQueryArgs{
+		query, err := buildPkValuesQuery(buildPkValuesQueryArgs{
 			Keys: []Column{
 				{Name: "a", Type: Text},
 				{Name: "b", Type: Text},
@@ -149,11 +149,12 @@ func TestBuildPkValuesQuery(t *testing.T) {
 			TableName: "table",
 			CastFunc:  cast,
 		})
+		assert.NoError(t, err)
 		assert.Equal(t, `SELECT "a","b","c" FROM "schema"."table" ORDER BY "a","b","c" LIMIT 1`, query)
 	}
 	// Descending
 	{
-		query := buildPkValuesQuery(buildPkValuesQueryArgs{
+		query, err := buildPkValuesQuery(buildPkValuesQueryArgs{
 			Keys: []Column{
 				{Name: "a", Type: Text},
 				{Name: "b", Type: Text},
@@ -164,6 +165,7 @@ func TestBuildPkValuesQuery(t *testing.T) {
 			CastFunc:   cast,
 			Descending: true,
 		})
+		assert.NoError(t, err)
 		assert.Equal(t, `SELECT "a","b","c" FROM "schema"."table" ORDER BY "a" DESC,"b" DESC,"c" DESC LIMIT 1`, query)
 	}
 }


### PR DESCRIPTION
This will ensure that we update `castColumn` when we add a new `DataType`.

I checked that `castColumn` currently works for all of the types defined here: https://github.com/artie-labs/reader/blob/60f0d745c6b8f90a49b7c374440d1be0ee5a3836/lib/postgres/schema/schema.go#L16