### PR TITLE
[dynamodb] Add max attempts to `processShard`

### DIFF
--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -96,7 +96,7 @@ func (b *BatchWriter) WriteMessages(ctx context.Context, msgs []kafka.Message) e
 
 		var kafkaErr error
 		chunk := iter.Next()
-		for attempts := 0; attempts < 10; attempts++ {
+		for attempts := range 10 {
 			if attempts > 0 {
 				sleepDuration := jitter.Jitter(baseJitterMs, maxJitterMs, attempts-1)
 				slog.Info("Failed to publish to kafka",


### PR DESCRIPTION
Due to a [bug with `jitter.Jitter`](https://github.com/artie-labs/transfer/pull/395) when we call it with attempts > 58 it'll panic. I fixed the bug in transfer, but it seems smart to also build in a maximum amount of attempts here so that we don't loop forever.