### PR TITLE
[postgres] Remove casting from primary key values query

### DIFF
--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -198,9 +198,9 @@ type buildPkValuesQueryArgs struct {
 }
 
 func buildPkValuesQuery(args buildPkValuesQueryArgs) string {
-	castedColumns := make([]string, len(args.Keys))
+	escapedColumns := make([]string, len(args.Keys))
 	for i, col := range args.Keys {
-		castedColumns[i] = pgx.Identifier{col.Name}.Sanitize()
+		escapedColumns[i] = pgx.Identifier{col.Name}.Sanitize()
 	}
 
 	var fragments []string
@@ -211,7 +211,7 @@ func buildPkValuesQuery(args buildPkValuesQueryArgs) string {
 		}
 		fragments = append(fragments, fragment)
 	}
-	return fmt.Sprintf(`SELECT %s FROM %s ORDER BY %s LIMIT 1`, strings.Join(castedColumns, ","),
+	return fmt.Sprintf(`SELECT %s FROM %s ORDER BY %s LIMIT 1`, strings.Join(escapedColumns, ","),
 		pgx.Identifier{args.Schema, args.TableName}.Sanitize(), strings.Join(fragments, ","))
 }
 

--- a/lib/postgres/schema/schema_test.go
+++ b/lib/postgres/schema/schema_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/artie-labs/transfer/lib/ptr"
-	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -142,12 +141,8 @@ func TestParseColumnDataType(t *testing.T) {
 }
 
 func TestBuildPkValuesQuery(t *testing.T) {
-	var cast = func(c Column) (string, error) {
-		return pgx.Identifier{c.Name}.Sanitize(), nil
-	}
-
 	{
-		query, err := buildPkValuesQuery(buildPkValuesQueryArgs{
+		query := buildPkValuesQuery(buildPkValuesQueryArgs{
 			Keys: []Column{
 				{Name: "a", Type: Text},
 				{Name: "b", Type: Text},
@@ -155,14 +150,12 @@ func TestBuildPkValuesQuery(t *testing.T) {
 			},
 			Schema:    "schema",
 			TableName: "table",
-			CastFunc:  cast,
 		})
-		assert.NoError(t, err)
 		assert.Equal(t, `SELECT "a","b","c" FROM "schema"."table" ORDER BY "a","b","c" LIMIT 1`, query)
 	}
 	// Descending
 	{
-		query, err := buildPkValuesQuery(buildPkValuesQueryArgs{
+		query := buildPkValuesQuery(buildPkValuesQueryArgs{
 			Keys: []Column{
 				{Name: "a", Type: Text},
 				{Name: "b", Type: Text},
@@ -170,10 +163,8 @@ func TestBuildPkValuesQuery(t *testing.T) {
 			},
 			Schema:     "schema",
 			TableName:  "table",
-			CastFunc:   cast,
 			Descending: true,
 		})
-		assert.NoError(t, err)
 		assert.Equal(t, `SELECT "a","b","c" FROM "schema"."table" ORDER BY "a" DESC,"b" DESC,"c" DESC LIMIT 1`, query)
 	}
 }

--- a/lib/postgres/table.go
+++ b/lib/postgres/table.go
@@ -42,7 +42,7 @@ func (t *Table) GetPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
 		return nil, fmt.Errorf("missing primary key columns: %w", err)
 	}
 
-	primaryKeysBounds, err := schema.GetPrimaryKeysBounds(db, t.Schema, t.Name, keyColumns, castColumn)
+	primaryKeysBounds, err := schema.GetPrimaryKeysBounds(db, t.Schema, t.Name, keyColumns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve bounds for primary keys: %w", err)
 	}


### PR DESCRIPTION
Since the only [two columns type that require casting ](https://github.com/artie-labs/reader/blob/970631c7c8f25b34ad687eec142308e2e739efb7/lib/postgres/scanner.go#L140)(`schema.Array`, `schema.TimeWithTimeZone`) are [not supported as primary key types](https://github.com/artie-labs/reader/blob/970631c7c8f25b34ad687eec142308e2e739efb7/lib/postgres/scanner.go#L19) we can remove the logic that casts columns when we fetch the primary key values.