### PR TITLE
Add `iterator.Flatten` function

### DIFF
--- a/integration_tests/utils/utils.go
+++ b/integration_tests/utils/utils.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/artie-labs/reader/lib"
 	"github.com/artie-labs/reader/lib/debezium/transformer"
+	"github.com/artie-labs/reader/lib/iterator"
 	"github.com/artie-labs/transfer/lib/cdc/util"
 )
 
@@ -31,16 +32,7 @@ func ReadTable(db *sql.DB, dbzAdapter transformer.Adapter) ([]lib.RawMessage, er
 	if err != nil {
 		return nil, err
 	}
-
-	rows := []lib.RawMessage{}
-	for dbzTransformer.HasNext() {
-		batch, err := dbzTransformer.Next()
-		if err != nil {
-			return nil, err
-		}
-		rows = append(rows, batch...)
-	}
-	return rows, nil
+	return iterator.Collect(iterator.Flatten(dbzTransformer))
 }
 
 func GetPayload(message lib.RawMessage) util.SchemaEventPayload {

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -71,7 +71,7 @@ func (fi *flatIterator[T]) Next() (T, error) {
 	return value, nil
 }
 
-// Flatten takes an [Iterator] of slices and produces new iterator over the items in all the slices.
+// Flatten takes an [Iterator] of slices and produces new iterator over all the items in all the slices.
 func Flatten[T any](iter Iterator[[]T]) Iterator[T] {
 	return &flatIterator[T]{iter: iter}
 }

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -1,5 +1,7 @@
 package iterator
 
+import "fmt"
+
 type Iterator[T any] interface {
 	HasNext() bool
 	Next() (T, error)
@@ -17,4 +19,59 @@ func Collect[T any](iter Iterator[T]) ([]T, error) {
 		result = append(result, value)
 	}
 	return result, nil
+}
+
+type flatIterator[T any] struct {
+	iter Iterator[[]T]
+
+	cur      []T
+	curIndex int
+
+	err error
+}
+
+func (fi *flatIterator[T]) seek() bool {
+	fi.curIndex = 0
+	fi.cur = nil
+
+	for fi.iter.HasNext() {
+		items, err := fi.iter.Next()
+		if err != nil {
+			fi.err = err
+			return true
+		} else if len(items) > 0 {
+			fi.cur = items
+			return true
+		}
+	}
+
+	return false
+}
+
+func (fi *flatIterator[T]) HasNext() bool {
+	if fi.curIndex < len(fi.cur) {
+		return true
+	}
+	return fi.seek()
+}
+
+func (fi *flatIterator[T]) Next() (T, error) {
+	if !fi.HasNext() {
+		var unused T
+		return unused, fmt.Errorf("iterator has finished")
+	}
+
+	if fi.err != nil {
+		var unused T
+		return unused, fi.err
+	}
+
+	value := fi.cur[fi.curIndex]
+	fi.curIndex++
+	return value, nil
+}
+
+// Flatten takes an [Iterator] of slices and produces new iterator over the items in all the slices.
+func Flatten[T any](iter Iterator[[]T]) Iterator[T] {
+	return &flatIterator[T]{iter: iter}
 }

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -93,7 +93,7 @@ func TestFlatten(t *testing.T) {
 	}
 	{
 		// Empty and non-empty batches with differing amounts of items.
-		iter := ForSlice([][]int{{6, 7, 8, 9}, {}, {1, 2, 3}, {4}, {}, {}, {3, 2}})
+		iter := ForSlice([][]int{{}, {6, 7, 8, 9}, {}, {1, 2, 3}, {4}, {}, {}, {3, 2}, {}})
 		items, err := Collect(Flatten(iter))
 		assert.NoError(t, err)
 		assert.Equal(t, items, []int{6, 7, 8, 9, 1, 2, 3, 4, 3, 2})

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -7,11 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type errorIterator struct{}
+type errorIterator struct {
+	errorAfter int
+}
 
 func (errorIterator) HasNext() bool { return true }
 
-func (errorIterator) Next() (int, error) { return 0, fmt.Errorf("error in Next()") }
+func (ei *errorIterator) Next() ([]int, error) {
+	if ei.errorAfter <= 0 {
+		return nil, fmt.Errorf("error in Next()")
+	}
+	ei.errorAfter--
+	return []int{ei.errorAfter}, nil
+}
 
 func TestCollect(t *testing.T) {
 	{
@@ -29,8 +37,75 @@ func TestCollect(t *testing.T) {
 		assert.Equal(t, items, []int{1, 2, 3, 4})
 	}
 	{
-		// When [Iterator.Next] throws an error.
-		_, err := Collect(errorIterator{})
+		// When [Iterator.Next] returns an error immedately.
+		_, err := Collect(&errorIterator{})
+		assert.ErrorContains(t, err, "error in Next()")
+	}
+	{
+		// When [Iterator.Next] returns an error after several calls.
+		_, err := Collect(&errorIterator{errorAfter: 5})
+		assert.ErrorContains(t, err, "error in Next()")
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	{
+		// Empty iterator.
+		iter := ForSlice([][]int{})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Empty(t, items)
+	}
+	{
+		// One empty batch.
+		iter := ForSlice([][]int{{}})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Empty(t, items)
+	}
+	{
+		// Two empty batches.
+		iter := ForSlice([][]int{{}, {}})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Empty(t, items)
+	}
+	{
+		// One non-empty batch with a single item.
+		iter := ForSlice([][]int{{6}})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Equal(t, items, []int{6})
+	}
+	{
+		// One non-empty batch with multiple items.
+		iter := ForSlice([][]int{{6, 7, 8, 9}})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Equal(t, items, []int{6, 7, 8, 9})
+	}
+	{
+		// Two non-empty batches with multiple items.
+		iter := ForSlice([][]int{{6, 7, 8, 9}, {1, 2, 3}})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Equal(t, items, []int{6, 7, 8, 9, 1, 2, 3})
+	}
+	{
+		// Empty and non-empty batches with differing amounts of items.
+		iter := ForSlice([][]int{{6, 7, 8, 9}, {}, {1, 2, 3}, {4}, {}, {}, {3, 2}})
+		items, err := Collect(Flatten(iter))
+		assert.NoError(t, err)
+		assert.Equal(t, items, []int{6, 7, 8, 9, 1, 2, 3, 4, 3, 2})
+	}
+	{
+		// When [Iterator.Next] returns an error immediately.
+		_, err := Collect(Flatten(&errorIterator{}))
+		assert.ErrorContains(t, err, "error in Next()")
+	}
+	{
+		// When [Iterator.Next] returns an error after several successful calls.
+		_, err := Collect(Flatten(&errorIterator{errorAfter: 10}))
 		assert.ErrorContains(t, err, "error in Next()")
 	}
 }


### PR DESCRIPTION
Currently we read a chunk of rows from a source table (which is configurable by specifying `batchSize` in the config) and then write to Kafka after splitting each chunk into sub-chunks (configured by specifying `publishSize` in the config). This is fine so long as `publishSize` is a multiple of `batchSize`, however when it's not some of the batches we write may be very small or if `publishSize` > `batchSize` it'll be basically be ignored.

This PR adds a new function `iterator.Flatten`, that used together with [an iterator version of `iterator.Batched`](https://github.com/artie-labs/reader/pull/328) will allow us to rebatch streams such that each chunk is exactly `publishSize`:
```
dbIter := readFromDB(batchSize) // -> Iterator[[]Row]
flatIter := iterators.Flatten(dbIter) // -> Iterator[Row]
batchedIter := iterators.Batched(flatIter, publishSize) // -> Iterator[[]Row]
```