### PR TITLE
Upgrade Artie Transfer dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
-	github.com/artie-labs/transfer v1.24.7
+	github.com/artie-labs/transfer v1.24.10
 	github.com/aws/aws-sdk-go v1.44.327
 	github.com/aws/aws-sdk-go-v2 v1.18.1
 	github.com/aws/aws-sdk-go-v2/config v1.18.19

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/apache/thrift v0.0.0-20181112125854-24918abba929/go.mod h1:cp2SuWMxlE
 github.com/apache/thrift v0.14.2/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
-github.com/artie-labs/transfer v1.24.7 h1:baQr09Jc2Q56fB5LBNWVPalUGP2LTOshW4HFx919LJI=
-github.com/artie-labs/transfer v1.24.7/go.mod h1:mlDGYVa9CH93Rrcsh2bxrZW6HxSG65lnUjSOot8+oIc=
+github.com/artie-labs/transfer v1.24.10 h1:hP3U83vYBP/ljR0dUzcOPlZUhB6UaKeNEbREcSgLLnw=
+github.com/artie-labs/transfer v1.24.10/go.mod h1:mlDGYVa9CH93Rrcsh2bxrZW6HxSG65lnUjSOot8+oIc=
 github.com/aws/aws-sdk-go v1.30.19/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.44.327 h1:ZS8oO4+7MOBLhkdwIhgtVeDzCeWOlTfKJS7EgggbIEY=
 github.com/aws/aws-sdk-go v1.44.327/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=


### PR DESCRIPTION
This will allow us to pick up the new BigQuery dedupe