### PR TITLE
[postgres] Test variable numeric data type

### DIFF
--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -98,6 +98,7 @@ CREATE TABLE %s (
 	c_macaddr8 macaddr8,
 	c_money money,
 	c_numeric numeric(7, 2),
+	c_numeric_variable numeric,
 	-- c_path path,
 	-- c_pg_lsn pg_lsn,
 	-- c_pg_snapshot pg_snapshot,
@@ -182,6 +183,8 @@ INSERT INTO %s VALUES (
 		'52093.89',
 	-- c_numeric
 		'987.654',
+	-- c_numeric_variable,
+		'10987.65401',
 	-- c_path
 		-- Not supported
 	-- c_pg_lsn
@@ -417,6 +420,14 @@ const expectedPayloadTemplate = `{
 						"type": "struct",
 						"optional": false,
 						"default": null,
+						"field": "c_numeric_variable",
+						"name": "io.debezium.data.VariableScaleDecimal",
+						"parameters": null
+					},
+					{
+						"type": "struct",
+						"optional": false,
+						"default": null,
 						"field": "c_point",
 						"name": "io.debezium.data.geometry.Point",
 						"parameters": null
@@ -631,6 +642,10 @@ const expectedPayloadTemplate = `{
 			"c_macaddr8": "12:34:56:78:90:ab:cd:ef",
 			"c_money": "T30t",
 			"c_numeric": "AYHN",
+			"c_numeric_variable": {
+				"scale": "5",
+				"value": "QX3UWQ=="
+			},
 			"c_numrange": "[11.1,22.2)",
 			"c_point": {
 				"x": 12.34,


### PR DESCRIPTION
We have special logic for Postgres numeric columns that have variable precision, so adding it explicitly to the integration test. This help avoid bugs in https://github.com/artie-labs/reader/pull/246 