### PR TITLE
[postgres] Stricter column type handling

### DIFF
--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -11,8 +11,6 @@ import (
 func castColumn(col schema.Column) (string, error) {
 	colName := pgx.Identifier{col.Name}.Sanitize()
 	switch col.Type {
-	case schema.InvalidDataType:
-		return colName, nil
 	case schema.Inet:
 		return fmt.Sprintf("%s::text", colName), nil
 	case schema.Time, schema.Interval:

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -36,6 +36,6 @@ func castColumn(col schema.Column) (string, error) {
 		// These are all the columns that do not need to be escaped.
 		return colName, nil
 	default:
-		return "", fmt.Errorf("unsupported column type DataType(%d)", col.Type)
+		return "", fmt.Errorf("unsupported column type: DataType(%d)", col.Type)
 	}
 }

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -13,7 +13,8 @@ func TestCastColumn(t *testing.T) {
 		name     string
 		dataType schema.DataType
 
-		expected string
+		expected    string
+		expectedErr string
 	}
 
 	var testCases = []_testCase{
@@ -67,11 +68,20 @@ func TestCastColumn(t *testing.T) {
 			dataType: schema.VariableNumeric,
 			expected: `"foo"`,
 		},
+		{
+			name:        "unsupported",
+			dataType:    -1,
+			expectedErr: "unsupported column type: DataType(-1)",
+		},
 	}
 
 	for _, testCase := range testCases {
 		actualEscCol, err := castColumn(schema.Column{Name: "foo", Type: testCase.dataType})
-		assert.NoError(t, err)
-		assert.Equal(t, testCase.expected, actualEscCol, testCase.name)
+		if testCase.expectedErr == "" {
+			assert.NoError(t, err, testCase.name)
+			assert.Equal(t, testCase.expected, actualEscCol, testCase.name)
+		} else {
+			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
+		}
 	}
 }

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -81,8 +81,6 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 
 func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	switch dataType {
-	case schema.InvalidDataType:
-		return false, fmt.Errorf("invalid data type")
 	case
 		schema.Bit,       // Fails: operator does not exist: bit >= boolean (SQLSTATE 42883)
 		schema.Time,      // Fails: invalid input syntax for type time: "45296000" (SQLSTATE 22007)
@@ -147,7 +145,7 @@ func convertToStringForQuery(value any, dataType schema.DataType) (string, error
 			return fmt.Sprint(value), nil
 		default:
 			slog.Error("bool value with non-bool column type",
-				slog.Any("value", value),
+				slog.Bool("value", castValue),
 				slog.Any("dataType", dataType),
 			)
 		}
@@ -155,10 +153,10 @@ func convertToStringForQuery(value any, dataType schema.DataType) (string, error
 		switch dataType {
 		case schema.Text, schema.UserDefinedText, schema.Inet, schema.UUID, schema.JSON, schema.VariableNumeric,
 			schema.Numeric, schema.Money:
-			return QuoteLiteral(fmt.Sprint(value)), nil
+			return QuoteLiteral(castValue), nil
 		default:
 			slog.Error("string value with non-string column type",
-				slog.Any("value", value),
+				slog.String("value", castValue),
 				slog.Any("dataType", dataType),
 			)
 		}

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -53,8 +53,8 @@ func TestShouldQuoteValue(t *testing.T) {
 		}
 	}
 
-	_, err := shouldQuoteValue(schema.InvalidDataType)
-	assert.ErrorContains(t, err, "invalid data type")
+	_, err := shouldQuoteValue(-1)
+	assert.ErrorContains(t, err, "unsupported data type: DataType(-1)")
 }
 
 func TestConvertToStringForQuery(t *testing.T) {
@@ -106,12 +106,6 @@ func TestConvertToStringForQuery(t *testing.T) {
 			value:    "foo",
 			dataType: schema.Text,
 			expected: "'foo'",
-		},
-		{
-			name:        "text - invalid data type",
-			value:       "foo",
-			dataType:    schema.InvalidDataType,
-			expectedErr: "invalid data type",
 		},
 		{
 			name:        "text - unsupported data type",

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -15,8 +15,7 @@ import (
 type DataType int
 
 const (
-	InvalidDataType DataType = iota
-	VariableNumeric
+	VariableNumeric DataType = iota
 	Money
 	Numeric
 	Bit
@@ -78,9 +77,9 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 			return nil, err
 		}
 
-		dataType, opts := ParseColumnDataType(colType, numericPrecision, numericScale, udtName)
-		if dataType == InvalidDataType {
-			return nil, fmt.Errorf("unable to identify type for column %s: %s", colName, colType)
+		dataType, opts, err := ParseColumnDataType(colType, numericPrecision, numericScale, udtName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse data type for %s: %w", colName, err)
 		}
 
 		cols = append(cols, Column{
@@ -92,70 +91,70 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 	return cols, nil
 }
 
-func ParseColumnDataType(colKind string, precision, scale, udtName *string) (DataType, *Opts) {
+func ParseColumnDataType(colKind string, precision, scale, udtName *string) (DataType, *Opts, error) {
 	colKind = strings.ToLower(colKind)
 	switch colKind {
 	case "point":
-		return Point, nil
+		return Point, nil, nil
 	case "real", "double precision":
-		return Float, nil
+		return Float, nil, nil
 	case "smallint":
-		return Int16, nil
+		return Int16, nil, nil
 	case "integer":
-		return Int32, nil
+		return Int32, nil, nil
 	case "bigint", "oid":
-		return Int64, nil
+		return Int64, nil, nil
 	case "array":
-		return Array, nil
+		return Array, nil, nil
 	case "bit":
-		return Bit, nil
+		return Bit, nil, nil
 	case "boolean":
-		return Boolean, nil
+		return Boolean, nil, nil
 	case "date":
-		return Date, nil
+		return Date, nil, nil
 	case "uuid":
-		return UUID, nil
+		return UUID, nil, nil
 	case "user-defined":
 		if udtName != nil && *udtName == "hstore" {
-			return HStore, nil
+			return HStore, nil, nil
 		} else if udtName != nil && *udtName == "geometry" {
-			return Geometry, nil
+			return Geometry, nil, nil
 		} else if udtName != nil && *udtName == "geography" {
-			return Geography, nil
+			return Geography, nil, nil
 		} else {
-			return UserDefinedText, nil
+			return UserDefinedText, nil, nil
 		}
 	case "interval":
-		return Interval, nil
+		return Interval, nil, nil
 	case "time with time zone", "time without time zone":
-		return Time, nil
+		return Time, nil, nil
 	case "money":
 		return Money, &Opts{
 			Scale: ptr.ToString("2"),
-		}
+		}, nil
 	case "character varying", "text", "character", "xml", "cidr", "macaddr", "macaddr8",
 		"int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
-		return Text, nil
+		return Text, nil, nil
 	case "inet":
-		return Inet, nil
+		return Inet, nil, nil
 	case "json", "jsonb":
-		return JSON, nil
+		return JSON, nil, nil
 	case "timestamp without time zone", "timestamp with time zone":
-		return Timestamp, nil
+		return Timestamp, nil, nil
 	default:
 		if strings.Contains(colKind, "numeric") {
 			if precision == nil && scale == nil {
-				return VariableNumeric, nil
+				return VariableNumeric, nil, nil
 			} else {
 				return Numeric, &Opts{
 					Scale:     scale,
 					Precision: precision,
-				}
+				}, nil
 			}
 		}
 	}
 
-	return InvalidDataType, nil
+	return -1, nil, fmt.Errorf("unknown data type: %s", colKind)
 }
 
 // This is a fork of: https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -79,7 +79,7 @@ func DescribeTable(db *sql.DB, _schema, table string) ([]Column, error) {
 
 		dataType, opts, err := ParseColumnDataType(colType, numericPrecision, numericScale, udtName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse data type for %s: %w", colName, err)
+			return nil, fmt.Errorf("unable to identify type for column %s: %s", colName, colType)
 		}
 
 		cols = append(cols, Column{

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -18,6 +18,7 @@ func TestParseColumnDataType(t *testing.T) {
 
 		expectedDataType DataType
 		expectedOpts     *Opts
+		expectedErr      string
 	}
 
 	var testCases = []_testCase{
@@ -124,12 +125,22 @@ func TestParseColumnDataType(t *testing.T) {
 			udtName:          ptr.ToString("foo"),
 			expectedDataType: UserDefinedText,
 		},
+		{
+			name:        "unsupported",
+			colKind:     "foo",
+			expectedErr: "unknown data type: foo",
+		},
 	}
 
 	for _, testCase := range testCases {
-		dataType, opts := ParseColumnDataType(testCase.colKind, testCase.precision, testCase.scale, testCase.udtName)
-		assert.Equal(t, testCase.expectedDataType, dataType, testCase.name)
-		assert.Equal(t, testCase.expectedOpts, opts, testCase.name)
+		dataType, opts, err := ParseColumnDataType(testCase.colKind, testCase.precision, testCase.scale, testCase.udtName)
+		if testCase.expectedErr == "" {
+			assert.NoError(t, err, testCase.name)
+			assert.Equal(t, testCase.expectedDataType, dataType, testCase.name)
+			assert.Equal(t, testCase.expectedOpts, opts, testCase.name)
+		} else {
+			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
+		}
 	}
 }
 

--- a/sources/mysql/adapter/adapter.go
+++ b/sources/mysql/adapter/adapter.go
@@ -43,7 +43,7 @@ func newMySQLAdapter(db *sql.DB, table mysql.Table, scannerCfg scan.ScannerConfi
 	for i, col := range table.Columns {
 		converter, err := valueConverterForType(col.Type, col.Opts)
 		if err != nil {
-			return mysqlAdapter{}, err
+			return mysqlAdapter{}, fmt.Errorf("failed to build field for column %s: %w", col.Name, err)
 		}
 		fields[i] = converter.ToField(col.Name)
 		valueConverters[col.Name] = converter

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -34,7 +34,7 @@ func NewPostgresAdapter(db *sql.DB, tableCfg config.PostgreSQLTable) (postgresAd
 	for i, col := range table.Columns {
 		fields[i], err = ColumnToField(col)
 		if err != nil {
-			return postgresAdapter{}, err
+			return postgresAdapter{}, fmt.Errorf("failed to build field for column %s: %w", col.Name, err)
 		}
 	}
 

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -3,11 +3,9 @@ package adapter
 import (
 	"testing"
 
-	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/artie-labs/reader/lib/postgres"
-	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
 func TestPostgresAdapter_TableName(t *testing.T) {
@@ -45,26 +43,6 @@ func TestPostgresAdapter_TopicSuffix(t *testing.T) {
 		adapter := postgresAdapter{table: tc.table}
 		assert.Equal(t, tc.expectedTopicName, adapter.TopicSuffix())
 	}
-}
-
-func TestPostgresAdapter_Fields(t *testing.T) {
-	table := postgres.Table{
-		Name:   "table1",
-		Schema: "schema1",
-		Columns: []schema.Column{
-			{Name: "col1", Type: schema.Text},
-			{Name: "col2", Type: schema.Boolean},
-			{Name: "col3", Type: schema.Array},
-		},
-	}
-	adapter := postgresAdapter{table: table}
-
-	expected := []debezium.Field{
-		{Type: "string", FieldName: "col1"},
-		{Type: "boolean", FieldName: "col2"},
-		{Type: "array", FieldName: "col3"},
-	}
-	assert.Equal(t, expected, adapter.Fields())
 }
 
 func TestPostgresAdapter_PartitionKey(t *testing.T) {

--- a/sources/postgres/adapter/fields.go
+++ b/sources/postgres/adapter/fields.go
@@ -105,7 +105,7 @@ func toDebeziumType(d schema.DataType) (Result, error) {
 		}, nil
 	}
 
-	return Result{}, fmt.Errorf("unsupported data type DataType(%d)", d)
+	return Result{}, fmt.Errorf("unsupported data type: DataType(%d)", d)
 }
 
 func ColumnToField(col schema.Column) (debezium.Field, error) {

--- a/sources/postgres/adapter/fields.go
+++ b/sources/postgres/adapter/fields.go
@@ -1,6 +1,8 @@
 package adapter
 
 import (
+	"fmt"
+
 	"github.com/artie-labs/transfer/lib/debezium"
 
 	"github.com/artie-labs/reader/lib/postgres/schema"
@@ -11,103 +13,106 @@ type Result struct {
 	Type         string
 }
 
-func toDebeziumType(d schema.DataType) Result {
+func toDebeziumType(d schema.DataType) (Result, error) {
 	switch d {
 	case schema.Geography:
 		return Result{
 			DebeziumType: string(debezium.GeographyType),
 			Type:         "struct",
-		}
+		}, nil
 	case schema.Geometry:
 		return Result{
 			DebeziumType: string(debezium.GeometryType),
 			Type:         "struct",
-		}
+		}, nil
 	case schema.Point:
 		return Result{
 			DebeziumType: string(debezium.GeometryPointType),
 			Type:         "struct",
-		}
+		}, nil
 	case schema.VariableNumeric:
 		return Result{
 			DebeziumType: string(debezium.KafkaVariableNumericType),
 			Type:         "struct",
-		}
+		}, nil
 	case schema.Money, schema.Numeric:
 		return Result{
 			DebeziumType: string(debezium.KafkaDecimalType),
-		}
+		}, nil
 	case schema.Boolean, schema.Bit:
 		return Result{
 			Type: "boolean",
-		}
+		}, nil
 	case schema.Text, schema.UserDefinedText, schema.Inet:
 		return Result{
 			Type: "string",
-		}
+		}, nil
 	case schema.Interval:
 		return Result{
 			DebeziumType: "io.debezium.time.MicroDuration",
 			Type:         "int64",
-		}
+		}, nil
 	case schema.Array:
 		return Result{
 			Type: "array",
-		}
+		}, nil
 	case schema.Float:
 		return Result{
 			Type: "float",
-		}
+		}, nil
 	case schema.Int16:
 		return Result{
 			Type: "int16",
-		}
+		}, nil
 	case schema.Int32:
 		return Result{
 			Type: "int32",
-		}
+		}, nil
 	case schema.Int64:
 		return Result{
 			Type: "int64",
-		}
+		}, nil
 	case schema.UUID:
 		return Result{
 			DebeziumType: "io.debezium.data.Uuid",
 			Type:         "string",
-		}
+		}, nil
 	case schema.JSON:
 		return Result{
 			DebeziumType: "io.debezium.data.Json",
 			Type:         "string",
-		}
+		}, nil
 	case schema.Time:
 		return Result{
 			DebeziumType: string(debezium.Time),
 			Type:         "int32",
-		}
+		}, nil
 	case schema.Date:
 		return Result{
 			DebeziumType: string(debezium.Date),
 			Type:         "int32",
-		}
+		}, nil
 	case schema.HStore:
 		return Result{
 			DebeziumType: "",
 			Type:         "map",
-		}
+		}, nil
 	case schema.Timestamp:
 		return Result{
 			DebeziumType: string(debezium.Timestamp),
 			// NOTE: We are returning string here because we want the right layout to be used by our Typing library
 			Type: "string",
-		}
+		}, nil
 	}
 
-	return Result{}
+	return Result{}, fmt.Errorf("unsupported data type DataType(%d)", d)
 }
 
-func ColumnToField(col schema.Column) debezium.Field {
-	res := toDebeziumType(col.Type)
+func ColumnToField(col schema.Column) (debezium.Field, error) {
+	res, err := toDebeziumType(col.Type)
+	if err != nil {
+		return debezium.Field{}, err
+	}
 	field := debezium.Field{
 		FieldName:    col.Name,
 		Type:         res.Type,
@@ -125,5 +130,5 @@ func ColumnToField(col schema.Column) debezium.Field {
 			field.Parameters[debezium.KafkaDecimalPrecisionKey] = *col.Opts.Precision
 		}
 	}
-	return field
+	return field, nil
 }

--- a/sources/postgres/adapter/fields_test.go
+++ b/sources/postgres/adapter/fields_test.go
@@ -17,7 +17,8 @@ func TestColumnToField(t *testing.T) {
 		dataType schema.DataType
 		opts     *schema.Opts
 
-		expected debezium.Field
+		expected    debezium.Field
+		expectedErr string
 	}
 
 	testCases := []_testCase{
@@ -121,12 +122,22 @@ func TestColumnToField(t *testing.T) {
 				FieldName: "inet_col",
 			},
 		},
+		{
+			name:        "unsupported data type",
+			colName:     "inet_col",
+			dataType:    -1,
+			expectedErr: "unsupported data type: DataType(-1)",
+		},
 	}
 
 	for _, testCase := range testCases {
 		col := schema.Column{Name: testCase.colName, Type: testCase.dataType, Opts: testCase.opts}
 		field, err := ColumnToField(col)
-		assert.NoError(t, err, testCase.name)
-		assert.Equal(t, testCase.expected, field, testCase.name)
+		if testCase.expectedErr == "" {
+			assert.NoError(t, err, testCase.name)
+			assert.Equal(t, testCase.expected, field, testCase.name)
+		} else {
+			assert.ErrorContains(t, err, testCase.expectedErr)
+		}
 	}
 }

--- a/sources/postgres/adapter/fields_test.go
+++ b/sources/postgres/adapter/fields_test.go
@@ -125,7 +125,8 @@ func TestColumnToField(t *testing.T) {
 
 	for _, testCase := range testCases {
 		col := schema.Column{Name: testCase.colName, Type: testCase.dataType, Opts: testCase.opts}
-		field := ColumnToField(col)
+		field, err := ColumnToField(col)
+		assert.NoError(t, err, testCase.name)
 		assert.Equal(t, testCase.expected, field, testCase.name)
 	}
 }

--- a/sources/postgres/adapter/fields_test.go
+++ b/sources/postgres/adapter/fields_test.go
@@ -137,7 +137,7 @@ func TestColumnToField(t *testing.T) {
 			assert.NoError(t, err, testCase.name)
 			assert.Equal(t, testCase.expected, field, testCase.name)
 		} else {
-			assert.ErrorContains(t, err, testCase.expectedErr)
+			assert.ErrorContains(t, err, testCase.expectedErr, testCase.name)
 		}
 	}
 }

--- a/sources/postgres/adapter/values_test.go
+++ b/sources/postgres/adapter/values_test.go
@@ -76,7 +76,9 @@ func TestConvertValueToDebezium(t *testing.T) {
 		} else {
 			assert.NoError(t, actualErr, tc.name)
 			if tc.numericValue {
-				val, err := ColumnToField(tc.col).DecodeDecimal(fmt.Sprint(actualValue))
+				field, err := ColumnToField(tc.col)
+				assert.NoError(t, err, tc.name)
+				val, err := field.DecodeDecimal(fmt.Sprint(actualValue))
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedValue, val.String(), tc.name)
 			} else {


### PR DESCRIPTION
Kill `InvalidDataType` and instead throw an error in `DescribeTable` if we encounter a column type we don't support.