### PR TITLE
[Kafka] Update error assertion for MessageTooLargeError

### DIFF
--- a/lib/kafkalib/errors.go
+++ b/lib/kafkalib/errors.go
@@ -6,7 +6,12 @@ import (
 )
 
 func isExceedMaxMessageBytesErr(err error) bool {
-	return err != nil && errors.Is(err, kafka.MessageSizeTooLarge)
+	var e kafka.MessageTooLargeError
+	if err != nil && errors.As(err, &e) {
+		return true
+	}
+
+	return false
 }
 
 // isRetryableError - returns true if the error is retryable

--- a/lib/kafkalib/errors_test.go
+++ b/lib/kafkalib/errors_test.go
@@ -27,7 +27,7 @@ func TestIsExceedMaxMessageBytesErr(t *testing.T) {
 			expected: false,
 		},
 		{
-			err:      kafka.MessageSizeTooLarge,
+			err:      kafka.MessageTooLargeError{},
 			expected: true,
 		},
 	}

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -134,7 +134,6 @@ func (b *BatchWriter) Write(ctx context.Context, rawMsgs []lib.RawMessage) error
 				break
 			}
 
-			fmt.Println("kafkaErr: ", kafkaErr, isExceedMaxMessageBytesErr(kafkaErr))
 			if isExceedMaxMessageBytesErr(kafkaErr) {
 				slog.Info("Skipping this batch since the message size exceeded the server max")
 				kafkaErr = nil

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -134,6 +134,7 @@ func (b *BatchWriter) Write(ctx context.Context, rawMsgs []lib.RawMessage) error
 				break
 			}
 
+			fmt.Println("kafkaErr: ", kafkaErr, isExceedMaxMessageBytesErr(kafkaErr))
 			if isExceedMaxMessageBytesErr(kafkaErr) {
 				slog.Info("Skipping this batch since the message size exceeded the server max")
 				kafkaErr = nil


### PR DESCRIPTION
Using `errors.Is` is not capturing the MessageTooLarge error.

This is because the Kafka writer calls: https://github.com/segmentio/kafka-go/blob/ebca72eaee918d303c532feb7ff29afdcd8c2efa/writer.go#L634 which is: https://github.com/segmentio/kafka-go/blob/ebca72eaee918d303c532feb7ff29afdcd8c2efa/error.go#L644-L652

This returns the struct https://github.com/segmentio/kafka-go/blob/ebca72eaee918d303c532feb7ff29afdcd8c2efa/error.go#L644-L652


The tests in the SDK is also using `errors.As`: https://github.com/segmentio/kafka-go/blob/ebca72eaee918d303c532feb7ff29afdcd8c2efa/writer_test.go#L383-L385
