### PR TITLE
[postgres] Use value type in `convertToStringForQuery`

### DIFF
--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -154,7 +154,8 @@ func convertToStringForQuery(value any, dataType schema.DataType) (string, error
 		}
 	case string:
 		switch dataType {
-		case schema.Text, schema.UserDefinedText, schema.Inet, schema.UUID:
+		case schema.Text, schema.UserDefinedText, schema.Inet, schema.UUID, schema.JSON, schema.VariableNumeric,
+			schema.Numeric, schema.Money:
 			return QuoteLiteral(fmt.Sprint(value)), nil
 		default:
 			slog.Error("string value with non-string column type",

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -84,14 +84,20 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	switch dataType {
 	case schema.InvalidDataType:
 		return false, fmt.Errorf("invalid data type")
-	case schema.Interval, // TODO: This doesn't work: operator does not exist: interval >= bigint (SQLSTATE 42883)
-		schema.Array: // TODO: This doesn't work: need to serialize to Postgres array format "{1,2,3}"
-		return false, fmt.Errorf("unsupported primary key type: DataType[%d]", dataType)
+	case
+		schema.Bit,       // Fails: operator does not exist: bit >= boolean (SQLSTATE 42883)
+		schema.Time,      // Fails: invalid input syntax for type time: "45296000" (SQLSTATE 22007)
+		schema.Interval,  // Fails: operator does not exist: interval >= bigint (SQLSTATE 42883)
+		schema.Array,     // Fails: This doesn't work: need to serialize to Postgres array format "{1,2,3}"
+		schema.HStore,    // Fails: operator does not exist: hstore >= unknown (SQLSTATE 42883)
+		schema.Point,     // Can't be used as a primary key
+		schema.Geometry,  // Fails: parse error - invalid geometry (SQLSTATE XX000)
+		schema.Geography: // Fails: parse error - invalid geometry (SQLSTATE XX000)
+		return false, fmt.Errorf("unsupported primary key type: DataType(%d)", dataType)
 	case schema.Float,
 		schema.Int16,
 		schema.Int32,
 		schema.Int64,
-		schema.Bit,
 		schema.Boolean:
 		return false, nil
 	case schema.VariableNumeric,
@@ -99,19 +105,14 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 		schema.Numeric,
 		schema.Inet,
 		schema.Text,
-		schema.HStore,
 		schema.UUID,
 		schema.UserDefinedText,
 		schema.JSON,
 		schema.Timestamp,
-		schema.Time,
-		schema.Date,
-		schema.Point,
-		schema.Geometry,
-		schema.Geography:
+		schema.Date:
 		return true, nil
 	default:
-		return false, fmt.Errorf("unsupported data type: DataType[%d]", dataType)
+		return false, fmt.Errorf("unsupported data type: DataType(%d)", dataType)
 	}
 }
 

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -167,7 +167,7 @@ func convertToStringForQuery(value any, dataType schema.DataType) (string, error
 			slog.Any("dataType", dataType),
 		)
 	}
-	// fallback to legacy behavior
+	// legacy behavior
 	shouldQuote, err := shouldQuoteValue(dataType)
 	if err != nil {
 		return "", err

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -116,6 +116,7 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	}
 }
 
+// convertToStringForQuery returns a string value suitable for use directly in a query.
 func convertToStringForQuery(value any, dataType schema.DataType) (string, error) {
 	// TODO: Change logs to actual errors then remove legacy behavior
 	switch castValue := value.(type) {

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -17,18 +17,16 @@ func TestShouldQuoteValue(t *testing.T) {
 		expected    bool
 		expectedErr string
 	}{
-		{"Invalid", schema.InvalidDataType, false, "invalid data type"},
-		{"Unsupported", 100, false, "unsupported data type: DataType[100]"},
 		{"VariableNumeric", schema.VariableNumeric, true, ""},
 		{"Money", schema.Money, true, ""},
 		{"Numeric", schema.Numeric, true, ""},
-		{"Bit", schema.Bit, false, ""},
+		{"Bit", schema.Bit, false, "unsupported primary key type: DataType"},
 		{"Boolean", schema.Boolean, false, ""},
 		{"Inet", schema.Inet, true, ""},
 		{"Text", schema.Text, true, ""},
-		{"Interval", schema.Interval, false, "unsupported primary key type: DataType[8]"},
-		{"Array", schema.Array, false, "unsupported primary key type: DataType[9]"},
-		{"HStore", schema.HStore, true, ""},
+		{"Interval", schema.Interval, false, "unsupported primary key type: DataType"},
+		{"Array", schema.Array, false, "unsupported primary key type: DataType"},
+		{"HStore", schema.HStore, true, "unsupported primary key type: DataType"},
 		{"Float", schema.Float, false, ""},
 		{"Int16", schema.Int16, false, ""},
 		{"Int32", schema.Int32, false, ""},
@@ -37,21 +35,21 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"UserDefinedText", schema.UserDefinedText, true, ""},
 		{"JSON", schema.JSON, true, ""},
 		{"Timestamp", schema.Timestamp, true, ""},
-		{"Time", schema.Time, true, ""},
+		{"Time", schema.Time, true, "unsupported primary key type: DataType"},
 		{"Date", schema.Date, true, ""},
 		// PostGIS
-		{"Point", schema.Point, true, ""},
-		{"Geometry", schema.Geometry, true, ""},
-		{"Geography", schema.Geography, true, ""},
+		{"Point", schema.Point, true, "unsupported primary key type: DataType"},
+		{"Geometry", schema.Geometry, true, "unsupported primary key type: DataType"},
+		{"Geography", schema.Geography, true, "unsupported primary key type: DataType"},
 	}
 
-	for _, testCase := range testCases {
-		actual, err := shouldQuoteValue(testCase.dataType)
-		if testCase.expectedErr == "" {
-			assert.NoError(t, err)
-			assert.Equal(t, testCase.expected, actual, testCase.name)
+	for _, tc := range testCases {
+		actual, err := shouldQuoteValue(tc.dataType)
+		if tc.expectedErr == "" {
+			assert.NoError(t, err, tc.name)
+			assert.Equal(t, tc.expected, actual, tc.name)
 		} else {
-			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
+			assert.ErrorContains(t, err, tc.expectedErr, tc.name)
 		}
 	}
 

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -90,19 +90,31 @@ func TestConvertToStringForQuery(t *testing.T) {
 			expected: "1234.1234",
 		},
 		{
+			name:     "boolean - true",
+			value:    true,
+			dataType: schema.Boolean,
+			expected: "true",
+		},
+		{
+			name:     "boolean - false",
+			value:    false,
+			dataType: schema.Boolean,
+			expected: "false",
+		},
+		{
 			name:     "text",
 			value:    "foo",
 			dataType: schema.Text,
 			expected: "'foo'",
 		},
 		{
-			name:        "text",
+			name:        "text - invalid data type",
 			value:       "foo",
 			dataType:    schema.InvalidDataType,
 			expectedErr: "invalid data type",
 		},
 		{
-			name:        "text",
+			name:        "text - unsupported data type",
 			value:       "foo",
 			dataType:    -1,
 			expectedErr: "unsupported data type",

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -93,7 +93,19 @@ func TestConvertToStringForQuery(t *testing.T) {
 			name:     "text",
 			value:    "foo",
 			dataType: schema.Text,
-			expected: `'foo'`,
+			expected: "'foo'",
+		},
+		{
+			name:        "text",
+			value:       "foo",
+			dataType:    schema.InvalidDataType,
+			expectedErr: "invalid data type",
+		},
+		{
+			name:        "text",
+			value:       "foo",
+			dataType:    -1,
+			expectedErr: "unsupported data type",
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
We should be able to depend on the Go type of `value` when we encode it for use in a query. In order to safely move towards that behavior we'll first log when we encounter a value that has a different type than the type we expect for a column and in those cases fall back to the legacy behavior. Once we've run this code for a while without error logs we'll switch to returning an error instead.

Note that `convertToStringForQuery` is only used to encode primary key values for use in the scanner query.

The longterm goal is to switch to doing a parameterized query and letting the driver take care of this string conversion.