### PR TITLE
[postgres] Default to not casting columns

### DIFF
--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -18,15 +18,7 @@ func castColumn(col schema.Column) (string, error) {
 		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name), nil
 	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, col.Name), nil
-	case schema.Int16, schema.Int32, schema.Int64, schema.Real, schema.Double, schema.UUID,
-		schema.UserDefinedText, schema.Text, schema.Inet,
-		schema.Money, schema.VariableNumeric, schema.Numeric,
-		schema.Boolean, schema.Bit, schema.Bytea,
-		schema.Time, schema.Date, schema.Timestamp, schema.Interval, schema.HStore, schema.JSON,
-		schema.Point, schema.Geography, schema.Geometry:
-		// These are all the columns that do not need to be escaped.
-		return colName, nil
 	default:
-		return "", fmt.Errorf("unsupported column type: DataType(%d)", col.Type)
+		return colName, nil
 	}
 }

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -58,11 +58,6 @@ func TestCastColumn(t *testing.T) {
 			dataType: schema.VariableNumeric,
 			expected: `"foo"`,
 		},
-		{
-			name:        "unsupported",
-			dataType:    -1,
-			expectedErr: "unsupported column type: DataType(-1)",
-		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Since casting is the exception we don't need to be explicit about which columns are not cast.