### PR TITLE
Skip MySQL Zero Dates

### DIFF
--- a/lib/mysql/schema/convert.go
+++ b/lib/mysql/schema/convert.go
@@ -71,6 +71,13 @@ func ConvertValue(value any, colType DataType) (any, error) {
 		if !ok {
 			return nil, fmt.Errorf("expected []byte got %T for value: %v", value, value)
 		}
+
+		// TODO: We should check for zero datetime, timestamp, etc.
+		// MySQL returns 0000-00-00 for zero dates
+		if string(bytesValue) == "0000-00-00" {
+			return nil, nil
+		}
+
 		timeValue, err := time.Parse(time.DateOnly, string(bytesValue))
 		if err != nil {
 			return nil, err
@@ -123,7 +130,7 @@ func ConvertValues(values []any, cols []Column) ([]any, error) {
 		col := cols[idx]
 		convertedVal, err := ConvertValue(value, col.Type)
 		if err != nil {
-			return nil, fmt.Errorf("faild to convert value for column %s: %w", col.Name, err)
+			return nil, fmt.Errorf("failed to convert value for column %s: %w", col.Name, err)
 		}
 		result[idx] = convertedVal
 	}

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -166,6 +166,12 @@ func TestConvertValue(t *testing.T) {
 			expected: time.Date(2021, 1, 2, 0, 0, 0, 0, time.UTC),
 		},
 		{
+			name:     "date",
+			dataType: Date,
+			value:    []byte("0000-00-00"),
+			expected: nil,
+		},
+		{
 			name:     "datetime",
 			dataType: DateTime,
 			value:    []byte("2021-01-02 03:04:05"),

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -265,7 +265,7 @@ func TestConvertValues(t *testing.T) {
 	{
 		// Malformed data
 		_, err := ConvertValues([]any{"bad", "bad", "bad"}, columns)
-		assert.ErrorContains(t, err, "faild to convert value for column a: expected int64 got string for value: bad")
+		assert.ErrorContains(t, err, "failed to convert value for column a: expected int64 got string for value: bad")
 	}
 	{
 		// Happy path - nils


### PR DESCRIPTION
We were previously failing on this, however this is valid in MySQL.

> The "0000-00-00" date is often used in MySQL databases as a placeholder for an unknown or default date. However, this value is not considered a valid date in many contexts, including some programming languages or database drivers that might be used to interact with MySQL.

