### PR TITLE
[postgres] Add `PgTimeConverter`

### DIFF
--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -872,6 +872,7 @@ CREATE TABLE %s (
 	c_smallint smallserial,
 	c_serial serial,
 	c_text text,
+	c_time_without_timezone time WITHOUT TIME ZONE,
 	c_timestamp_without_timezone timestamp WITHOUT TIME ZONE,
 	c_timestamp_with_timezone timestamp WITH TIME ZONE,
 	c_uuid uuid,
@@ -885,8 +886,8 @@ CREATE TABLE %s (
 	PRIMARY KEY (
 		c_bigint, c_bigserial, c_boolean, c_character, c_character_varying, c_cidr, c_date, c_double_precision, c_inet,
 		c_integer, c_interval, c_jsonb, c_macaddr, c_macaddr8, c_money, c_numeric, c_real, c_smallint, c_serial, c_text,
-		c_timestamp_without_timezone, c_timestamp_with_timezone, c_uuid, c_int4range, c_int8range, c_numrange,
-		c_tsrange, c_tstzrange, c_daterange
+		c_time_without_timezone, c_timestamp_without_timezone, c_timestamp_with_timezone, c_uuid, c_int4range,
+		c_int8range, c_numrange, c_tsrange, c_tstzrange, c_daterange
 	)
 )
 `
@@ -933,6 +934,8 @@ INSERT INTO %s VALUES (
 		1000000123,
 	-- c_text
 		'QWERTYUIOP',
+	-- c_time_without_timezone
+		'20:38:21',
 	-- c_timestamp_without_timezone
 		'2001-02-16 20:38:40',
 	-- c_timestamp_with_timezone

--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -11,7 +11,7 @@ import (
 type MicroTimeConverter struct{}
 
 func (MicroTimeConverter) ToField(name string) debezium.Field {
-	// Represents the number of microseconds past midnight.
+	// Represents the number of microseconds past midnight, and does not include timezone information.
 	return debezium.Field{
 		FieldName:    name,
 		Type:         "int64",
@@ -33,6 +33,25 @@ func (MicroTimeConverter) Convert(value any) (any, error) {
 	minutes := time.Duration(timeValue.Minute()) * time.Minute
 	seconds := time.Duration(timeValue.Second()) * time.Second
 	return int64((hours + minutes + seconds) / time.Microsecond), nil
+}
+
+type TimeConverter struct{}
+
+func (p TimeConverter) ToField(name string) debezium.Field {
+	// Represents the number of milliseconds past midnight, and does not include timezone information.
+	return debezium.Field{
+		FieldName:    name,
+		Type:         "int32",
+		DebeziumType: string(debezium.Time),
+	}
+}
+
+func (TimeConverter) Convert(value any) (any, error) {
+	duration, ok := value.(time.Duration)
+	if !ok {
+		return nil, fmt.Errorf("expected time.Duration got %T with value: %v", value, value)
+	}
+	return asInt32(int64(time.Duration(duration) / time.Millisecond))
 }
 
 type DateConverter struct{}

--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -35,25 +35,6 @@ func (MicroTimeConverter) Convert(value any) (any, error) {
 	return int64((hours + minutes + seconds) / time.Microsecond), nil
 }
 
-type TimeConverter struct{}
-
-func (p TimeConverter) ToField(name string) debezium.Field {
-	// Represents the number of milliseconds past midnight, and does not include timezone information.
-	return debezium.Field{
-		FieldName:    name,
-		Type:         "int32",
-		DebeziumType: string(debezium.Time),
-	}
-}
-
-func (TimeConverter) Convert(value any) (any, error) {
-	duration, ok := value.(time.Duration)
-	if !ok {
-		return nil, fmt.Errorf("expected time.Duration got %T with value: %v", value, value)
-	}
-	return asInt32(int64(time.Duration(duration) / time.Millisecond))
-}
-
 type DateConverter struct{}
 
 func (DateConverter) ToField(name string) debezium.Field {

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -41,6 +41,37 @@ func TestMicroTimeConverter_Convert(t *testing.T) {
 	}
 }
 
+func TestTimeConverter_Convert(t *testing.T) {
+	converter := TimeConverter{}
+	{
+		// Invalid type
+		_, err := converter.Convert(1234)
+		assert.ErrorContains(t, err, "expected time.Duration got int with value: 1234")
+	}
+	{
+		// 1 millisecond
+		value, err := converter.Convert(time.Duration(1) * time.Millisecond)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(1), value)
+	}
+	{
+		// 1 day
+		value, err := converter.Convert(time.Duration(24) * time.Hour)
+		assert.NoError(t, err)
+		assert.Equal(t, int32(86400000), value)
+	}
+	{
+		// Positive overflow
+		_, err := converter.Convert(time.Duration(math.MaxInt64))
+		assert.ErrorContains(t, err, "value overflows int32")
+	}
+	{
+		// Negative overflow
+		_, err := converter.Convert(time.Duration(math.MinInt64))
+		assert.ErrorContains(t, err, "value overflows int32")
+	}
+}
+
 func TestDateConverter_Convert(t *testing.T) {
 	converter := DateConverter{}
 	{

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -41,37 +41,6 @@ func TestMicroTimeConverter_Convert(t *testing.T) {
 	}
 }
 
-func TestTimeConverter_Convert(t *testing.T) {
-	converter := TimeConverter{}
-	{
-		// Invalid type
-		_, err := converter.Convert(1234)
-		assert.ErrorContains(t, err, "expected time.Duration got int with value: 1234")
-	}
-	{
-		// 1 millisecond
-		value, err := converter.Convert(time.Duration(1) * time.Millisecond)
-		assert.NoError(t, err)
-		assert.Equal(t, int32(1), value)
-	}
-	{
-		// 1 day
-		value, err := converter.Convert(time.Duration(24) * time.Hour)
-		assert.NoError(t, err)
-		assert.Equal(t, int32(86400000), value)
-	}
-	{
-		// Positive overflow
-		_, err := converter.Convert(time.Duration(math.MaxInt64))
-		assert.ErrorContains(t, err, "value overflows int32")
-	}
-	{
-		// Negative overflow
-		_, err := converter.Convert(time.Duration(math.MinInt64))
-		assert.ErrorContains(t, err, "value overflows int32")
-	}
-}
-
 func TestDateConverter_Convert(t *testing.T) {
 	converter := DateConverter{}
 	{

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -23,7 +23,7 @@ func castColumn(col schema.Column) (string, error) {
 		schema.UserDefinedText, schema.Text,
 		schema.Money, schema.VariableNumeric, schema.Numeric,
 		schema.Boolean, schema.Bit, schema.Bytea,
-		schema.TimeWithoutTimeZone, schema.Date, schema.Timestamp, schema.Interval, schema.HStore, schema.JSON,
+		schema.Time, schema.Date, schema.Timestamp, schema.Interval, schema.HStore, schema.JSON,
 		schema.Point, schema.Geography, schema.Geometry:
 		// These are all the columns that do not need to be escaped.
 		return colName, nil

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -14,7 +14,7 @@ func castColumn(col schema.Column) (string, error) {
 	case schema.Inet:
 		return fmt.Sprintf("%s::text", colName), nil
 	case schema.TimeWithTimeZone:
-		// If we don't convert "time with time zone" to UTC we end up with strings like `10:23:54-02`
+		// If we don't convert `time with time zone` to UTC we end up with strings like `10:23:54-02`
 		// And pgtype.Time doesn't parse the offset propertly.
 		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name), nil
 	case schema.Array:

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -16,6 +16,7 @@ func castColumn(col schema.Column) (string, error) {
 	case schema.TimeWithTimeZone:
 		// If we don't convert `time with time zone` to UTC we end up with strings like `10:23:54-02`
 		// And pgtype.Time doesn't parse the offset propertly.
+		// See https://github.com/jackc/pgx/issues/1940
 		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name), nil
 	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, col.Name), nil

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -14,7 +14,7 @@ func castColumn(col schema.Column) (string, error) {
 	case schema.Inet:
 		return fmt.Sprintf("%s::text", colName), nil
 	case schema.TimeWithTimeZone:
-		// If we don't convert "time with time zone" to UTC we end up with strings like `10:23:54+02
+		// If we don't convert "time with time zone" to UTC we end up with strings like `10:23:54-02`
 		// And pgtype.Time doesn't parse the offset propertly.
 		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name), nil
 	case schema.Array:

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -13,17 +13,17 @@ func castColumn(col schema.Column) (string, error) {
 	switch col.Type {
 	case schema.Inet:
 		return fmt.Sprintf("%s::text", colName), nil
-	case schema.Time:
-		// Use `extract(epoch from time)` which will emit this in seconds
-		// We need to use CAST, because regular ::int makes this into a bytes array.
-		return fmt.Sprintf(`cast(extract(epoch from %s) as bigint) as "%s"`, colName, col.Name), nil
+	case schema.TimeWithTimeZone:
+		// If we don't convert "time with time zone" to UTC we end up with strings like `10:23:54+02
+		// And pgtype.Time doesn't parse the offset propertly.
+		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name), nil
 	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, col.Name), nil
 	case schema.Int16, schema.Int32, schema.Int64, schema.Real, schema.Double, schema.UUID,
 		schema.UserDefinedText, schema.Text,
 		schema.Money, schema.VariableNumeric, schema.Numeric,
 		schema.Boolean, schema.Bit, schema.Bytea,
-		schema.Date, schema.Timestamp, schema.Interval, schema.HStore, schema.JSON,
+		schema.TimeWithoutTimeZone, schema.Date, schema.Timestamp, schema.Interval, schema.HStore, schema.JSON,
 		schema.Point, schema.Geography, schema.Geometry:
 		// These are all the columns that do not need to be escaped.
 		return colName, nil

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -14,11 +14,9 @@ func castColumn(col schema.Column) (string, error) {
 	case schema.Inet:
 		return fmt.Sprintf("%s::text", colName), nil
 	case schema.Time:
-		// We want to extract(epoch from interval) will emit this in ms
-		// However, Debezium wants this in microseconds, so we are multiplying this by 1000.
+		// Use `extract(epoch from time)` which will emit this in seconds
 		// We need to use CAST, because regular ::int makes this into a bytes array.
-		// extract from epoch outputs in seconds, default multiplier to ms.
-		return fmt.Sprintf(`cast(extract(epoch from %s)*%d as bigint) as "%s"`, colName, 1000, col.Name), nil
+		return fmt.Sprintf(`cast(extract(epoch from %s) as bigint) as "%s"`, colName, col.Name), nil
 	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, col.Name), nil
 	case schema.Int16, schema.Int32, schema.Int64, schema.Real, schema.Double, schema.UUID,

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -45,8 +45,8 @@ func TestCastColumn(t *testing.T) {
 		},
 		{
 			name:     "time",
-			dataType: schema.Time,
-			expected: `cast(extract(epoch from "foo") as bigint) as "foo"`,
+			dataType: schema.TimeWithTimeZone,
+			expected: `"foo" AT TIME ZONE 'UTC' AS "foo"`,
 		},
 		{
 			name:     "date",

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -46,7 +46,7 @@ func TestCastColumn(t *testing.T) {
 		{
 			name:     "time",
 			dataType: schema.Time,
-			expected: `cast(extract(epoch from "foo")*1000 as bigint) as "foo"`,
+			expected: `cast(extract(epoch from "foo") as bigint) as "foo"`,
 		},
 		{
 			name:     "date",

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -44,7 +44,7 @@ func TestCastColumn(t *testing.T) {
 			expected: `"foo"`,
 		},
 		{
-			name:     "time",
+			name:     "time with time zone",
 			dataType: schema.TimeWithTimeZone,
 			expected: `"foo" AT TIME ZONE 'UTC' AS "foo"`,
 		},

--- a/lib/postgres/parse/parse.go
+++ b/lib/postgres/parse/parse.go
@@ -45,10 +45,10 @@ func ParseValue(colKind schema.DataType, value any) (any, error) {
 		}
 		var timeValue pgtype.Time
 		if err := timeValue.Scan(stringValue); err != nil {
-			return nil, fmt.Errorf("failed to parse time value %s: %w", value, err)
+			return nil, fmt.Errorf("failed to parse time value %s: %w", stringValue, err)
 		}
 		if !timeValue.Valid {
-			return nil, nil
+			return nil, fmt.Errorf("parsed time value %s is not valid", stringValue)
 		}
 		return timeValue, nil
 	case schema.Interval:

--- a/lib/postgres/parse/parse.go
+++ b/lib/postgres/parse/parse.go
@@ -38,7 +38,7 @@ func ParseValue(colKind schema.DataType, value any) (any, error) {
 		}
 
 		return nil, fmt.Errorf("value: %v not of string type for Numeric or VariableNumeric", value)
-	case schema.TimeWithoutTimeZone, schema.TimeWithTimeZone:
+	case schema.Time, schema.TimeWithTimeZone:
 		stringValue, ok := value.(string)
 		if !ok {
 			return nil, fmt.Errorf("expected string got %T with value: %v", value, value)

--- a/lib/postgres/parse/parse.go
+++ b/lib/postgres/parse/parse.go
@@ -3,6 +3,7 @@ package parse
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -38,6 +39,14 @@ func ParseValue(colKind schema.DataType, value any) (any, error) {
 		}
 
 		return nil, fmt.Errorf("value: %v not of string type for Numeric or VariableNumeric", value)
+	case schema.Time:
+		// TODO: Switch from casting the value to seconds in the query to parsing the value to a `pgtypes.Time`
+		// Not using `pgtypes.Time` right now as it doesn't handle TIME WITH TIME ZONE properly.
+		secondsValue, ok := value.(int64)
+		if !ok {
+			return nil, fmt.Errorf("expected int64 got %T with value: %v", value, value)
+		}
+		return time.Duration(secondsValue) * time.Second, nil
 	case schema.Interval:
 		stringValue, ok := value.(string)
 		if !ok {

--- a/lib/postgres/parse/parse_test.go
+++ b/lib/postgres/parse/parse_test.go
@@ -44,6 +44,42 @@ func TestParse(t *testing.T) {
 			expectedValue: "hello",
 		},
 		{
+			name:          "time - one second",
+			dataType:      schema.TimeWithoutTimeZone,
+			value:         "00:00:01",
+			expectedValue: pgtype.Time{Microseconds: 100_0000, Valid: true},
+		},
+		{
+			name:          "time - 24 hours",
+			dataType:      schema.TimeWithoutTimeZone,
+			value:         "24:00:00",
+			expectedValue: pgtype.Time{Microseconds: 86_400_000_000, Valid: true},
+		},
+		{
+			name:        "time - malformed",
+			dataType:    schema.TimeWithoutTimeZone,
+			value:       "blah",
+			expectedErr: "failed to parse time value blah: cannot decode blah into Time",
+		},
+		{
+			name:          "time with time zone - one second",
+			dataType:      schema.TimeWithTimeZone,
+			value:         "00:00:01",
+			expectedValue: pgtype.Time{Microseconds: 100_0000, Valid: true},
+		},
+		{
+			name:          "time with time zone  - 24 hours",
+			dataType:      schema.TimeWithTimeZone,
+			value:         "24:00:00",
+			expectedValue: pgtype.Time{Microseconds: 86_400_000_000, Valid: true},
+		},
+		{
+			name:        "time with time zone  - malformed",
+			dataType:    schema.TimeWithTimeZone,
+			value:       "blah",
+			expectedErr: "failed to parse time value blah: cannot decode blah into Time",
+		},
+		{
 			name:          "interval",
 			dataType:      schema.Interval,
 			value:         "1 day 2 mon 03:00:00",

--- a/lib/postgres/parse/parse_test.go
+++ b/lib/postgres/parse/parse_test.go
@@ -45,19 +45,19 @@ func TestParse(t *testing.T) {
 		},
 		{
 			name:          "time - one second",
-			dataType:      schema.TimeWithoutTimeZone,
+			dataType:      schema.Time,
 			value:         "00:00:01",
 			expectedValue: pgtype.Time{Microseconds: 100_0000, Valid: true},
 		},
 		{
 			name:          "time - 24 hours",
-			dataType:      schema.TimeWithoutTimeZone,
+			dataType:      schema.Time,
 			value:         "24:00:00",
 			expectedValue: pgtype.Time{Microseconds: 86_400_000_000, Valid: true},
 		},
 		{
 			name:        "time - malformed",
-			dataType:    schema.TimeWithoutTimeZone,
+			dataType:    schema.Time,
 			value:       "blah",
 			expectedErr: "failed to parse time value blah: cannot decode blah into Time",
 		},

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -84,7 +84,7 @@ func shouldQuoteValue(dataType schema.DataType) (bool, error) {
 	switch dataType {
 	case
 		// Natively supported types in convertToStringForQuery
-		schema.TimeWithoutTimeZone,
+		schema.Time,
 		schema.Interval:
 		return false, fmt.Errorf("unexpected primary key type: DataType(%d)", dataType)
 	case

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -37,7 +37,7 @@ var supportedPrimaryKeyDataType []schema.DataType = []schema.DataType{
 	schema.Inet,
 	schema.JSON,
 	// schema.Bit - fails: operator does not exist: bit >= boolean (SQLSTATE 42883)
-	// schema.Bytea - fails: ERROR: invalid byte sequence for encoding
+	// schema.Bytea - fails: invalid byte sequence for encoding
 	// schema.TimeWithTimeZone - fails: without the original timezone offset the query doesn't match any rows
 	// schema.Array - fails: this doesn't work: need to serialize to Postgres array format "{1,2,3}"
 	// schema.HStore - fails: operator does not exist: hstore >= unknown (SQLSTATE 42883)

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -139,7 +139,6 @@ func convertToStringForQuery(value any, dataType schema.DataType) (string, error
 		if !ok {
 			return "", fmt.Errorf("expected string got %T with value %v", value, value)
 		}
-
 		return QuoteLiteral(stringValue), nil
 	case pgtype.Interval:
 		if !castValue.Valid {

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -29,7 +29,7 @@ var supportedPrimaryKeyDataType []schema.DataType = []schema.DataType{
 	schema.Money,
 	schema.Text,
 	schema.UserDefinedText,
-  schema.Time,
+	schema.Time,
 	schema.Date,
 	schema.Timestamp,
 	schema.Interval,
@@ -38,8 +38,8 @@ var supportedPrimaryKeyDataType []schema.DataType = []schema.DataType{
 	schema.JSON,
 	// schema.Bit - fails: operator does not exist: bit >= boolean (SQLSTATE 42883)
 	// schema.Bytea - fails: ERROR: invalid byte sequence for encoding
-  // schema.TimeWithTimeZone, // fails: without the original timezone offset the query doesn't match any rows
-	// schema.Array - fails: This doesn't work: need to serialize to Postgres array format "{1,2,3}"
+	// schema.TimeWithTimeZone - fails: without the original timezone offset the query doesn't match any rows
+	// schema.Array - fails: this doesn't work: need to serialize to Postgres array format "{1,2,3}"
 	// schema.HStore - fails: operator does not exist: hstore >= unknown (SQLSTATE 42883)
 	// schema.Point - can't be used as a primary key
 	// schema.Geometry - fails: parse error - invalid geometry (SQLSTATE XX000)

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -37,7 +37,8 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"UserDefinedText", schema.UserDefinedText, true, ""},
 		{"JSON", schema.JSON, true, ""},
 		{"Timestamp", schema.Timestamp, true, ""},
-		{"Time", schema.Time, true, "unsupported primary key type: DataType"},
+		{"Time", schema.TimeWithTimeZone, true, "unsupported primary key type: DataType"},
+		{"TimeWithTimeZone", schema.TimeWithTimeZone, true, "unsupported primary key type: DataType"},
 		{"Date", schema.Date, true, ""},
 		// PostGIS
 		{"Point", schema.Point, true, "unsupported primary key type: DataType"},

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -37,7 +37,7 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"UserDefinedText", schema.UserDefinedText, true, ""},
 		{"JSON", schema.JSON, true, ""},
 		{"Timestamp", schema.Timestamp, true, ""},
-		{"Time", schema.Time, true, "unexpected primary key type: DataType(13)"},
+		{"Time", schema.Time, true, "unexpected primary key type: DataType"},
 		{"TimeWithTimeZone", schema.TimeWithTimeZone, true, "unsupported primary key type: DataType"},
 		{"Date", schema.Date, true, ""},
 		// PostGIS

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -37,7 +37,7 @@ func TestShouldQuoteValue(t *testing.T) {
 		{"UserDefinedText", schema.UserDefinedText, true, ""},
 		{"JSON", schema.JSON, true, ""},
 		{"Timestamp", schema.Timestamp, true, ""},
-		{"Time", schema.TimeWithTimeZone, true, "unsupported primary key type: DataType"},
+		{"Time", schema.Time, true, "unexpected primary key type: DataType(13)"},
 		{"TimeWithTimeZone", schema.TimeWithTimeZone, true, "unsupported primary key type: DataType"},
 		{"Date", schema.Date, true, ""},
 		// PostGIS

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -27,7 +27,7 @@ const (
 	Bytea
 	Text
 	UserDefinedText
-	TimeWithoutTimeZone
+	Time
 	TimeWithTimeZone
 	Date
 	Timestamp
@@ -118,7 +118,7 @@ func ParseColumnDataType(colKind string, precision, scale *int, udtName *string)
 		"int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
 		return Text, nil, nil
 	case "time without time zone":
-		return TimeWithoutTimeZone, nil, nil
+		return Time, nil, nil
 	case "time with time zone":
 		return TimeWithTimeZone, nil, nil
 	case "date":

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -27,7 +27,8 @@ const (
 	Bytea
 	Text
 	UserDefinedText
-	Time
+	TimeWithoutTimeZone
+	TimeWithTimeZone
 	Date
 	Timestamp
 	Interval
@@ -116,8 +117,10 @@ func ParseColumnDataType(colKind string, precision, scale *int, udtName *string)
 	case "character varying", "text", "character", "xml", "cidr", "macaddr", "macaddr8",
 		"int4range", "int8range", "numrange", "daterange", "tsrange", "tstzrange":
 		return Text, nil, nil
-	case "time with time zone", "time without time zone":
-		return Time, nil, nil
+	case "time without time zone":
+		return TimeWithoutTimeZone, nil, nil
+	case "time with time zone":
+		return TimeWithTimeZone, nil, nil
 	case "date":
 		return Date, nil, nil
 	case "timestamp without time zone", "timestamp with time zone":

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -50,12 +50,12 @@ func TestParseColumnDataType(t *testing.T) {
 		{
 			name:             "time with time zone",
 			colKind:          "time with time zone",
-			expectedDataType: Time,
+			expectedDataType: TimeWithTimeZone,
 		},
 		{
 			name:             "time without time zone",
 			colKind:          "time without time zone",
-			expectedDataType: Time,
+			expectedDataType: TimeWithoutTimeZone,
 		},
 		{
 			name:             "date",

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -55,7 +55,7 @@ func TestParseColumnDataType(t *testing.T) {
 		{
 			name:             "time without time zone",
 			colKind:          "time without time zone",
-			expectedDataType: TimeWithoutTimeZone,
+			expectedDataType: Time,
 		},
 		{
 			name:             "date",

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -91,8 +91,8 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 		return converters.BytesPassthrough{}, nil
 	case schema.Text, schema.UserDefinedText, schema.Inet:
 		return converters.StringPassthrough{}, nil
-	case schema.Time:
-		return converters.TimeConverter{}, nil
+	case schema.TimeWithoutTimeZone, schema.TimeWithTimeZone:
+		return PgTimeConverter{}, nil
 	case schema.Date:
 		return converters.DateConverter{}, nil
 	case schema.Timestamp:

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -91,7 +91,7 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 		return converters.BytesPassthrough{}, nil
 	case schema.Text, schema.UserDefinedText, schema.Inet:
 		return converters.StringPassthrough{}, nil
-	case schema.TimeWithoutTimeZone, schema.TimeWithTimeZone:
+	case schema.Time, schema.TimeWithTimeZone:
 		return PgTimeConverter{}, nil
 	case schema.Date:
 		return converters.DateConverter{}, nil

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -92,7 +92,7 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 	case schema.Int64:
 		return converters.Int64Passthrough{}, nil
 	case schema.Time:
-		return PgTimeConverter{}, nil
+		return converters.TimeConverter{}, nil
 	case schema.Date:
 		return converters.DateConverter{}, nil
 	case schema.Timestamp:

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -6,8 +6,6 @@ import (
 	"log/slog"
 	"strings"
 
-	transferDbz "github.com/artie-labs/transfer/lib/debezium"
-
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib/debezium/converters"
 	"github.com/artie-labs/reader/lib/debezium/transformer"
@@ -93,6 +91,8 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 		return converters.Int32Passthrough{}, nil
 	case schema.Int64:
 		return converters.Int64Passthrough{}, nil
+	case schema.Time:
+		return PgTimeConverter{}, nil
 	case schema.Date:
 		return converters.DateConverter{}, nil
 	case schema.Timestamp:
@@ -113,9 +113,6 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 		return converters.NewGeometryConverter(), nil
 	case schema.Geography:
 		return converters.NewGeographyConverter(), nil
-	// TODO: Replace the following uses of `NewPassthroughConverter` with type specific converters
-	case schema.Time:
-		return NewPassthroughConverter("int32", string(transferDbz.Time)), nil
 	default:
 		return nil, fmt.Errorf("unsupported data type: DataType(%d)", dataType)
 	}

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -135,7 +135,17 @@ func TestValueConverterForType_ToField(t *testing.T) {
 		{
 			name:     "time",
 			colName:  "time",
-			dataType: schema.Time,
+			dataType: schema.TimeWithoutTimeZone,
+			expected: debezium.Field{
+				Type:         "int32",
+				FieldName:    "time",
+				DebeziumType: string(debezium.Time),
+			},
+		},
+		{
+			name:     "time with time zone",
+			colName:  "time",
+			dataType: schema.TimeWithTimeZone,
 			expected: debezium.Field{
 				Type:         "int32",
 				FieldName:    "time",

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -135,7 +135,7 @@ func TestValueConverterForType_ToField(t *testing.T) {
 		{
 			name:     "time",
 			colName:  "time",
-			dataType: schema.TimeWithoutTimeZone,
+			dataType: schema.Time,
 			expected: debezium.Field{
 				Type:         "int32",
 				FieldName:    "time",

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -65,27 +65,6 @@ func (PgTimestampConverter) Convert(value any) (any, error) {
 	return value, nil
 }
 
-type PgTimeConverter struct{}
-
-func (p PgTimeConverter) ToField(name string) transferDbz.Field {
-	// Represents the number of milliseconds past midnight, and does not include timezone information.
-	return transferDbz.Field{
-		FieldName:    name,
-		Type:         "int32",
-		DebeziumType: string(transferDbz.Time),
-	}
-}
-
-func (PgTimeConverter) Convert(value any) (any, error) {
-	// TODO: Switch from casting the value to seconds in the query to parsing the value to a `pgtypes.Time`
-	// Not using `pgtypes.Time` right now as it doesn't handle TIME WITH TIME ZONE properly.
-	seconds, ok := value.(int64)
-	if !ok {
-		return nil, fmt.Errorf("expected int64 got %T with value: %v", value, value)
-	}
-	return (time.Duration(seconds) * time.Second) / time.Millisecond, nil
-}
-
 type PgIntervalConverter struct{}
 
 func (PgIntervalConverter) ToField(name string) transferDbz.Field {

--- a/sources/postgres/adapter/converters_test.go
+++ b/sources/postgres/adapter/converters_test.go
@@ -115,6 +115,22 @@ func TestPgTimeConverter_Convert(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, int32(86_400_000), value)
 	}
+	{
+		// Valid pgtype.Time - negative overflow
+		_, err := converter.Convert(pgtype.Time{
+			Valid:        true,
+			Microseconds: math.MinInt64,
+		})
+		assert.ErrorContains(t, err, "milliseconds overflows int32")
+	}
+	{
+		// Valid pgtype.Time - positive overflow
+		_, err := converter.Convert(pgtype.Time{
+			Valid:        true,
+			Microseconds: math.MaxInt64,
+		})
+		assert.ErrorContains(t, err, "milliseconds overflows int32")
+	}
 }
 
 func TestPgIntervalConverter_ToField(t *testing.T) {


### PR DESCRIPTION
- No longer need to cast `time without time zone` columns
- Still have to cast `time with time zone` but now it's just converting to `UTC` rather than Unix epoch
- We now support using `time without time zone` as a primary key 
  - `time without time zone` is harder to support as `pgtype.Time` doesn't parse them properly: https://github.com/jackc/pgx/issues/1940