### PR TITLE
Update Logging handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
+
+	"github.com/artie-labs/transfer/lib/telemetry/metrics"
+
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib/kafkalib"
 	"github.com/artie-labs/reader/lib/logger"
@@ -13,8 +17,6 @@ import (
 	"github.com/artie-labs/reader/sources/mongo"
 	"github.com/artie-labs/reader/sources/mysql"
 	"github.com/artie-labs/reader/sources/postgres"
-	"github.com/artie-labs/transfer/lib/telemetry/metrics"
-	"log/slog"
 )
 
 func setUpMetrics(cfg *config.Metrics) (mtr.Client, error) {


### PR DESCRIPTION
Right now, when we call `logger.Fatal(...)`, it just exits the program. However, the error doesn't actually make it to Sentry since the program has been exited.

This PR refactors the logger such that it will call a list of clean up functions like `sentry.Flush(...)`, this is following the same pattern as Logrus