### PR TITLE
[debezium] Format `time.Time` to string in `TimestampConverter`

### DIFF
--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -91,7 +91,7 @@ func (TimestampConverter) Convert(value any) (any, error) {
 		return nil, nil
 	}
 
-	return timeValue, nil
+	return timeValue.Format(time.RFC3339Nano), nil
 }
 
 type YearConverter struct{}

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -144,7 +144,7 @@ func TestTimestampConverter_Convert(t *testing.T) {
 		// time.Time
 		value, err := converter.Convert(time.Date(2001, 2, 3, 4, 5, 0, 0, time.UTC))
 		assert.NoError(t, err)
-		assert.Equal(t, time.Date(2001, 2, 3, 4, 5, 0, 0, time.UTC), value)
+		assert.Equal(t, "2001-02-03T04:05:00Z", value)
 	}
 }
 


### PR DESCRIPTION
Rather than relying on `Time.MarshalJSON` to convert `time.Time` to a string do the conversion in `TimestampConverter` so we know exactly what format is being used. `Time.MarshalJSON` [uses RFC 3339 format with sub-second precision](https://github.com/golang/go/blob/0a6f05e30f58023bf45f747a79c20751db2bcfe7/src/time/time.go#L1365)

This also seems more correct since we're defining the field type as string https://github.com/artie-labs/reader/pull/301/files#diff-5de60c74c1cf57a3f6e6d17dc239b2e77d2e9b9ac954257b55972fdc22926f0cR76