### PR TITLE
[postgres] Add native support for `time with time zone` type

### DIFF
--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -506,11 +506,11 @@ const expectedPayloadTemplate = `{
 						"parameters": null
 					},
 					{
-						"type": "int32",
+						"type": "string",
 						"optional": false,
 						"default": null,
 						"field": "c_time_with_timezone",
-						"name": "io.debezium.time.Time",
+						"name": "io.debezium.time.ZonedTime",
 						"parameters": null
 					},
 					{
@@ -691,7 +691,7 @@ const expectedPayloadTemplate = `{
 			"c_serial": 1000000123,
 			"c_smallint": 32767,
 			"c_text": "QWERTYUIOP",
-			"c_time_with_timezone": 38057000,
+			"c_time_with_timezone": "10:34:17Z",
 			"c_time_without_timezone": 45296000,
 			"c_timestamp_with_timezone": "2001-02-16T13:38:40Z",
 			"c_timestamp_without_timezone": "2001-02-16T20:38:40Z",
@@ -899,7 +899,7 @@ CREATE TABLE %s (
 	c_date date,
 	c_double_precision double precision,
 	c_inet inet,
-	c_integer integer,
+	-- c_integer integer, - integer is already tested by the other tests
 	c_interval interval,
 	c_jsonb jsonb,
 	c_macaddr macaddr,
@@ -911,6 +911,7 @@ CREATE TABLE %s (
 	c_serial serial,
 	c_text text,
 	c_time_without_timezone time WITHOUT TIME ZONE,
+	c_time_with_timezone time WITH TIME ZONE,
 	c_timestamp_without_timezone timestamp WITHOUT TIME ZONE,
 	c_timestamp_with_timezone timestamp WITH TIME ZONE,
 	c_uuid uuid,
@@ -923,9 +924,9 @@ CREATE TABLE %s (
 	c_daterange daterange,
 	PRIMARY KEY (
 		c_bigint, c_bigserial, c_bit, c_boolean, c_bytea, c_character, c_character_varying, c_cidr, c_date, c_double_precision,
-		c_inet, c_integer, c_interval, c_jsonb, c_macaddr, c_macaddr8, c_money, c_numeric, c_real, c_smallint, c_serial,
-		c_text, c_time_without_timezone, c_timestamp_without_timezone, c_timestamp_with_timezone, c_uuid, c_int4range,
-		c_int8range, c_numrange, c_tsrange, c_tstzrange, c_daterange
+		c_inet, c_interval, c_jsonb, c_macaddr, c_macaddr8, c_money, c_numeric, c_real, c_smallint, c_serial,
+		c_text, c_time_without_timezone, c_time_with_timezone, c_timestamp_without_timezone, c_timestamp_with_timezone,
+		c_uuid, c_int4range, c_int8range, c_numrange, c_tsrange, c_tstzrange, c_daterange
 	)
 )
 `
@@ -954,8 +955,6 @@ INSERT INTO %s VALUES (
 		123.456,
 	-- c_inet
 		'192.168.1.5',
-	-- c_integer
-		12345,
 	-- c_interval
 		'2 mon 3 day 4 hours',
 	-- c_jsonb
@@ -978,6 +977,8 @@ INSERT INTO %s VALUES (
 		'QWERTYUIOP',
 	-- c_time_without_timezone
 		'20:38:21',
+	-- c_time_with_timezone
+		'02:38:21+07',
 	-- c_timestamp_without_timezone
 		'2001-02-16 20:38:40.123123',
 	-- c_timestamp_with_timezone

--- a/lib/postgres/cast.go
+++ b/lib/postgres/cast.go
@@ -11,19 +11,14 @@ import (
 func castColumn(col schema.Column) (string, error) {
 	colName := pgx.Identifier{col.Name}.Sanitize()
 	switch col.Type {
-	case schema.TimeWithTimeZone:
-		// If we don't convert `time with time zone` to UTC we end up with strings like `10:23:54-02`
-		// And pgtype.Time doesn't parse the offset propertly.
-		// See https://github.com/jackc/pgx/issues/1940
-		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name), nil
 	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, col.Name), nil
 	case schema.Int16, schema.Int32, schema.Int64, schema.Real, schema.Double, schema.UUID,
 		schema.UserDefinedText, schema.Text, schema.Inet,
 		schema.Money, schema.VariableNumeric, schema.Numeric,
 		schema.Boolean, schema.Bit, schema.Bytea,
-		schema.Time, schema.Date, schema.Timestamp, schema.Interval, schema.HStore, schema.JSON,
-		schema.Point, schema.Geography, schema.Geometry:
+		schema.Time, schema.TimeWithTimeZone, schema.Date, schema.Timestamp, schema.Interval, schema.HStore,
+		schema.JSON, schema.Point, schema.Geography, schema.Geometry:
 		// These are all the columns that do not need to be escaped.
 		return colName, nil
 	default:

--- a/lib/postgres/cast_test.go
+++ b/lib/postgres/cast_test.go
@@ -46,7 +46,7 @@ func TestCastColumn(t *testing.T) {
 		{
 			name:     "time with time zone",
 			dataType: schema.TimeWithTimeZone,
-			expected: `"foo" AT TIME ZONE 'UTC' AS "foo"`,
+			expected: `"foo"`,
 		},
 		{
 			name:     "date",

--- a/lib/postgres/parse/parse.go
+++ b/lib/postgres/parse/parse.go
@@ -37,7 +37,7 @@ func ParseValue(colKind schema.DataType, value any) (any, error) {
 		}
 
 		return nil, fmt.Errorf("value: %v not of string type for Numeric or VariableNumeric", value)
-	case schema.Time, schema.TimeWithTimeZone:
+	case schema.Time:
 		stringValue, ok := value.(string)
 		if !ok {
 			return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
@@ -50,6 +50,12 @@ func ParseValue(colKind schema.DataType, value any) (any, error) {
 			return nil, fmt.Errorf("parsed time value %s is not valid", stringValue)
 		}
 		return timeValue, nil
+	case schema.TimeWithTimeZone:
+		stringValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
+		}
+		return stringValue, nil
 	case schema.Interval:
 		stringValue, ok := value.(string)
 		if !ok {

--- a/lib/postgres/parse/parse_test.go
+++ b/lib/postgres/parse/parse_test.go
@@ -64,20 +64,14 @@ func TestParse(t *testing.T) {
 		{
 			name:          "time with time zone - one second",
 			dataType:      schema.TimeWithTimeZone,
-			value:         "00:00:01",
-			expectedValue: pgtype.Time{Microseconds: 100_0000, Valid: true},
+			value:         "00:00:01+00",
+			expectedValue: "00:00:01+00",
 		},
 		{
 			name:          "time with time zone  - 24 hours",
 			dataType:      schema.TimeWithTimeZone,
-			value:         "24:00:00",
-			expectedValue: pgtype.Time{Microseconds: 86_400_000_000, Valid: true},
-		},
-		{
-			name:        "time with time zone  - malformed",
-			dataType:    schema.TimeWithTimeZone,
-			value:       "blah",
-			expectedErr: "failed to parse time value blah: cannot decode blah into Time",
+			value:         "24:00:00+00",
+			expectedValue: "24:00:00+00",
 		},
 		{
 			name:          "interval",

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -31,13 +31,13 @@ var supportedPrimaryKeyDataType []schema.DataType = []schema.DataType{
 	schema.Text,
 	schema.UserDefinedText,
 	schema.Time,
+	schema.TimeWithTimeZone,
 	schema.Date,
 	schema.Timestamp,
 	schema.Interval,
 	schema.UUID,
 	schema.Inet,
 	schema.JSON,
-	// schema.TimeWithTimeZone - fails: without the original timezone offset the query doesn't match any rows
 	// schema.Array - fails: this doesn't work: need to serialize to Postgres array format "{1,2,3}"
 	// schema.HStore - fails: operator does not exist: hstore >= unknown (SQLSTATE 42883)
 	// schema.Point - can't be used as a primary key

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -101,8 +101,10 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 		return converters.BytesPassthrough{}, nil
 	case schema.Text, schema.UserDefinedText:
 		return converters.StringPassthrough{}, nil
-	case schema.Time, schema.TimeWithTimeZone:
+	case schema.Time:
 		return PgTimeConverter{}, nil
+	case schema.TimeWithTimeZone:
+		return PgTimeTzConverter{}, nil
 	case schema.Date:
 		return converters.DateConverter{}, nil
 	case schema.Timestamp:

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -147,9 +147,9 @@ func TestValueConverterForType_ToField(t *testing.T) {
 			colName:  "time",
 			dataType: schema.TimeWithTimeZone,
 			expected: debezium.Field{
-				Type:         "int32",
+				Type:         "string",
 				FieldName:    "time",
-				DebeziumType: string(debezium.Time),
+				DebeziumType: string(debezium.TimeWithTimezone),
 			},
 		},
 		{

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -66,6 +66,30 @@ func (PgTimeConverter) Convert(value any) (any, error) {
 	return int32(milliseconds), nil
 }
 
+type PgTimeTzConverter struct{}
+
+func (PgTimeTzConverter) ToField(name string) transferDbz.Field {
+	return transferDbz.Field{
+		FieldName:    name,
+		Type:         "string",
+		DebeziumType: string(transferDbz.TimeWithTimezone),
+	}
+}
+
+func (PgTimeTzConverter) Convert(value any) (any, error) {
+	stringValue, ok := value.(string)
+	if !ok {
+		return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
+	}
+
+	timeValue, err := time.Parse("15:04:05-07", stringValue)
+	if err != nil {
+		return nil, err
+	}
+
+	return timeValue.UTC().Format("15:04:05Z"), nil
+}
+
 // TODO: Replace this with `converters.TimestampConverter` once we've run it for a while and not seen error logs
 type PgTimestampConverter struct{}
 


### PR DESCRIPTION
Also support using it as a primary key.