### PR TITLE
[debeziuim] Kill `VariableScaleDecimal`

### DIFF
--- a/lib/debezium/converters/decimal.go
+++ b/lib/debezium/converters/decimal.go
@@ -64,11 +64,6 @@ func (VariableNumericConverter) ToField(name string) debezium.Field {
 	}
 }
 
-type VariableScaleDecimal struct {
-	Scale int32  `json:"scale"`
-	Value []byte `json:"value"`
-}
-
 func (VariableNumericConverter) Convert(value any) (any, error) {
 	stringValue, ok := value.(string)
 	if !ok {
@@ -76,8 +71,8 @@ func (VariableNumericConverter) Convert(value any) (any, error) {
 	}
 
 	scale := getScale(stringValue)
-	return VariableScaleDecimal{
-		Scale: int32(scale),
-		Value: debezium.EncodeDecimal(stringValue, scale),
+	return map[string]any{
+		"scale": int32(scale),
+		"value": debezium.EncodeDecimal(stringValue, scale),
 	}, nil
 }

--- a/lib/debezium/converters/decimal_test.go
+++ b/lib/debezium/converters/decimal_test.go
@@ -104,12 +104,9 @@ func TestVariableNumericConverter_Convert(t *testing.T) {
 		// Happy path
 		converted, err := converter.Convert("12.34")
 		assert.NoError(t, err)
-		convertedMap, ok := converted.(VariableScaleDecimal)
-		assert.True(t, ok)
-		assert.Equal(t, VariableScaleDecimal{Scale: 2, Value: []byte{0x4, 0xd2}}, convertedMap)
-
-		actualValue := debezium.DecodeDecimal(convertedMap.Value, nil, int(convertedMap.Scale))
+		assert.Equal(t, map[string]any{"scale": int32(2), "value": []byte{0x4, 0xd2}}, converted)
+		actualValue, err := converter.ToField("").DecodeDebeziumVariableDecimal(converted)
 		assert.NoError(t, err)
-		assert.Equal(t, "12.34", fmt.Sprint(actualValue))
+		assert.Equal(t, "12.34", actualValue.String())
 	}
 }

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/artie-labs/reader/lib/debezium/converters"
 	"github.com/artie-labs/reader/lib/postgres"
 	"github.com/artie-labs/reader/lib/postgres/schema"
 	"github.com/artie-labs/transfer/lib/debezium"
@@ -229,7 +228,7 @@ func TestValueConverterForType_Convert(t *testing.T) {
 			name:          "numeric (postgres.Numeric) - variable numeric",
 			col:           schema.Column{Name: "variable_numeric_col", Type: schema.VariableNumeric},
 			value:         "123.98",
-			expectedValue: converters.VariableScaleDecimal{Scale: 2, Value: []byte{0x30, 0x6e}},
+			expectedValue: map[string]any{"scale": 2, "value": []byte{0x30, 0x6e}},
 		},
 		{
 			name:          "string",

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -228,7 +228,7 @@ func TestValueConverterForType_Convert(t *testing.T) {
 			name:          "numeric (postgres.Numeric) - variable numeric",
 			col:           schema.Column{Name: "variable_numeric_col", Type: schema.VariableNumeric},
 			value:         "123.98",
-			expectedValue: map[string]any{"scale": 2, "value": []byte{0x30, 0x6e}},
+			expectedValue: map[string]any{"scale": int32(2), "value": []byte{0x30, 0x6e}},
 		},
 		{
 			name:          "string",


### PR DESCRIPTION
By returning a map instead of a struct we can test the output of `VariableNumericConverter.Convert` using `Field.DecodeDebeziumVariableDecimal`.