### PR TITLE
Use `%q` instead of `"%s"`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -130,7 +130,7 @@ func (s *Settings) Validate() error {
 			return fmt.Errorf("postgres validation failed: %w", err)
 		}
 	default:
-		return fmt.Errorf("invalid source: '%s'", s.Source)
+		return fmt.Errorf("invalid source: %q", s.Source)
 	}
 
 	switch s.Destination {
@@ -167,7 +167,7 @@ func (s *Settings) Validate() error {
 			return fmt.Errorf("transfer mode must be replication")
 		}
 	default:
-		return fmt.Errorf("invalid destination: '%s'", s.Destination)
+		return fmt.Errorf("invalid destination: %q", s.Destination)
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,12 +38,12 @@ func TestSettings_Validate(t *testing.T) {
 		{
 			name:        "nil source",
 			settings:    &Settings{},
-			expectedErr: "invalid source: ''",
+			expectedErr: `invalid source: ""`,
 		},
 		{
 			name:        "invalid source",
 			settings:    &Settings{Source: "foo"},
-			expectedErr: "invalid source: 'foo'",
+			expectedErr: `invalid source: "foo"`,
 		},
 		{
 			name: "nil dynamodb",
@@ -56,12 +56,12 @@ func TestSettings_Validate(t *testing.T) {
 		{
 			name:        "nil destination",
 			settings:    &Settings{Source: SourceDynamo, DynamoDB: dynamoDBCfg()},
-			expectedErr: "invalid destination: ''",
+			expectedErr: `invalid destination: ""`,
 		},
 		{
 			name:        "invalid destination",
 			settings:    &Settings{Source: SourceDynamo, DynamoDB: dynamoDBCfg(), Destination: "foo"},
-			expectedErr: "invalid destination: 'foo'",
+			expectedErr: `invalid destination: "foo"`,
 		},
 		{
 			name:        "nil kafka",

--- a/lib/debezium/converters/bit.go
+++ b/lib/debezium/converters/bit.go
@@ -24,7 +24,7 @@ func (BitConverter) Convert(value any) (any, error) {
 		} else if stringValue == "1" {
 			return true, nil
 		}
-		return nil, fmt.Errorf(`string value "%s" is not in ["0", "1"]`, value)
+		return nil, fmt.Errorf(`string value %q is not in ["0", "1"]`, value)
 	}
 	return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
 }

--- a/lib/debezium/transformer/transformer.go
+++ b/lib/debezium/transformer/transformer.go
@@ -131,14 +131,14 @@ func convertRow(valueConverters map[string]converters.ValueConverter, row Row) (
 	for key, value := range row {
 		valueConverter, isOk := valueConverters[key]
 		if !isOk {
-			return nil, fmt.Errorf(`failed to get ValueConverter for key "%s"`, key)
+			return nil, fmt.Errorf("failed to get ValueConverter for key %q", key)
 		}
 
 		if value != nil {
 			var err error
 			value, err = valueConverter.Convert(value)
 			if err != nil {
-				return nil, fmt.Errorf(`failed to convert row value for key "%s": %w`, key, err)
+				return nil, fmt.Errorf("failed to convert row value for key %q: %w", key, err)
 			}
 		}
 

--- a/lib/mysql/scanner/scanner.go
+++ b/lib/mysql/scanner/scanner.go
@@ -39,49 +39,49 @@ func (s scanAdapter) ParsePrimaryKeyValue(columnName string, value string) (any,
 	case schema.TinyInt:
 		intValue, err := strconv.ParseInt(value, 10, 8)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a tinyint: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a tinyint: %w", value, err)
 		}
 		return int8(intValue), nil
 	case schema.SmallInt:
 		intValue, err := strconv.ParseInt(value, 10, 16)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a smallint: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a smallint: %w", value, err)
 		}
 		return int16(intValue), nil
 	case schema.MediumInt:
 		intValue, err := strconv.ParseInt(value, 10, 24)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a mediumint: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a mediumint: %w", value, err)
 		}
 		return int32(intValue), nil
 	case schema.Int:
 		intValue, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to an int: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to an int: %w", value, err)
 		}
 		return int32(intValue), nil
 	case schema.BigInt:
 		intValue, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a bigint: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a bigint: %w", value, err)
 		}
 		return intValue, nil
 	case schema.Bit, schema.Boolean:
 		boolValue, err := strconv.ParseBool(value)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a bool: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a bool: %w", value, err)
 		}
 		return boolValue, nil
 	case schema.Float:
 		floatValue, err := strconv.ParseFloat(value, 32)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a float: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a float: %w", value, err)
 		}
 		return float32(floatValue), nil
 	case schema.Double:
 		floatValue, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a double: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a double: %w", value, err)
 		}
 		return floatValue, nil
 	case schema.DateTime, schema.Timestamp:
@@ -93,14 +93,14 @@ func (s scanAdapter) ParsePrimaryKeyValue(columnName string, value string) (any,
 	case schema.Year:
 		intValue, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a year: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a year: %w", value, err)
 		}
 		// MySQL only supports years from 1901 to 2155
 		// https://dev.mysql.com/doc/refman/8.3/en/year.html
 		if intValue < 1901 {
-			return nil, fmt.Errorf(`unable to convert "%s" to a year: value must be >= 1901`, value)
+			return nil, fmt.Errorf("unable to convert %q to a year: value must be >= 1901", value)
 		} else if intValue > 2155 {
-			return nil, fmt.Errorf(`unable to convert "%s" to a year: value must be <= 2155`, value)
+			return nil, fmt.Errorf("unable to convert %q to a year: value must be <= 2155", value)
 		}
 		return int16(intValue), nil
 	case

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -49,10 +49,10 @@ func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.Scann
 	for _, key := range table.PrimaryKeys {
 		column, err := column.GetColumnByName(columns, key)
 		if err != nil {
-			return nil, fmt.Errorf("missing column with name: %s", key)
+			return nil, fmt.Errorf("missing column with name: %q", key)
 		}
 		if !slices.Contains(supportedPrimaryKeyDataType, column.Type) {
-			return nil, fmt.Errorf("DataType(%d) for column '%s' is not supported for use as a primary key", column.Type, column.Name)
+			return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", column.Type, column.Name)
 		}
 	}
 
@@ -74,49 +74,49 @@ type scanAdapter struct {
 func (s scanAdapter) ParsePrimaryKeyValue(columnName string, value string) (any, error) {
 	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
 	if columnIdx < 0 {
-		return nil, fmt.Errorf("primary key column does not exist: %s", columnName)
+		return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
 	}
 	column := s.columns[columnIdx]
 
 	if !slices.Contains(supportedPrimaryKeyDataType, column.Type) {
-		return nil, fmt.Errorf("DataType(%d) for column '%s' is not supported for use as a primary key", column.Type, column.Name)
+		return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", column.Type, column.Name)
 	}
 
 	switch column.Type {
 	case schema.Boolean:
 		boolValue, err := strconv.ParseBool(value)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a bool: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a bool: %w", value, err)
 		}
 		return boolValue, nil
 	case schema.Int16:
 		intValue, err := strconv.ParseInt(value, 10, 16)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to an int16: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to an int16: %w", value, err)
 		}
 		return int16(intValue), nil
 	case schema.Int32:
 		intValue, err := strconv.ParseInt(value, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to an int32: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to an int32: %w", value, err)
 		}
 		return int32(intValue), nil
 	case schema.Int64:
 		intValue, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to an int64: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to an int64: %w", value, err)
 		}
 		return intValue, nil
 	case schema.Real:
 		floatValue, err := strconv.ParseFloat(value, 32)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a float32: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a float32: %w", value, err)
 		}
 		return float32(floatValue), nil
 	case schema.Double:
 		floatValue, err := strconv.ParseFloat(value, 64)
 		if err != nil {
-			return nil, fmt.Errorf(`unable to convert "%s" to a float64: %w`, value, err)
+			return nil, fmt.Errorf("unable to convert %q to a float64: %w", value, err)
 		}
 		return floatValue, nil
 	case
@@ -146,9 +146,9 @@ func castColumn(col schema.Column) string {
 		// If we don't convert `time with time zone` to UTC we end up with strings like `10:23:54-02`
 		// And pgtype.Time doesn't parse the offset propertly.
 		// See https://github.com/jackc/pgx/issues/1940
-		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS "%s"`, colName, col.Name)
+		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS %q`, colName, col.Name)
 	case schema.Array:
-		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as "%s"`, colName, col.Name)
+		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as %q`, colName, col.Name)
 	default:
 		return colName
 	}

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -82,7 +82,7 @@ func TestScanAdapter_ParsePrimaryKeyValue(t *testing.T) {
 		// Column does not exist
 		adapter := scanAdapter{columns: []schema.Column{{Name: "bar"}}}
 		_, err := adapter.ParsePrimaryKeyValue("foo", "1234")
-		assert.ErrorContains(t, err, "primary key column does not exist: foo")
+		assert.ErrorContains(t, err, `primary key column does not exist: "foo"`)
 	}
 
 	testCases := []struct {
@@ -96,7 +96,7 @@ func TestScanAdapter_ParsePrimaryKeyValue(t *testing.T) {
 			name:        "unsupported data type",
 			dataType:    schema.Array,
 			value:       "1234",
-			expectedErr: "DataType(21) for column 'col' is not supported for use as a primary key",
+			expectedErr: `DataType(21) for column "col" is not supported for use as a primary key`,
 		},
 		{
 			name:        "boolean - malformed",

--- a/lib/rdbms/column/column.go
+++ b/lib/rdbms/column/column.go
@@ -41,7 +41,7 @@ func FilterOutExcludedColumns[T ~int, O any](columns []Column[T, O], excludeName
 	for _, column := range columns {
 		if slices.Contains(excludeNames, column.Name) {
 			if slices.Contains(primaryKeys, column.Name) {
-				return nil, fmt.Errorf(`cannot exclude primary key column "%s""`, column.Name)
+				return nil, fmt.Errorf("cannot exclude primary key column %q", column.Name)
 			}
 		} else {
 			result = append(result, column)

--- a/main.go
+++ b/main.go
@@ -97,12 +97,12 @@ func main() {
 
 	destinationWriter, err := buildDestinationWriter(ctx, cfg, statsD)
 	if err != nil {
-		logger.Fatal(fmt.Sprintf("Failed to init '%s' destination writer", cfg.Destination), slog.Any("err", err))
+		logger.Fatal(fmt.Sprintf("Failed to init %q destination writer", cfg.Destination), slog.Any("err", err))
 	}
 
 	source, isStreamingMode, err := buildSource(cfg)
 	if err != nil {
-		logger.Fatal(fmt.Sprintf("Failed to init '%s' source", cfg.Source), slog.Any("err", err))
+		logger.Fatal(fmt.Sprintf("Failed to init %q source", cfg.Source), slog.Any("err", err))
 	}
 	defer source.Close()
 


### PR DESCRIPTION
Just learned about [%q](https://pkg.go.dev/fmt#:~:text=%25q%09a%20double%2Dquoted%20string%20safely%20escaped%20with%20Go%20syntax) which prints strings inside of double quotes.