### PR TITLE
[gha] Use prebuilt binary for `staticcheck`

### DIFF
--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -2,24 +2,20 @@ name: Go tests
 run-name: Running tests
 on: [push]
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: [ '1.22' ]
-    name: Go ${{ matrix.go }}
+  test:
+    runs-on: ubuntu-latest    
     steps:
       - uses: actions/checkout@v4 # Checks out the code
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: 1.22
       - name: Run staticcheck
-        run: |
-          SC_VERSION="2023.1.7"
+        env:
+          SC_VERSION: 2023.1.7
+        run: |          
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"
           wget -q ${SC_URL} -O - | tar -xzf - --strip-components 1 -C /usr/local/bin staticcheck/staticcheck
-
           make static
       - name: Run test
         run: make test

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -19,5 +19,5 @@ jobs:
           make static
       - name: Run test
         run: make test
-      - name: Run race test
+      - name: Run race condition check
         run: make race

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest    
     steps:
-      - uses: actions/checkout@v4 # Checks out the code
+      - uses: actions/checkout@v4
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -19,5 +19,5 @@ jobs:
           make static
       - name: Run test
         run: make test
-      - name: Run test-race
+      - name: Run race test
         run: make race

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -16,7 +16,10 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Run staticcheck
         run: |
-          go install honnef.co/go/tools/cmd/staticcheck@latest
+          SC_VERSION="2023.1.7"
+          SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"
+          wget -q ${SC_URL} -O - | tar -xzf - --strip-components 1 -C /usr/local/bin staticcheck/staticcheck
+
           make static
       - name: Run test
         run: make test

--- a/goreleaser.dockerfile
+++ b/goreleaser.dockerfile
@@ -1,2 +1,2 @@
-FROM --platform=linux/amd64 alpine:3.16
+FROM --platform=linux/amd64 alpine:3.19
 COPY reader /reader


### PR DESCRIPTION
Also bump `alpine` to `3.19`.