### PR TITLE
[mysql,postgres] Offset `DataType`s by one

### DIFF
--- a/lib/mysql/schema/schema.go
+++ b/lib/mysql/schema/schema.go
@@ -16,7 +16,7 @@ type DataType int
 
 const (
 	// Integer Types (Exact Value)
-	TinyInt DataType = iota
+	TinyInt DataType = iota + 1
 	SmallInt
 	MediumInt
 	Int

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -208,7 +208,7 @@ func TestScanAdapter_ParsePrimaryKeyValue(t *testing.T) {
 			name:        "unsupported data type",
 			dataType:    schema.Array,
 			value:       "1234",
-			expectedErr: "DataType(20) for column 'col' is not supported for use as a primary key",
+			expectedErr: "DataType(21) for column 'col' is not supported for use as a primary key",
 		},
 		{
 			name:        "boolean - malformed",

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -14,7 +14,7 @@ import (
 type DataType int
 
 const (
-	Bit DataType = iota
+	Bit DataType = iota + 1
 	Boolean
 	Int16
 	Int32


### PR DESCRIPTION
This way if we forget to pass a `DataType` in to a struct it'll default to the `0` value which is invalid and we'll get an error in our switch statements rather than `Bit` or `TinyInt`.