### PR TITLE
Add functional iterators

### DIFF
--- a/lib/debezium/transformer/transformer_test.go
+++ b/lib/debezium/transformer/transformer_test.go
@@ -73,7 +73,7 @@ func TestDebeziumTransformer_Iteration(t *testing.T) {
 		// Empty iterator
 		transformer, err := NewDebeziumTransformer(mockAdatper{iter: iterator.ForSlice([][]Row{})})
 		assert.NoError(t, err)
-		items, err := iterator.Collect(transformer)
+		items, err := iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.NoError(t, err)
 		assert.Empty(t, items)
 	}
@@ -82,7 +82,7 @@ func TestDebeziumTransformer_Iteration(t *testing.T) {
 		batches := [][]Row{{}}
 		transformer, err := NewDebeziumTransformer(mockAdatper{iter: iterator.ForSlice(batches)})
 		assert.NoError(t, err)
-		results, err := iterator.Collect(transformer)
+		results, err := iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.NoError(t, err)
 		assert.Len(t, results, 1)
 		assert.Empty(t, results[0])
@@ -101,7 +101,7 @@ func TestDebeziumTransformer_Iteration(t *testing.T) {
 			iter:            iterator.ForSlice(batches),
 		})
 		assert.NoError(t, err)
-		results, err := iterator.Collect(transformer)
+		results, err := iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.NoError(t, err)
 		assert.Len(t, results, 1)
 		rows := results[0]
@@ -132,7 +132,7 @@ func TestDebeziumTransformer_Iteration(t *testing.T) {
 			iter:            iterator.ForSlice(batches),
 		})
 		assert.NoError(t, err)
-		results, err := iterator.Collect(transformer)
+		results, err := iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.NoError(t, err)
 		assert.Len(t, results, 3)
 		// First batch
@@ -164,7 +164,7 @@ func TestDebeziumTransformer_Next(t *testing.T) {
 			},
 		)
 		assert.NoError(t, err)
-		_, err = iterator.Collect(transformer)
+		_, err = iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.ErrorContains(t, err, `failed to scan: test iteration error`)
 	}
 	{
@@ -179,7 +179,7 @@ func TestDebeziumTransformer_Next(t *testing.T) {
 		},
 		)
 		assert.NoError(t, err)
-		_, err = iterator.Collect(transformer)
+		_, err = iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.ErrorContains(t, err, `failed to create Debezium payload: failed to convert row value for key "foo": test error`)
 	}
 	{
@@ -199,7 +199,7 @@ func TestDebeziumTransformer_Next(t *testing.T) {
 		},
 		)
 		assert.NoError(t, err)
-		results, err := iterator.Collect(transformer)
+		results, err := iterator.Collect(iterator.ToFunctionalIterator(transformer))
 		assert.NoError(t, err)
 		assert.Len(t, results, 1)
 		rows := results[0]

--- a/lib/iterator/batch.go
+++ b/lib/iterator/batch.go
@@ -1,32 +1,17 @@
 package iterator
 
-import "fmt"
-
-type batchIterator[T any] struct {
-	items []T
-	index int
-	step  int
-}
-
 // Batched returns an iterator that splits a list of items into batches of the given step size.
-func Batched[T any](items []T, step int) Iterator[[]T] {
-	return &batchIterator[T]{
-		items: items,
-		index: 0,
-		step:  max(step, 1),
-	}
-}
+func Batched[T any](items []T, step int) FunctionalIterator[[]T] {
+	step = max(step, 1)
+	var index int
 
-func (i *batchIterator[T]) HasNext() bool {
-	return i.index < len(i.items)
-}
-
-func (i *batchIterator[T]) Next() ([]T, error) {
-	if !i.HasNext() {
-		return nil, fmt.Errorf("iterator has finished")
+	return func() ([]T, error, bool) {
+		if index < len(items) {
+			end := min(index+step, len(items))
+			result := items[index:end]
+			index = end
+			return result, nil, true
+		}
+		return nil, nil, false
 	}
-	end := min(i.index+i.step, len(i.items))
-	result := i.items[i.index:end]
-	i.index = end
-	return result, nil
 }

--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -7,14 +7,30 @@ type Iterator[T any] interface {
 
 // Collect returns a new slice containing all the items from an [Iterator].
 // Used for testing, use only with iterators containing a finite amount of items that fit in memory.
-func Collect[T any](iter Iterator[T]) ([]T, error) {
+func Collect[T any](iter FunctionalIterator[T]) ([]T, error) {
 	var result []T
-	for iter.HasNext() {
-		value, err := iter.Next()
-		if err != nil {
+	for {
+		item, err, ok := iter()
+		if !ok {
+			break
+		} else if err != nil {
 			return nil, err
 		}
-		result = append(result, value)
+		result = append(result, item)
 	}
 	return result, nil
+}
+
+// TODO: Replace all uses of [Iterator] with [FunctionalIterator] and then rename to [Iterator].
+type FunctionalIterator[T any] func() (value T, err error, ok bool)
+
+func ToFunctionalIterator[T any](iter Iterator[T]) FunctionalIterator[T] {
+	return func() (T, error, bool) {
+		if iter.HasNext() {
+			item, err := iter.Next()
+			return item, err, true
+		}
+		var empty T
+		return empty, nil, false
+	}
 }

--- a/lib/iterator/iterator_test.go
+++ b/lib/iterator/iterator_test.go
@@ -7,30 +7,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type errorIterator struct{}
-
-func (errorIterator) HasNext() bool { return true }
-
-func (errorIterator) Next() (int, error) { return 0, fmt.Errorf("error in Next()") }
+func errorIterator() FunctionalIterator[int] {
+	return func() (int, error, bool) {
+		return 0, fmt.Errorf("---==[ ERROR ]==---"), true
+	}
+}
 
 func TestCollect(t *testing.T) {
 	{
 		// Empty iterator.
 		iter := ForSlice([]int{})
-		items, err := Collect(iter)
+		items, err := Collect(ToFunctionalIterator(iter))
 		assert.NoError(t, err)
 		assert.Empty(t, items)
 	}
 	{
 		// Non-empty iterator.
 		iter := ForSlice([]int{1, 2, 3, 4})
-		items, err := Collect(iter)
+		items, err := Collect(ToFunctionalIterator(iter))
 		assert.NoError(t, err)
 		assert.Equal(t, items, []int{1, 2, 3, 4})
 	}
 	{
-		// When [Iterator.Next] throws an error.
-		_, err := Collect(errorIterator{})
-		assert.ErrorContains(t, err, "error in Next()")
+		// An iterator that returns an error.
+		_, err := Collect(errorIterator())
+		assert.ErrorContains(t, err, "---==[ ERROR ]==---")
 	}
 }

--- a/lib/iterator/slice_test.go
+++ b/lib/iterator/slice_test.go
@@ -16,7 +16,7 @@ func TestSliceIterator(t *testing.T) {
 	}
 	{
 		// One empty slice
-		items, err := Collect(ForSlice([]string{}))
+		items, err := Collect(ToFunctionalIterator(ForSlice([]string{})))
 		assert.NoError(t, err)
 		assert.Empty(t, items)
 	}
@@ -51,7 +51,7 @@ func TestSliceIterator(t *testing.T) {
 }
 
 func TestOnce(t *testing.T) {
-	items, err := Collect(Once(103))
+	items, err := Collect(ToFunctionalIterator(Once(103)))
 	assert.NoError(t, err)
 	assert.Equal(t, []int{103}, items)
 }

--- a/sources/postgres/adapter/transformer_test.go
+++ b/sources/postgres/adapter/transformer_test.go
@@ -41,7 +41,7 @@ func TestDebeziumTransformer(t *testing.T) {
 			PostgresAdapter{table: table},
 			iterator.ForSlice([][]transformer.Row{}),
 		)
-		results, err := iterator.Collect(dbzTransformer)
+		results, err := iterator.Collect(iterator.ToFunctionalIterator(dbzTransformer))
 		assert.NoError(t, err)
 		assert.Empty(t, results)
 	}
@@ -52,7 +52,7 @@ func TestDebeziumTransformer(t *testing.T) {
 			PostgresAdapter{table: table},
 			&ErrorRowIterator{},
 		)
-		_, err := iterator.Collect(dbzTransformer)
+		_, err := iterator.Collect(iterator.ToFunctionalIterator(dbzTransformer))
 		assert.ErrorContains(t, err, "mock error")
 	}
 
@@ -72,7 +72,7 @@ func TestDebeziumTransformer(t *testing.T) {
 			}),
 		)
 
-		results, err := iterator.Collect(dbzTransformer)
+		results, err := iterator.Collect(iterator.ToFunctionalIterator(dbzTransformer))
 		assert.NoError(t, err)
 		assert.Len(t, results, 2)
 
@@ -122,7 +122,7 @@ func TestDebeziumTransformer_NilOptionalSchema(t *testing.T) {
 		iterator.Once([]transformer.Row{rowData}),
 	)
 
-	results, err := iterator.Collect(dbzTransformer)
+	results, err := iterator.Collect(iterator.ToFunctionalIterator(dbzTransformer))
 	assert.NoError(t, err)
 	assert.Len(t, results, 1)
 	rows := results[0]


### PR DESCRIPTION
Go version 1.23 will likely ship with [built-in iterator support](https://go.dev/wiki/RangefuncExperiment). Version 1.22 has iterators but they are disabled unless you pass in a `GOEXPERIMENT ` flag. Switching from struct-based iterators to functional iterators will bring us more in-line with the proposed iterators so that we can switch to them in Go 1.23, plus they require less boilerplate since you don't have to implement both `Next()` and `HasNext()` methods.