### PR TITLE
[postgres] Add `PgTimestampConverter`

### DIFF
--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -104,6 +104,8 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) converte
 		return converters.BytesPassthrough{}
 	case schema.Date:
 		return converters.DateConverter{}
+	case schema.Timestamp:
+		return PgTimestampConverter{}
 	case schema.JSON:
 		return converters.JSONConverter{}
 	default:

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -35,7 +35,7 @@ func (MoneyConverter) Convert(value any) (any, error) {
 	return stringValue, nil
 }
 
-// TODO: Replace this with `converters.TimestampConverter` once we've run it for awhile and not seen error logs
+// TODO: Replace this with `converters.TimestampConverter` once we've run it for a while and not seen error logs
 type PgTimestampConverter struct{}
 
 func (PgTimestampConverter) ToField(name string) transferDbz.Field {

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -56,8 +56,9 @@ func (PgTimestampConverter) Convert(value any) (any, error) {
 			slog.Info("Skipping timestamp because year is greater than 9999 or less than 0", slog.Any("value", value))
 			return nil, nil
 		}
+	} else {
+		slog.Error("Emitting a value for a timestamp column that is not a time.Time", slog.Any("value", value), slog.String("type", fmt.Sprintf("%T", value)))
 	}
 
-	slog.Error("Emitting a value for a timestamp column that is not a time.Time", slog.Any("value", value), slog.String("type", fmt.Sprintf("%T", value)))
 	return value, nil
 }

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -35,7 +35,7 @@ func (MoneyConverter) Convert(value any) (any, error) {
 	return stringValue, nil
 }
 
-// TODO: Replace this with converters.TimestampConverter once we've run it for awhile and not seen error logs
+// TODO: Replace this with `converters.TimestampConverter` once we've run it for awhile and not seen error logs
 type PgTimestampConverter struct{}
 
 func (PgTimestampConverter) ToField(name string) transferDbz.Field {

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -2,6 +2,8 @@ package adapter
 
 import (
 	"fmt"
+	"log/slog"
+	"time"
 
 	transferDbz "github.com/artie-labs/transfer/lib/debezium"
 
@@ -31,4 +33,31 @@ func (MoneyConverter) Convert(value any) (any, error) {
 		return nil, fmt.Errorf("failed to encode decimal to b64: %w", err)
 	}
 	return stringValue, nil
+}
+
+// TODO: Replace this with converters.TimestampConverter once we've run it for awhile and not seen error logs
+type PgTimestampConverter struct{}
+
+func (PgTimestampConverter) ToField(name string) transferDbz.Field {
+	return transferDbz.Field{
+		FieldName:    name,
+		DebeziumType: string(transferDbz.Timestamp),
+		// NOTE: We are returning string here because we want the right layout to be used by our Typing library
+		Type: "string",
+	}
+}
+
+func (PgTimestampConverter) Convert(value any) (any, error) {
+	valTime, isOk := value.(time.Time)
+	if isOk {
+		if valTime.Year() > 9999 || valTime.Year() < 0 {
+			// Avoid copying this column over because it'll cause a JSON Marshal error:
+			// Time.MarshalJSON: year outside of range [0,9999]
+			slog.Info("Skipping timestamp because year is greater than 9999 or less than 0", slog.Any("value", value))
+			return nil, nil
+		}
+	}
+
+	slog.Error("Emitting a value for a timestamp column that is not a time.Time", slog.Any("value", value), slog.String("type", fmt.Sprintf("%T", value)))
+	return value, nil
 }

--- a/sources/postgres/adapter/fields.go
+++ b/sources/postgres/adapter/fields.go
@@ -82,12 +82,6 @@ func toDebeziumType(d schema.DataType) (Result, error) {
 			DebeziumType: "",
 			Type:         "map",
 		}, nil
-	case schema.Timestamp:
-		return Result{
-			DebeziumType: string(debezium.Timestamp),
-			// NOTE: We are returning string here because we want the right layout to be used by our Typing library
-			Type: "string",
-		}, nil
 	}
 
 	return Result{}, fmt.Errorf("unsupported data type: DataType(%d)", d)

--- a/sources/postgres/adapter/values.go
+++ b/sources/postgres/adapter/values.go
@@ -1,9 +1,6 @@
 package adapter
 
 import (
-	"log/slog"
-	"time"
-
 	"github.com/artie-labs/reader/lib/postgres/schema"
 )
 
@@ -14,19 +11,6 @@ func ConvertValueToDebezium(col schema.Column, value any) (any, error) {
 
 	if converter := valueConverterForType(col.Type, col.Opts); converter != nil {
 		return converter.Convert(value)
-	}
-
-	switch col.Type {
-	case schema.Timestamp:
-		valTime, isOk := value.(time.Time)
-		if isOk {
-			if valTime.Year() > 9999 || valTime.Year() < 0 {
-				// Avoid copying this column over because it'll cause a JSON Marshal error:
-				// Time.MarshalJSON: year outside of range [0,9999]
-				slog.Info("Skipping timestamp because year is greater than 9999 or less than 0", slog.String("key", col.Name), slog.Any("value", value))
-				return nil, nil
-			}
-		}
 	}
 
 	return value, nil


### PR DESCRIPTION
The `converters.TimestampConverter` returns an error if the value is not a `time.Time`, so adding a new converter just for postgres that preserves the existing functionality that logs if the value is not `time.Time` with the goal of eventually switching to `converters.TimestampConverter`.