### PR TITLE
[debezium] Fix `DateConverter` for dates > 290 years from 1970

### DIFF
--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -64,8 +64,7 @@ func (DateConverter) Convert(value any) (any, error) {
 		return nil, fmt.Errorf("expected string/time.Time got %T with value: %v", value, value)
 	}
 
-	unix := time.UnixMilli(0).In(time.UTC) // 1970-01-01
-	return int32(timeValue.Sub(unix).Hours() / 24), nil
+	return int32(timeValue.Unix() / (60 * 60 * 24)), nil
 }
 
 type TimestampConverter struct{}

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -66,16 +66,58 @@ func TestDateConverter_Convert(t *testing.T) {
 		assert.Equal(t, int32(19480), value)
 	}
 	{
-		// time.Time
+		// time.Time - Unix epoch
+		days, err := converter.Convert(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(0), days)
+	}
+	{
+		// time.Time - Unix epoch + 1 day
+		days, err := converter.Convert(time.Date(1970, 1, 2, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1), days)
+	}
+	{
+		// time.Time - Unix epoch + 1 year
 		value, err := converter.Convert(time.Date(1971, 1, 1, 0, 0, 0, 0, time.UTC))
 		assert.NoError(t, err)
 		assert.Equal(t, int32(365), value)
 	}
 	{
-		// time.Time
+		// time.Time - 2003
 		days, err := converter.Convert(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC))
 		assert.NoError(t, err)
 		assert.Equal(t, int32(19480), days)
+	}
+	{
+		// time.Time - 1969
+		days, err := converter.Convert(time.Date(1969, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(-365), days)
+	}
+	{
+		// time.Time - Year 9999
+		days, err := converter.Convert(time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(2_932_532), days)
+	}
+	{
+		// time.Time - Year 10_000
+		days, err := converter.Convert(time.Date(10_000, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(2_932_897), days)
+	}
+	{
+		// time.Time - Year 0
+		days, err := converter.Convert(time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(-719_528), days)
+	}
+	{
+		// time.Time - Year -1
+		days, err := converter.Convert(time.Date(-1, 1, 1, 0, 0, 0, 0, time.UTC))
+		assert.NoError(t, err)
+		assert.Equal(t, int32(-719_893), days)
 	}
 }
 


### PR DESCRIPTION
`time.Duration` [doesn't work for durations > 290 years](https://pkg.go.dev/time#pkg-types).
> A Duration represents the elapsed time between two instants as an int64 nanosecond count. The representation limits the largest representable duration to approximately 290 years.