### PR TITLE
[postgres] Kill `shouldQuoteValue`

### DIFF
--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
-	"log/slog"
 	"slices"
 	"strconv"
 	"strings"
@@ -73,13 +72,12 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 		if colIndex == -1 {
 			return "", fmt.Errorf("primary key %v not found in columns", pk.Name)
 		}
-		colType := args.Columns[colIndex].Type
 
 		var err error
-		if startingValues[i], err = convertToStringForQuery(pk.StartingValue, colType); err != nil {
+		if startingValues[i], err = convertToStringForQuery(pk.StartingValue); err != nil {
 			return "", err
 		}
-		if endingValues[i], err = convertToStringForQuery(pk.EndingValue, colType); err != nil {
+		if endingValues[i], err = convertToStringForQuery(pk.EndingValue); err != nil {
 			return "", err
 		}
 	}
@@ -110,44 +108,13 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 	), nil
 }
 
-func shouldQuoteValue(dataType schema.DataType) (bool, error) {
-	if !slices.Contains(supportedPrimaryKeyDataType, dataType) {
-		return false, fmt.Errorf("unsupported primary key type: DataType(%d)", dataType)
-	}
-
-	switch dataType {
-	case
-		// Natively supported types in convertToStringForQuery
-		schema.Time,
-		schema.Interval:
-		return false, fmt.Errorf("unexpected primary key type: DataType(%d)", dataType)
-	case
-		schema.Real,
-		schema.Double,
-		schema.Int16,
-		schema.Int32,
-		schema.Int64,
-		schema.Boolean:
-		return false, nil
-	case schema.VariableNumeric,
-		schema.Money,
-		schema.Numeric,
-		schema.Inet,
-		schema.Text,
-		schema.UUID,
-		schema.UserDefinedText,
-		schema.JSON,
-		schema.Timestamp,
-		schema.Date:
-		return true, nil
-	default:
-		return false, fmt.Errorf("unsupported data type: DataType(%d)", dataType)
-	}
-}
-
 // convertToStringForQuery returns a string value suitable for use directly in a query.
-func convertToStringForQuery(value any, dataType schema.DataType) (string, error) {
+func convertToStringForQuery(value any) (string, error) {
 	switch castValue := value.(type) {
+	case bool, int, int8, int16, int32, int64, float32, float64:
+		return fmt.Sprint(value), nil
+	case string:
+		return QuoteLiteral(castValue), nil
 	case time.Time:
 		return QuoteLiteral(castValue.Format(time.RFC3339)), nil
 	case pgtype.Time:
@@ -176,30 +143,6 @@ func convertToStringForQuery(value any, dataType schema.DataType) (string, error
 			return "", fmt.Errorf("expected string got %T with value %v", value, value)
 		}
 		return QuoteLiteral(stringValue), nil
-	case bool, int, int8, int16, int32, int64, float32, float64:
-		return fmt.Sprint(value), nil
-	case string:
-		switch dataType {
-		case schema.Text, schema.UserDefinedText, schema.Inet, schema.UUID, schema.JSON, schema.VariableNumeric,
-			schema.Numeric, schema.Money:
-			return QuoteLiteral(castValue), nil
-		default:
-			slog.Error("string value with non-string column type",
-				slog.String("value", castValue),
-				slog.Any("dataType", dataType),
-			)
-			// legacy behavior - used when optionalPrimaryKeyValStart/End is configured
-			// TODO: parse optionalPrimaryKeyValStart/End based on DataType to Go type
-			shouldQuote, err := shouldQuoteValue(dataType)
-			if err != nil {
-				return "", err
-			}
-			if shouldQuote {
-				return QuoteLiteral(fmt.Sprint(value)), nil
-			} else {
-				return fmt.Sprint(value), nil
-			}
-		}
 	default:
 		return "", fmt.Errorf("unexpected type %T for primary key with value %v", value, value)
 	}

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -110,6 +110,7 @@ func scanTableQuery(args scanTableQueryArgs) (string, error) {
 
 // convertToStringForQuery returns a string value suitable for use directly in a query.
 func convertToStringForQuery(value any) (string, error) {
+	// TODO: Switch to using a parameterized query
 	switch castValue := value.(type) {
 	case bool, int, int8, int16, int32, int64, float32, float64:
 		return fmt.Sprint(value), nil

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -79,12 +79,12 @@ func TestConvertToStringForQuery(t *testing.T) {
 			expected: "'2001-02-03T04:05:06Z'",
 		},
 		{
-			name:     "pgtime - not valid",
+			name:     "pgtype.Time - not valid",
 			value:    pgtype.Time{Microseconds: 1_000_000, Valid: false},
 			expected: "null",
 		},
 		{
-			name:     "pgtime - valid",
+			name:     "pgtype.Time - valid",
 			value:    pgtype.Time{Microseconds: 1_000_000 * 30, Valid: true},
 			expected: "'00:00:30.000000'",
 		},

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -89,14 +89,14 @@ func TestConvertToStringForQuery(t *testing.T) {
 			expected: "'00:00:30.000000'",
 		},
 		{
-			name:     "interval",
-			value:    pgtype.Interval{Days: 2, Months: 1, Microseconds: 1_000_000, Valid: true},
-			expected: "'1 mon 2 day 00:00:01.000000'",
-		},
-		{
-			name:     "interval - invalid",
+			name:     "pgtype.Interval - not valid",
 			value:    pgtype.Interval{Days: 2, Months: 1, Microseconds: 1_000_000, Valid: false},
 			expected: "null",
+		},
+		{
+			name:     "pgtype.Interval - valid",
+			value:    pgtype.Interval{Days: 2, Months: 1, Microseconds: 1_000_000, Valid: true},
+			expected: "'1 mon 2 day 00:00:01.000000'",
 		},
 	}
 	for _, testCase := range testCases {

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -11,132 +11,96 @@ import (
 	"github.com/artie-labs/reader/lib/rdbms/primary_key"
 )
 
-func TestShouldQuoteValue(t *testing.T) {
-	testCases := []struct {
-		name        string
-		dataType    schema.DataType
-		expected    bool
-		expectedErr string
-	}{
-		{"VariableNumeric", schema.VariableNumeric, true, ""},
-		{"Money", schema.Money, true, ""},
-		{"Numeric", schema.Numeric, true, ""},
-		{"Bit", schema.Bit, false, "unsupported primary key type: DataType"},
-		{"Boolean", schema.Boolean, false, ""},
-		{"Inet", schema.Inet, true, ""},
-		{"Text", schema.Text, true, ""},
-		{"Interval", schema.Interval, false, "unexpected primary key type: DataType"},
-		{"Array", schema.Array, false, "unsupported primary key type: DataType"},
-		{"HStore", schema.HStore, true, "unsupported primary key type: DataType"},
-		{"Real", schema.Real, false, ""},
-		{"Double", schema.Double, false, ""},
-		{"Int16", schema.Int16, false, ""},
-		{"Int32", schema.Int32, false, ""},
-		{"Int64", schema.Int64, false, ""},
-		{"UUID", schema.UUID, true, ""},
-		{"UserDefinedText", schema.UserDefinedText, true, ""},
-		{"JSON", schema.JSON, true, ""},
-		{"Timestamp", schema.Timestamp, true, ""},
-		{"Time", schema.Time, true, "unexpected primary key type: DataType"},
-		{"TimeWithTimeZone", schema.TimeWithTimeZone, true, "unsupported primary key type: DataType"},
-		{"Date", schema.Date, true, ""},
-		// PostGIS
-		{"Point", schema.Point, true, "unsupported primary key type: DataType"},
-		{"Geometry", schema.Geometry, true, "unsupported primary key type: DataType"},
-		{"Geography", schema.Geography, true, "unsupported primary key type: DataType"},
-	}
-
-	for _, tc := range testCases {
-		actual, err := shouldQuoteValue(tc.dataType)
-		if tc.expectedErr == "" {
-			assert.NoError(t, err, tc.name)
-			assert.Equal(t, tc.expected, actual, tc.name)
-		} else {
-			assert.ErrorContains(t, err, tc.expectedErr, tc.name)
-		}
-	}
-
-	_, err := shouldQuoteValue(-1)
-	assert.ErrorContains(t, err, "unsupported primary key type: DataType(-1)")
-}
-
 func TestConvertToStringForQuery(t *testing.T) {
 	testCases := []struct {
 		name        string
-		dataType    schema.DataType
 		value       any
-		expected    any
+		expected    string
 		expectedErr string
 	}{
 		{
-			name:     "time - schema.Int64",
-			value:    time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC),
-			dataType: schema.Int64, // isn't checked for time.Time
-			expected: "'2001-02-03T04:05:06Z'",
-		},
-		{
-			name:     "time - schema.Text",
-			value:    time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC),
-			dataType: schema.Text, // isn't checked for time.Time
-			expected: "'2001-02-03T04:05:06Z'",
-		},
-		{
-			name:     "int64",
-			value:    int64(1234),
-			dataType: schema.Int64,
-			expected: "1234",
-		},
-		{
-			name:     "float32",
-			value:    float32(1234.1234),
-			dataType: schema.Real,
-			expected: "1234.1234",
-		},
-		{
-			name:     "float64",
-			value:    float64(1234.1234),
-			dataType: schema.Double,
-			expected: "1234.1234",
+			name:        "unsupported data type",
+			value:       []byte("foo"),
+			expectedErr: "unexpected type []uint8 for primary key with value ",
 		},
 		{
 			name:     "boolean - true",
 			value:    true,
-			dataType: schema.Boolean,
 			expected: "true",
 		},
 		{
 			name:     "boolean - false",
 			value:    false,
-			dataType: schema.Boolean,
 			expected: "false",
+		},
+		{
+			name:     "int",
+			value:    int(1234),
+			expected: "1234",
+		},
+		{
+			name:     "int8",
+			value:    int8(12),
+			expected: "12",
+		},
+		{
+			name:     "int16",
+			value:    int16(1234),
+			expected: "1234",
+		},
+		{
+			name:     "int32",
+			value:    int32(1234),
+			expected: "1234",
+		},
+		{
+			name:     "int64",
+			value:    int64(1234),
+			expected: "1234",
+		},
+		{
+			name:     "float32",
+			value:    float32(1234.1234),
+			expected: "1234.1234",
+		},
+		{
+			name:     "float64",
+			value:    float64(1234.1234),
+			expected: "1234.1234",
 		},
 		{
 			name:     "text",
 			value:    "foo",
-			dataType: schema.Text,
 			expected: "'foo'",
 		},
 		{
-			name:        "text - unsupported data type",
-			value:       "foo",
-			dataType:    -1,
-			expectedErr: "unsupported primary key type: DataType(-1)",
+			name:     "time",
+			value:    time.Date(2001, 2, 3, 4, 5, 6, 0, time.UTC),
+			expected: "'2001-02-03T04:05:06Z'",
+		},
+		{
+			name:     "pgtime - not valid",
+			value:    pgtype.Time{Microseconds: 1_000_000, Valid: false},
+			expected: "null",
+		},
+		{
+			name:     "pgtime - valid",
+			value:    pgtype.Time{Microseconds: 1_000_000 * 30, Valid: true},
+			expected: "'00:00:30.000000'",
 		},
 		{
 			name:     "interval",
 			value:    pgtype.Interval{Days: 2, Months: 1, Microseconds: 1_000_000, Valid: true},
-			dataType: schema.Interval,
 			expected: "'1 mon 2 day 00:00:01.000000'",
 		},
 		{
 			name:     "interval - invalid",
 			value:    pgtype.Interval{Days: 2, Months: 1, Microseconds: 1_000_000, Valid: false},
-			dataType: schema.Interval,
 			expected: "null",
 		},
 	}
 	for _, testCase := range testCases {
-		actual, err := convertToStringForQuery(testCase.value, testCase.dataType)
+		actual, err := convertToStringForQuery(testCase.value)
 		if testCase.expectedErr == "" {
 			assert.NoError(t, err)
 			assert.Equal(t, testCase.expected, actual, testCase.name)


### PR DESCRIPTION
Instead of quoting a column based on its `DataType` we'll just quote it if it's a string and otherwise not quote it.