### PR TITLE
[kafka] Validate publish size when creating `BatchWriter`

### DIFF
--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -66,14 +66,14 @@ func NewBatchWriter(ctx context.Context, cfg config.Kafka, statsD mtr.Client) (*
 		return nil, fmt.Errorf("kafka topic prefix cannot be empty")
 	}
 
-	writer, err := newWriter(ctx, cfg)
-	if err != nil {
-		return nil, err
-	}
-
 	batchSize := cfg.GetPublishSize()
 	if batchSize < 1 {
 		return nil, fmt.Errorf("kafka publish size must be greater than zero")
+	}
+
+	writer, err := newWriter(ctx, cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	return &BatchWriter{writer, batchSize, cfg, statsD}, nil

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -143,7 +143,7 @@ func (b *BatchWriter) WriteRawMessages(ctx context.Context, rawMsgs []lib.RawMes
 			}
 
 			if isExceedMaxMessageBytesErr(kafkaErr) {
-				slog.Info("Skipping this chunk since the message size was too big for the server")
+				slog.Info("Skipping this batch since the message exceeded the server max")
 				kafkaErr = nil
 				break
 			}

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -55,10 +55,9 @@ func newWriter(ctx context.Context, cfg config.Kafka) (*kafka.Writer, error) {
 }
 
 type BatchWriter struct {
-	writer    *kafka.Writer
-	batchSize uint
-	cfg       config.Kafka
-	statsD    mtr.Client
+	writer *kafka.Writer
+	cfg    config.Kafka
+	statsD mtr.Client
 }
 
 func NewBatchWriter(ctx context.Context, cfg config.Kafka, statsD mtr.Client) (*BatchWriter, error) {
@@ -66,8 +65,7 @@ func NewBatchWriter(ctx context.Context, cfg config.Kafka, statsD mtr.Client) (*
 		return nil, fmt.Errorf("kafka topic prefix cannot be empty")
 	}
 
-	batchSize := cfg.GetPublishSize()
-	if batchSize < 1 {
+	if cfg.GetPublishSize() < 1 {
 		return nil, fmt.Errorf("kafka publish size must be greater than zero")
 	}
 
@@ -75,7 +73,7 @@ func NewBatchWriter(ctx context.Context, cfg config.Kafka, statsD mtr.Client) (*
 	if err != nil {
 		return nil, err
 	}
-	return &BatchWriter{writer, batchSize, cfg, statsD}, nil
+	return &BatchWriter{writer, cfg, statsD}, nil
 }
 
 func (b *BatchWriter) reload(ctx context.Context) error {
@@ -107,7 +105,7 @@ func (b *BatchWriter) WriteRawMessages(ctx context.Context, rawMsgs []lib.RawMes
 		msgs = append(msgs, kafkaMsg)
 	}
 
-	iter := iterator.Batched(msgs, int(b.batchSize))
+	iter := iterator.Batched(msgs, int(b.cfg.GetPublishSize()))
 	for iter.HasNext() {
 		tags := map[string]string{
 			"what": "error",

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -75,7 +75,6 @@ func NewBatchWriter(ctx context.Context, cfg config.Kafka, statsD mtr.Client) (*
 	if err != nil {
 		return nil, err
 	}
-
 	return &BatchWriter{writer, batchSize, cfg, statsD}, nil
 }
 

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -143,7 +143,7 @@ func (b *BatchWriter) WriteRawMessages(ctx context.Context, rawMsgs []lib.RawMes
 			}
 
 			if isExceedMaxMessageBytesErr(kafkaErr) {
-				slog.Info("Skipping this batch since the message exceeded the server max")
+				slog.Info("Skipping this batch since the message size exceeded the server max")
 				kafkaErr = nil
 				break
 			}


### PR DESCRIPTION
Moves checking `cfg.GetPublishSize()` from `WriteRawMessages` to `NewBatchWriter` so that we fail fast.