### PR TITLE
Rename database functions to start with `Fetch` instead of `Get`

### DIFF
--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -3,9 +3,10 @@ package mssql
 import (
 	"database/sql"
 	"fmt"
-	"github.com/artie-labs/transfer/clients/mssql/dialect"
 	"slices"
 	"strings"
+
+	"github.com/artie-labs/transfer/clients/mssql/dialect"
 
 	"github.com/artie-labs/reader/lib/mssql/parse"
 	"github.com/artie-labs/reader/lib/mssql/schema"
@@ -47,7 +48,7 @@ func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.Scann
 		}
 	}
 
-	primaryKeyBounds, err := table.GetPrimaryKeysBounds(db)
+	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/mssql/schema/schema.go
+++ b/lib/mssql/schema/schema.go
@@ -50,16 +50,16 @@ type Opts struct {
 type Column = column.Column[DataType, Opts]
 
 const describeTableQuery = `
-SELECT 
+SELECT
     COLUMN_NAME,
     DATA_TYPE,
     NUMERIC_PRECISION,
     NUMERIC_SCALE,
     DATETIME_PRECISION
-FROM 
+FROM
     INFORMATION_SCHEMA.COLUMNS
-WHERE 
-    TABLE_SCHEMA = ? AND 
+WHERE
+    TABLE_SCHEMA = ? AND
     TABLE_NAME = ?;
 `
 
@@ -168,22 +168,22 @@ func ParseColumnDataType(colKind string, precision, scale, datetimePrecision *in
 }
 
 const pkQuery = `
-SELECT 
+SELECT
     c.COLUMN_NAME
-FROM 
+FROM
     INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
-    JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu 
+    JOIN INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE ccu
         ON tc.CONSTRAINT_NAME = ccu.CONSTRAINT_NAME
-    JOIN INFORMATION_SCHEMA.COLUMNS c 
-        ON c.TABLE_NAME = ccu.TABLE_NAME 
+    JOIN INFORMATION_SCHEMA.COLUMNS c
+        ON c.TABLE_NAME = ccu.TABLE_NAME
         AND c.COLUMN_NAME = ccu.COLUMN_NAME
-WHERE 
-    tc.TABLE_SCHEMA = ? 
+WHERE
+    tc.TABLE_SCHEMA = ?
     AND tc.TABLE_NAME = ?
     AND tc.CONSTRAINT_TYPE = 'PRIMARY KEY';
 `
 
-func GetPrimaryKeys(db *sql.DB, schema, table string) ([]string, error) {
+func FetchPrimaryKeys(db *sql.DB, schema, table string) ([]string, error) {
 	query := strings.TrimSpace(pkQuery)
 	rows, err := db.Query(query, mssql.VarChar(schema), mssql.VarChar(table))
 	if err != nil {
@@ -250,7 +250,7 @@ func getPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column,
 	return result, nil
 }
 
-func GetPrimaryKeysBounds(db *sql.DB, schema, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
+func FetchPrimaryKeysBounds(db *sql.DB, schema, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
 	minValues, err := getPrimaryKeyValues(db, schema, table, primaryKeys, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve lower bounds for primary keys: %w", err)

--- a/lib/mssql/schema/schema.go
+++ b/lib/mssql/schema/schema.go
@@ -227,7 +227,7 @@ func buildPkValuesQuery(keys []Column, schema string, tableName string, desc boo
 	)
 }
 
-func getPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column, descending bool) ([]any, error) {
+func fetchPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column, descending bool) ([]any, error) {
 	result := make([]any, len(primaryKeys))
 	resultPtrs := make([]any, len(primaryKeys))
 	for i := range result {
@@ -251,12 +251,12 @@ func getPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column,
 }
 
 func FetchPrimaryKeysBounds(db *sql.DB, schema, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
-	minValues, err := getPrimaryKeyValues(db, schema, table, primaryKeys, false)
+	minValues, err := fetchPrimaryKeyValues(db, schema, table, primaryKeys, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve lower bounds for primary keys: %w", err)
 	}
 
-	maxValues, err := getPrimaryKeyValues(db, schema, table, primaryKeys, true)
+	maxValues, err := fetchPrimaryKeyValues(db, schema, table, primaryKeys, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve upper bounds for primary keys: %w", err)
 	}

--- a/lib/mssql/table.go
+++ b/lib/mssql/table.go
@@ -37,7 +37,7 @@ func LoadTable(db *sql.DB, _schema string, name string) (*Table, error) {
 		return nil, fmt.Errorf("failed to describe table %s.%s: %w", tbl.Schema, tbl.Name, err)
 	}
 
-	primaryKeys, err := schema.GetPrimaryKeys(db, tbl.Schema, tbl.Name)
+	primaryKeys, err := schema.FetchPrimaryKeys(db, tbl.Schema, tbl.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve primary keys: %w", err)
 	}
@@ -47,13 +47,13 @@ func LoadTable(db *sql.DB, _schema string, name string) (*Table, error) {
 	return tbl, nil
 }
 
-func (t *Table) GetPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
+func (t *Table) FetchPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
 	keyColumns, err := column.GetColumnsByName(t.Columns(), t.PrimaryKeys())
 	if err != nil {
 		return nil, fmt.Errorf("missing primary key columns: %w", err)
 	}
 
-	primaryKeysBounds, err := schema.GetPrimaryKeysBounds(db, t.Schema, t.Name, keyColumns)
+	primaryKeysBounds, err := schema.FetchPrimaryKeysBounds(db, t.Schema, t.Name, keyColumns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve bounds for primary keys: %w", err)
 	}

--- a/lib/mysql/scanner/scanner.go
+++ b/lib/mysql/scanner/scanner.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewScanner(db *sql.DB, table mysql.Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-	primaryKeyBounds, err := table.GetPrimaryKeysBounds(db)
+	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/mysql/schema/schema.go
+++ b/lib/mysql/schema/schema.go
@@ -228,7 +228,7 @@ WHERE table_constraints.constraint_type='PRIMARY KEY'
   AND table_constraints.table_name=?
 `
 
-func GetPrimaryKeys(db *sql.DB, table string) ([]string, error) {
+func FetchPrimaryKeys(db *sql.DB, table string) ([]string, error) {
 	query := strings.TrimSpace(primaryKeysQuery)
 	rows, err := db.Query(query, table)
 	if err != nil {
@@ -272,7 +272,7 @@ func buildPkValuesQuery(keys []Column, tableName string, descending bool) string
 	)
 }
 
-func getPrimaryKeyValues(db *sql.DB, table string, primaryKeys []Column, descending bool) ([]any, error) {
+func fetchPrimaryKeyValues(db *sql.DB, table string, primaryKeys []Column, descending bool) ([]any, error) {
 	result := make([]any, len(primaryKeys))
 	resultPtrs := make([]any, len(primaryKeys))
 	for i := range result {
@@ -309,7 +309,7 @@ func getPrimaryKeyValues(db *sql.DB, table string, primaryKeys []Column, descend
 	return result, nil
 }
 
-func GetPrimaryKeysBounds(db *sql.DB, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
+func FetchPrimaryKeysBounds(db *sql.DB, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
 	minValues, err := getPrimaryKeyValues(db, table, primaryKeys, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve lower bounds for primary keys: %w", err)

--- a/lib/mysql/schema/schema.go
+++ b/lib/mysql/schema/schema.go
@@ -310,12 +310,12 @@ func fetchPrimaryKeyValues(db *sql.DB, table string, primaryKeys []Column, desce
 }
 
 func FetchPrimaryKeysBounds(db *sql.DB, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
-	minValues, err := getPrimaryKeyValues(db, table, primaryKeys, false)
+	minValues, err := fetchPrimaryKeyValues(db, table, primaryKeys, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve lower bounds for primary keys: %w", err)
 	}
 
-	maxValues, err := getPrimaryKeyValues(db, table, primaryKeys, true)
+	maxValues, err := fetchPrimaryKeyValues(db, table, primaryKeys, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve upper bounds for primary keys: %w", err)
 	}

--- a/lib/mysql/table.go
+++ b/lib/mysql/table.go
@@ -26,20 +26,20 @@ func LoadTable(db *sql.DB, name string) (*Table, error) {
 		return nil, fmt.Errorf("failed to describe table %q: %w", tbl.Name, err)
 	}
 
-	if tbl.PrimaryKeys, err = schema.GetPrimaryKeys(db, tbl.Name); err != nil {
+	if tbl.PrimaryKeys, err = schema.FetchPrimaryKeys(db, tbl.Name); err != nil {
 		return nil, fmt.Errorf("failed to retrieve primary keys: %w", err)
 	}
 
 	return tbl, nil
 }
 
-func (t *Table) GetPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
+func (t *Table) FetchPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
 	keyColumns, err := column.GetColumnsByName(t.Columns, t.PrimaryKeys)
 	if err != nil {
 		return nil, fmt.Errorf("missing primary key columns: %w", err)
 	}
 
-	primaryKeysBounds, err := schema.GetPrimaryKeysBounds(db, t.Name, keyColumns)
+	primaryKeysBounds, err := schema.FetchPrimaryKeysBounds(db, t.Name, keyColumns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve bounds for primary keys: %w", err)
 	}

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -56,7 +56,7 @@ func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.Scann
 		}
 	}
 
-	primaryKeyBounds, err := table.GetPrimaryKeysBounds(db)
+	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/postgres/schema/schema.go
+++ b/lib/postgres/schema/schema.go
@@ -176,7 +176,7 @@ JOIN   pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
 WHERE  i.indrelid = $1::regclass
 AND    i.indisprimary;`
 
-func GetPrimaryKeys(db *sql.DB, schema, table string) ([]string, error) {
+func FetchPrimaryKeys(db *sql.DB, schema, table string) ([]string, error) {
 	query := strings.TrimSpace(primaryKeysQuery)
 	rows, err := db.Query(query, pgx.Identifier{schema, table}.Sanitize())
 	if err != nil {
@@ -220,7 +220,7 @@ func buildPkValuesQuery(args buildPkValuesQueryArgs) string {
 		pgx.Identifier{args.Schema, args.TableName}.Sanitize(), strings.Join(fragments, ","))
 }
 
-func getPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column, descending bool) ([]any, error) {
+func fetchPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column, descending bool) ([]any, error) {
 	result := make([]any, len(primaryKeys))
 	resultPtrs := make([]any, len(primaryKeys))
 	for i := range result {
@@ -248,13 +248,13 @@ func getPrimaryKeyValues(db *sql.DB, schema, table string, primaryKeys []Column,
 	return result, nil
 }
 
-func GetPrimaryKeysBounds(db *sql.DB, schema, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
-	minValues, err := getPrimaryKeyValues(db, schema, table, primaryKeys, false)
+func FetchPrimaryKeysBounds(db *sql.DB, schema, table string, primaryKeys []Column) ([]primary_key.Bounds, error) {
+	minValues, err := fetchPrimaryKeyValues(db, schema, table, primaryKeys, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve lower bounds for primary keys: %w", err)
 	}
 
-	maxValues, err := getPrimaryKeyValues(db, schema, table, primaryKeys, true)
+	maxValues, err := fetchPrimaryKeyValues(db, schema, table, primaryKeys, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve upper bounds for primary keys: %w", err)
 	}

--- a/lib/postgres/table.go
+++ b/lib/postgres/table.go
@@ -29,20 +29,20 @@ func LoadTable(db *sql.DB, _schema string, name string) (*Table, error) {
 		return nil, fmt.Errorf("failed to describe table %s.%s: %w", tbl.Schema, tbl.Name, err)
 	}
 
-	if tbl.PrimaryKeys, err = schema.GetPrimaryKeys(db, tbl.Schema, tbl.Name); err != nil {
+	if tbl.PrimaryKeys, err = schema.FetchPrimaryKeys(db, tbl.Schema, tbl.Name); err != nil {
 		return nil, fmt.Errorf("failed to retrieve primary keys: %w", err)
 	}
 
 	return tbl, nil
 }
 
-func (t *Table) GetPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
+func (t *Table) FetchPrimaryKeysBounds(db *sql.DB) ([]primary_key.Key, error) {
 	keyColumns, err := column.GetColumnsByName(t.Columns, t.PrimaryKeys)
 	if err != nil {
 		return nil, fmt.Errorf("missing primary key columns: %w", err)
 	}
 
-	primaryKeysBounds, err := schema.GetPrimaryKeysBounds(db, t.Schema, t.Name, keyColumns)
+	primaryKeysBounds, err := schema.FetchPrimaryKeysBounds(db, t.Schema, t.Name, keyColumns)
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve bounds for primary keys: %w", err)
 	}


### PR DESCRIPTION
I started naming the schema functions prefixed with `Get` back before I knew that `Get` [wasn't idiomatic Go](https://go.dev/doc/effective_go#:~:text=it%27s%20neither%20idiomatic%20nor%20necessary%20to%20put%20Get%20into%20the%20getter%27s%20name), plus this makes it more obvious that a database call is going to be performed.