### PR TITLE
[MSSQL] To support date, time, datetime primary keys

### DIFF
--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -1,192 +1,192 @@
 package mssql
 
 import (
-    "database/sql"
-    "fmt"
-    "slices"
-    "strings"
-    "time"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
 
-    "github.com/artie-labs/transfer/clients/mssql/dialect"
+	"github.com/artie-labs/transfer/clients/mssql/dialect"
 
-    "github.com/artie-labs/reader/lib/mssql/parse"
-    "github.com/artie-labs/reader/lib/mssql/schema"
-    "github.com/artie-labs/reader/lib/rdbms"
-    "github.com/artie-labs/reader/lib/rdbms/column"
-    "github.com/artie-labs/reader/lib/rdbms/primary_key"
-    "github.com/artie-labs/reader/lib/rdbms/scan"
+	"github.com/artie-labs/reader/lib/mssql/parse"
+	"github.com/artie-labs/reader/lib/mssql/schema"
+	"github.com/artie-labs/reader/lib/rdbms"
+	"github.com/artie-labs/reader/lib/rdbms/column"
+	"github.com/artie-labs/reader/lib/rdbms/primary_key"
+	"github.com/artie-labs/reader/lib/rdbms/scan"
 )
 
 const (
-    TimeMicro      = "15:04:05.000000"
-    TimeNano       = "15:04:05.000000000"
-    DateTimeMicro  = "2006-01-02 15:04:05.000000"
-    DateTimeNano   = "2006-01-02 15:04:05.000000000"
-    DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
+	TimeMicro      = "15:04:05.000000"
+	TimeNano       = "15:04:05.000000000"
+	DateTimeMicro  = "2006-01-02 15:04:05.000000"
+	DateTimeNano   = "2006-01-02 15:04:05.000000000"
+	DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
 )
 
 func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-    for _, key := range table.PrimaryKeys() {
-        if _, err := column.ByName(columns, key); err != nil {
-            return nil, fmt.Errorf("missing column with name: %q", key)
-        }
-    }
+	for _, key := range table.PrimaryKeys() {
+		if _, err := column.ByName(columns, key); err != nil {
+			return nil, fmt.Errorf("missing column with name: %q", key)
+		}
+	}
 
-    primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
-    if err != nil {
-        return nil, err
-    }
+	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
+	if err != nil {
+		return nil, err
+	}
 
-    adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
-    return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
+	adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
+	return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
 }
 
 type scanAdapter struct {
-    schema    string
-    tableName string
-    columns   []schema.Column
+	schema    string
+	tableName string
+	columns   []schema.Column
 }
 
 func (s scanAdapter) ParsePrimaryKeyValueForOverrides(_ string, value string) (any, error) {
-    // We don't need to cast it at all.
-    return value, nil
+	// We don't need to cast it at all.
+	return value, nil
 }
 
 // parsePrimaryKeyValues - parse primary key values based on the column type.
 // This is needed because the MSSQL SDK does not support parsing `time.Time`, so we need to do it ourselves.
 func (s scanAdapter) parsePrimaryKeyValues(columnName string, value any) (any, error) {
-    columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
-    if columnIdx < 0 {
-        return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
-    }
-	
-    switch _columnType := s.columns[columnIdx].Type; _columnType {
-    case schema.Time:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(time.TimeOnly), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.TimeMicro:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(TimeMicro), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.TimeNano:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(TimeNano), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.Datetime2:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(time.DateTime), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.Datetime2Micro:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(DateTimeMicro), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.Datetime2Nano:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(DateTimeNano), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.DatetimeOffset:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(DateTimeOffset), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    default:
-        return value, nil
-    }
+	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
+	if columnIdx < 0 {
+		return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
+	}
+
+	switch _columnType := s.columns[columnIdx].Type; _columnType {
+	case schema.Time:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(time.TimeOnly), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.TimeMicro:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(TimeMicro), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.TimeNano:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(TimeNano), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.Datetime2:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(time.DateTime), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.Datetime2Micro:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(DateTimeMicro), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.Datetime2Nano:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(DateTimeNano), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.DatetimeOffset:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(DateTimeOffset), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	default:
+		return value, nil
+	}
 }
 
 func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
-    mssqlDialect := dialect.MSSQLDialect{}
-    colNames := make([]string, len(s.columns))
-    for idx, col := range s.columns {
-        colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
-    }
+	mssqlDialect := dialect.MSSQLDialect{}
+	colNames := make([]string, len(s.columns))
+	for idx, col := range s.columns {
+		colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
+	}
 
-    startingValues := make([]any, len(primaryKeys))
-    endingValues := make([]any, len(primaryKeys))
-    for i, pk := range primaryKeys {
-        pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
-        if err != nil {
-            return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
-        }
+	startingValues := make([]any, len(primaryKeys))
+	endingValues := make([]any, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
+		}
 
-        pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
-        if err != nil {
-            return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
-        }
+		pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
+		}
 
-        startingValues[i] = pkStartVal
-        endingValues[i] = pkEndVal
-    }
+		startingValues[i] = pkStartVal
+		endingValues[i] = pkEndVal
+	}
 
-    quotedKeyNames := make([]string, len(primaryKeys))
-    for i, key := range primaryKeys {
-        quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
-    }
+	quotedKeyNames := make([]string, len(primaryKeys))
+	for i, key := range primaryKeys {
+		quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
+	}
 
-    lowerBoundComparison := ">"
-    if isFirstBatch {
-        lowerBoundComparison = ">="
-    }
+	lowerBoundComparison := ">"
+	if isFirstBatch {
+		lowerBoundComparison = ">="
+	}
 
-    return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
-        // TOP
-        batchSize,
-        // SELECT
-        strings.Join(colNames, ","),
-        // FROM
-        mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
-        // WHERE (pk) > (123)
-        strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
-        strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
-        // ORDER BY
-        strings.Join(quotedKeyNames, ","),
-    ), slices.Concat(startingValues, endingValues), nil
+	return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
+		// TOP
+		batchSize,
+		// SELECT
+		strings.Join(colNames, ","),
+		// FROM
+		mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
+		// WHERE (pk) > (123)
+		strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
+		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
+		// ORDER BY
+		strings.Join(quotedKeyNames, ","),
+	), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {
-    for i, value := range values {
-        parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
-        if err != nil {
-            return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
-        }
+	for i, value := range values {
+		parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
+		if err != nil {
+			return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
+		}
 
-        values[i] = parsedValue
-    }
+		values[i] = parsedValue
+	}
 
-    return nil
+	return nil
 }

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -1,136 +1,223 @@
 package mssql
 
 import (
-	"database/sql"
-	"fmt"
-	"slices"
-	"strings"
+    "database/sql"
+    "fmt"
+    "slices"
+    "strings"
+    "time"
 
-	"github.com/artie-labs/transfer/clients/mssql/dialect"
+    "github.com/artie-labs/transfer/clients/mssql/dialect"
 
-	"github.com/artie-labs/reader/lib/mssql/parse"
-	"github.com/artie-labs/reader/lib/mssql/schema"
-	"github.com/artie-labs/reader/lib/rdbms"
-	"github.com/artie-labs/reader/lib/rdbms/column"
-	"github.com/artie-labs/reader/lib/rdbms/primary_key"
-	"github.com/artie-labs/reader/lib/rdbms/scan"
+    "github.com/artie-labs/reader/lib/mssql/parse"
+    "github.com/artie-labs/reader/lib/mssql/schema"
+    "github.com/artie-labs/reader/lib/rdbms"
+    "github.com/artie-labs/reader/lib/rdbms/column"
+    "github.com/artie-labs/reader/lib/rdbms/primary_key"
+    "github.com/artie-labs/reader/lib/rdbms/scan"
+)
+
+const (
+    TimeMicro      = "15:04:05.000000"
+    TimeNano       = "15:04:05.000000000"
+    DateTimeMicro  = "2006-01-02 15:04:05.000000"
+    DateTimeNano   = "2006-01-02 15:04:05.000000000"
+    DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
 )
 
 var supportedPrimaryKeyDataType = []schema.DataType{
-	schema.Bit,
-	schema.Bytes,
-	schema.Int16,
-	schema.Int32,
-	schema.Int64,
-	schema.Numeric,
-	schema.Float,
-	schema.Money,
-	schema.Date,
-	schema.String,
-	schema.Time,
-	schema.TimeMicro,
-	schema.TimeNano,
-	schema.Datetime2,
-	schema.Datetime2Micro,
-	schema.Datetime2Nano,
-	schema.DatetimeOffset,
+    schema.Bit,
+    schema.Bytes,
+    schema.Int16,
+    schema.Int32,
+    schema.Int64,
+    schema.Numeric,
+    schema.Float,
+    schema.Money,
+    schema.Date,
+    schema.String,
+    schema.Time,
+    schema.TimeMicro,
+    schema.TimeNano,
+    schema.Datetime2,
+    schema.Datetime2Micro,
+    schema.Datetime2Nano,
+    schema.DatetimeOffset,
 }
 
 func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-	for _, key := range table.PrimaryKeys() {
-		_column, err := column.ByName(columns, key)
-		if err != nil {
-			return nil, fmt.Errorf("missing column with name: %q", key)
-		}
+    for _, key := range table.PrimaryKeys() {
+        _column, err := column.ByName(columns, key)
+        if err != nil {
+            return nil, fmt.Errorf("missing column with name: %q", key)
+        }
 
-		if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
-			return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
-		}
-	}
+        if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
+            return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
+        }
+    }
 
-	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
-	if err != nil {
-		return nil, err
-	}
+    primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
+    if err != nil {
+        return nil, err
+    }
 
-	adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
-	return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
+    adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
+    return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
 }
 
 type scanAdapter struct {
-	schema    string
-	tableName string
-	columns   []schema.Column
+    schema    string
+    tableName string
+    columns   []schema.Column
 }
 
-func (s scanAdapter) ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error) {
-	// TODO: Implement Date, Time, Datetime for primary key types.
-	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
-	if columnIdx < 0 {
-		return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
-	}
+func (s scanAdapter) ParsePrimaryKeyValueForOverrides(_ string, value string) (any, error) {
+    // We don't need to cast it at all.
+    return value, nil
+}
 
-	_column := s.columns[columnIdx]
-	if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
-		return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
-	}
+func (s scanAdapter) parsePrimaryKeyValues(columnName string, value any) (any, error) {
+    columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
+    if columnIdx < 0 {
+        return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
+    }
 
-	switch _column.Type {
-	case schema.Bit:
-		return value == "1", nil
-	default:
-		return value, nil
-	}
+    _column := s.columns[columnIdx]
+    if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
+        return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
+    }
+
+    switch _column.Type {
+    case schema.Time:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(time.TimeOnly), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.TimeMicro:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(TimeMicro), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.TimeNano:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(TimeNano), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.Datetime2:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(time.DateTime), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.Datetime2Micro:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(DateTimeMicro), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.Datetime2Nano:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(DateTimeNano), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.DatetimeOffset:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(DateTimeOffset), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    default:
+        return value, nil
+    }
 }
 
 func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
-	mssqlDialect := dialect.MSSQLDialect{}
-	colNames := make([]string, len(s.columns))
-	for idx, col := range s.columns {
-		colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
-	}
+    mssqlDialect := dialect.MSSQLDialect{}
+    colNames := make([]string, len(s.columns))
+    for idx, col := range s.columns {
+        colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
+    }
 
-	startingValues := make([]any, len(primaryKeys))
-	endingValues := make([]any, len(primaryKeys))
-	for i, pk := range primaryKeys {
-		startingValues[i] = pk.StartingValue
-		endingValues[i] = pk.EndingValue
-	}
+    startingValues := make([]any, len(primaryKeys))
+    endingValues := make([]any, len(primaryKeys))
+    for i, pk := range primaryKeys {
+        pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
+        if err != nil {
+            return "", nil, err
+        }
 
-	quotedKeyNames := make([]string, len(primaryKeys))
-	for i, key := range primaryKeys {
-		quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
-	}
+        pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
+        if err != nil {
+            return "", nil, err
+        }
 
-	lowerBoundComparison := ">"
-	if isFirstBatch {
-		lowerBoundComparison = ">="
-	}
+        fmt.Println("pkStartVal", pkStartVal)
+        fmt.Println("pkEndVal", pkEndVal)
 
-	return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
-		// TOP
-		batchSize,
-		// SELECT
-		strings.Join(colNames, ","),
-		// FROM
-		mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
-		// WHERE (pk) > (123)
-		strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
-		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
-		// ORDER BY
-		strings.Join(quotedKeyNames, ","),
-	), slices.Concat(startingValues, endingValues), nil
+        startingValues[i] = pkStartVal
+        endingValues[i] = pkEndVal
+    }
+
+    quotedKeyNames := make([]string, len(primaryKeys))
+    for i, key := range primaryKeys {
+        quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
+    }
+
+    lowerBoundComparison := ">"
+    if isFirstBatch {
+        lowerBoundComparison = ">="
+    }
+
+    return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
+        // TOP
+        batchSize,
+        // SELECT
+        strings.Join(colNames, ","),
+        // FROM
+        mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
+        // WHERE (pk) > (123)
+        strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
+        strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
+        // ORDER BY
+        strings.Join(quotedKeyNames, ","),
+    ), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {
-	for i, value := range values {
-		parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
-		if err != nil {
-			return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
-		}
+    for i, value := range values {
+        parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
+        if err != nil {
+            return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
+        }
 
-		values[i] = parsedValue
-	}
+        values[i] = parsedValue
+    }
 
-	return nil
+    return nil
 }

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -77,6 +77,8 @@ func (s scanAdapter) ParsePrimaryKeyValueForOverrides(_ string, value string) (a
 	return value, nil
 }
 
+// parsePrimaryKeyValues - parse primary key values based on the column type.
+// This is needed because the MSSQL SDK does not support parsing `time.Time`, so we need to do it ourselves.
 func (s scanAdapter) parsePrimaryKeyValues(columnName string, value any) (any, error) {
 	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
 	if columnIdx < 0 {

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -83,7 +83,7 @@ func (s scanAdapter) ParsePrimaryKeyValueForOverrides(columnName string, value s
 	}
 }
 
-func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any) {
+func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
 	mssqlDialect := dialect.MSSQLDialect{}
 	colNames := make([]string, len(s.columns))
 	for idx, col := range s.columns {
@@ -119,7 +119,7 @@ func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool
 		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
 		// ORDER BY
 		strings.Join(quotedKeyNames, ","),
-	), slices.Concat(startingValues, endingValues)
+	), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -141,12 +141,12 @@ func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool
 	for i, pk := range primaryKeys {
 		pkStartVal, err := s.encodePrimaryKeyValue(pk.Name, pk.StartingValue)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
+			return "", nil, fmt.Errorf("failed to encode start primary key val: %w", err)
 		}
 
 		pkEndVal, err := s.encodePrimaryKeyValue(pk.Name, pk.EndingValue)
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
+			return "", nil, fmt.Errorf("failed to encode end primary key val: %w", err)
 		}
 
 		startingValues[i] = pkStartVal

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -171,16 +171,13 @@ func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool
 	for i, pk := range primaryKeys {
 		pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
 		if err != nil {
-			return "", nil, err
+			return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
 		}
 
 		pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
 		if err != nil {
-			return "", nil, err
+			return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
 		}
-
-		fmt.Println("pkStartVal", pkStartVal)
-		fmt.Println("pkEndVal", pkEndVal)
 
 		startingValues[i] = pkStartVal
 		endingValues[i] = pkEndVal

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -1,223 +1,223 @@
 package mssql
 
 import (
-    "database/sql"
-    "fmt"
-    "slices"
-    "strings"
-    "time"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
 
-    "github.com/artie-labs/transfer/clients/mssql/dialect"
+	"github.com/artie-labs/transfer/clients/mssql/dialect"
 
-    "github.com/artie-labs/reader/lib/mssql/parse"
-    "github.com/artie-labs/reader/lib/mssql/schema"
-    "github.com/artie-labs/reader/lib/rdbms"
-    "github.com/artie-labs/reader/lib/rdbms/column"
-    "github.com/artie-labs/reader/lib/rdbms/primary_key"
-    "github.com/artie-labs/reader/lib/rdbms/scan"
+	"github.com/artie-labs/reader/lib/mssql/parse"
+	"github.com/artie-labs/reader/lib/mssql/schema"
+	"github.com/artie-labs/reader/lib/rdbms"
+	"github.com/artie-labs/reader/lib/rdbms/column"
+	"github.com/artie-labs/reader/lib/rdbms/primary_key"
+	"github.com/artie-labs/reader/lib/rdbms/scan"
 )
 
 const (
-    TimeMicro      = "15:04:05.000000"
-    TimeNano       = "15:04:05.000000000"
-    DateTimeMicro  = "2006-01-02 15:04:05.000000"
-    DateTimeNano   = "2006-01-02 15:04:05.000000000"
-    DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
+	TimeMicro      = "15:04:05.000000"
+	TimeNano       = "15:04:05.000000000"
+	DateTimeMicro  = "2006-01-02 15:04:05.000000"
+	DateTimeNano   = "2006-01-02 15:04:05.000000000"
+	DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
 )
 
 var supportedPrimaryKeyDataType = []schema.DataType{
-    schema.Bit,
-    schema.Bytes,
-    schema.Int16,
-    schema.Int32,
-    schema.Int64,
-    schema.Numeric,
-    schema.Float,
-    schema.Money,
-    schema.Date,
-    schema.String,
-    schema.Time,
-    schema.TimeMicro,
-    schema.TimeNano,
-    schema.Datetime2,
-    schema.Datetime2Micro,
-    schema.Datetime2Nano,
-    schema.DatetimeOffset,
+	schema.Bit,
+	schema.Bytes,
+	schema.Int16,
+	schema.Int32,
+	schema.Int64,
+	schema.Numeric,
+	schema.Float,
+	schema.Money,
+	schema.Date,
+	schema.String,
+	schema.Time,
+	schema.TimeMicro,
+	schema.TimeNano,
+	schema.Datetime2,
+	schema.Datetime2Micro,
+	schema.Datetime2Nano,
+	schema.DatetimeOffset,
 }
 
 func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-    for _, key := range table.PrimaryKeys() {
-        _column, err := column.ByName(columns, key)
-        if err != nil {
-            return nil, fmt.Errorf("missing column with name: %q", key)
-        }
+	for _, key := range table.PrimaryKeys() {
+		_column, err := column.ByName(columns, key)
+		if err != nil {
+			return nil, fmt.Errorf("missing column with name: %q", key)
+		}
 
-        if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
-            return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
-        }
-    }
+		if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
+			return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
+		}
+	}
 
-    primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
-    if err != nil {
-        return nil, err
-    }
+	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
+	if err != nil {
+		return nil, err
+	}
 
-    adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
-    return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
+	adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
+	return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
 }
 
 type scanAdapter struct {
-    schema    string
-    tableName string
-    columns   []schema.Column
+	schema    string
+	tableName string
+	columns   []schema.Column
 }
 
 func (s scanAdapter) ParsePrimaryKeyValueForOverrides(_ string, value string) (any, error) {
-    // We don't need to cast it at all.
-    return value, nil
+	// We don't need to cast it at all.
+	return value, nil
 }
 
 func (s scanAdapter) parsePrimaryKeyValues(columnName string, value any) (any, error) {
-    columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
-    if columnIdx < 0 {
-        return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
-    }
+	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
+	if columnIdx < 0 {
+		return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
+	}
 
-    _column := s.columns[columnIdx]
-    if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
-        return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
-    }
+	_column := s.columns[columnIdx]
+	if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
+		return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
+	}
 
-    switch _column.Type {
-    case schema.Time:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(time.TimeOnly), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.TimeMicro:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(TimeMicro), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.TimeNano:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(TimeNano), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.Datetime2:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(time.DateTime), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.Datetime2Micro:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(DateTimeMicro), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.Datetime2Nano:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(DateTimeNano), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    case schema.DatetimeOffset:
-        switch castedVal := value.(type) {
-        case time.Time:
-            return castedVal.Format(DateTimeOffset), nil
-        case string:
-            return castedVal, nil
-        default:
-            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-        }
-    default:
-        return value, nil
-    }
+	switch _column.Type {
+	case schema.Time:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(time.TimeOnly), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.TimeMicro:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(TimeMicro), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.TimeNano:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(TimeNano), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.Datetime2:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(time.DateTime), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.Datetime2Micro:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(DateTimeMicro), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.Datetime2Nano:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(DateTimeNano), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	case schema.DatetimeOffset:
+		switch castedVal := value.(type) {
+		case time.Time:
+			return castedVal.Format(DateTimeOffset), nil
+		case string:
+			return castedVal, nil
+		default:
+			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+		}
+	default:
+		return value, nil
+	}
 }
 
 func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
-    mssqlDialect := dialect.MSSQLDialect{}
-    colNames := make([]string, len(s.columns))
-    for idx, col := range s.columns {
-        colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
-    }
+	mssqlDialect := dialect.MSSQLDialect{}
+	colNames := make([]string, len(s.columns))
+	for idx, col := range s.columns {
+		colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
+	}
 
-    startingValues := make([]any, len(primaryKeys))
-    endingValues := make([]any, len(primaryKeys))
-    for i, pk := range primaryKeys {
-        pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
-        if err != nil {
-            return "", nil, err
-        }
+	startingValues := make([]any, len(primaryKeys))
+	endingValues := make([]any, len(primaryKeys))
+	for i, pk := range primaryKeys {
+		pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
+		if err != nil {
+			return "", nil, err
+		}
 
-        pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
-        if err != nil {
-            return "", nil, err
-        }
+		pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
+		if err != nil {
+			return "", nil, err
+		}
 
-        fmt.Println("pkStartVal", pkStartVal)
-        fmt.Println("pkEndVal", pkEndVal)
+		fmt.Println("pkStartVal", pkStartVal)
+		fmt.Println("pkEndVal", pkEndVal)
 
-        startingValues[i] = pkStartVal
-        endingValues[i] = pkEndVal
-    }
+		startingValues[i] = pkStartVal
+		endingValues[i] = pkEndVal
+	}
 
-    quotedKeyNames := make([]string, len(primaryKeys))
-    for i, key := range primaryKeys {
-        quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
-    }
+	quotedKeyNames := make([]string, len(primaryKeys))
+	for i, key := range primaryKeys {
+		quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
+	}
 
-    lowerBoundComparison := ">"
-    if isFirstBatch {
-        lowerBoundComparison = ">="
-    }
+	lowerBoundComparison := ">"
+	if isFirstBatch {
+		lowerBoundComparison = ">="
+	}
 
-    return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
-        // TOP
-        batchSize,
-        // SELECT
-        strings.Join(colNames, ","),
-        // FROM
-        mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
-        // WHERE (pk) > (123)
-        strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
-        strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
-        // ORDER BY
-        strings.Join(quotedKeyNames, ","),
-    ), slices.Concat(startingValues, endingValues), nil
+	return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
+		// TOP
+		batchSize,
+		// SELECT
+		strings.Join(colNames, ","),
+		// FROM
+		mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
+		// WHERE (pk) > (123)
+		strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
+		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
+		// ORDER BY
+		strings.Join(quotedKeyNames, ","),
+	), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {
-    for i, value := range values {
-        parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
-        if err != nil {
-            return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
-        }
+	for i, value := range values {
+		parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
+		if err != nil {
+			return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
+		}
 
-        values[i] = parsedValue
-    }
+		values[i] = parsedValue
+	}
 
-    return nil
+	return nil
 }

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -25,35 +25,10 @@ const (
 	DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
 )
 
-var supportedPrimaryKeyDataType = []schema.DataType{
-	schema.Bit,
-	schema.Bytes,
-	schema.Int16,
-	schema.Int32,
-	schema.Int64,
-	schema.Numeric,
-	schema.Float,
-	schema.Money,
-	schema.Date,
-	schema.String,
-	schema.Time,
-	schema.TimeMicro,
-	schema.TimeNano,
-	schema.Datetime2,
-	schema.Datetime2Micro,
-	schema.Datetime2Nano,
-	schema.DatetimeOffset,
-}
-
 func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
 	for _, key := range table.PrimaryKeys() {
-		_column, err := column.ByName(columns, key)
-		if err != nil {
+		if _, err := column.ByName(columns, key); err != nil {
 			return nil, fmt.Errorf("missing column with name: %q", key)
-		}
-
-		if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
-			return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
 		}
 	}
 

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -52,9 +52,9 @@ func (s scanAdapter) ParsePrimaryKeyValueForOverrides(_ string, value string) (a
 	return value, nil
 }
 
-// parsePrimaryKeyValues - parse primary key values based on the column type.
+// encodePrimaryKeyValue - encodes primary key values based on the column type.
 // This is needed because the MSSQL SDK does not support parsing `time.Time`, so we need to do it ourselves.
-func (s scanAdapter) parsePrimaryKeyValues(columnName string, value any) (any, error) {
+func (s scanAdapter) encodePrimaryKeyValue(columnName string, value any) (any, error) {
 	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
 	if columnIdx < 0 {
 		return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
@@ -139,12 +139,12 @@ func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool
 	startingValues := make([]any, len(primaryKeys))
 	endingValues := make([]any, len(primaryKeys))
 	for i, pk := range primaryKeys {
-		pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
+		pkStartVal, err := s.encodePrimaryKeyValue(pk.Name, pk.StartingValue)
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
 		}
 
-		pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
+		pkEndVal, err := s.encodePrimaryKeyValue(pk.Name, pk.EndingValue)
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
 		}

--- a/lib/mssql/scanner.go
+++ b/lib/mssql/scanner.go
@@ -1,197 +1,192 @@
 package mssql
 
 import (
-	"database/sql"
-	"fmt"
-	"slices"
-	"strings"
-	"time"
+    "database/sql"
+    "fmt"
+    "slices"
+    "strings"
+    "time"
 
-	"github.com/artie-labs/transfer/clients/mssql/dialect"
+    "github.com/artie-labs/transfer/clients/mssql/dialect"
 
-	"github.com/artie-labs/reader/lib/mssql/parse"
-	"github.com/artie-labs/reader/lib/mssql/schema"
-	"github.com/artie-labs/reader/lib/rdbms"
-	"github.com/artie-labs/reader/lib/rdbms/column"
-	"github.com/artie-labs/reader/lib/rdbms/primary_key"
-	"github.com/artie-labs/reader/lib/rdbms/scan"
+    "github.com/artie-labs/reader/lib/mssql/parse"
+    "github.com/artie-labs/reader/lib/mssql/schema"
+    "github.com/artie-labs/reader/lib/rdbms"
+    "github.com/artie-labs/reader/lib/rdbms/column"
+    "github.com/artie-labs/reader/lib/rdbms/primary_key"
+    "github.com/artie-labs/reader/lib/rdbms/scan"
 )
 
 const (
-	TimeMicro      = "15:04:05.000000"
-	TimeNano       = "15:04:05.000000000"
-	DateTimeMicro  = "2006-01-02 15:04:05.000000"
-	DateTimeNano   = "2006-01-02 15:04:05.000000000"
-	DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
+    TimeMicro      = "15:04:05.000000"
+    TimeNano       = "15:04:05.000000000"
+    DateTimeMicro  = "2006-01-02 15:04:05.000000"
+    DateTimeNano   = "2006-01-02 15:04:05.000000000"
+    DateTimeOffset = "2006-01-02 15:04:05.0000000 -07:00"
 )
 
 func NewScanner(db *sql.DB, table Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-	for _, key := range table.PrimaryKeys() {
-		if _, err := column.ByName(columns, key); err != nil {
-			return nil, fmt.Errorf("missing column with name: %q", key)
-		}
-	}
+    for _, key := range table.PrimaryKeys() {
+        if _, err := column.ByName(columns, key); err != nil {
+            return nil, fmt.Errorf("missing column with name: %q", key)
+        }
+    }
 
-	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
-	if err != nil {
-		return nil, err
-	}
+    primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
+    if err != nil {
+        return nil, err
+    }
 
-	adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
-	return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
+    adapter := scanAdapter{schema: table.Schema, tableName: table.Name, columns: columns}
+    return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
 }
 
 type scanAdapter struct {
-	schema    string
-	tableName string
-	columns   []schema.Column
+    schema    string
+    tableName string
+    columns   []schema.Column
 }
 
 func (s scanAdapter) ParsePrimaryKeyValueForOverrides(_ string, value string) (any, error) {
-	// We don't need to cast it at all.
-	return value, nil
+    // We don't need to cast it at all.
+    return value, nil
 }
 
 // parsePrimaryKeyValues - parse primary key values based on the column type.
 // This is needed because the MSSQL SDK does not support parsing `time.Time`, so we need to do it ourselves.
 func (s scanAdapter) parsePrimaryKeyValues(columnName string, value any) (any, error) {
-	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
-	if columnIdx < 0 {
-		return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
-	}
-
-	_column := s.columns[columnIdx]
-	if !slices.Contains(supportedPrimaryKeyDataType, _column.Type) {
-		return nil, fmt.Errorf("DataType(%d) for column %q is not supported for use as a primary key", _column.Type, _column.Name)
-	}
-
-	switch _column.Type {
-	case schema.Time:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(time.TimeOnly), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	case schema.TimeMicro:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(TimeMicro), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	case schema.TimeNano:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(TimeNano), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	case schema.Datetime2:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(time.DateTime), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	case schema.Datetime2Micro:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(DateTimeMicro), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	case schema.Datetime2Nano:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(DateTimeNano), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	case schema.DatetimeOffset:
-		switch castedVal := value.(type) {
-		case time.Time:
-			return castedVal.Format(DateTimeOffset), nil
-		case string:
-			return castedVal, nil
-		default:
-			return nil, fmt.Errorf("expected time.Time type, received: %T", value)
-		}
-	default:
-		return value, nil
-	}
+    columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
+    if columnIdx < 0 {
+        return nil, fmt.Errorf("primary key column does not exist: %q", columnName)
+    }
+	
+    switch _columnType := s.columns[columnIdx].Type; _columnType {
+    case schema.Time:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(time.TimeOnly), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.TimeMicro:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(TimeMicro), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.TimeNano:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(TimeNano), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.Datetime2:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(time.DateTime), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.Datetime2Micro:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(DateTimeMicro), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.Datetime2Nano:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(DateTimeNano), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    case schema.DatetimeOffset:
+        switch castedVal := value.(type) {
+        case time.Time:
+            return castedVal.Format(DateTimeOffset), nil
+        case string:
+            return castedVal, nil
+        default:
+            return nil, fmt.Errorf("expected time.Time type, received: %T", value)
+        }
+    default:
+        return value, nil
+    }
 }
 
 func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
-	mssqlDialect := dialect.MSSQLDialect{}
-	colNames := make([]string, len(s.columns))
-	for idx, col := range s.columns {
-		colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
-	}
+    mssqlDialect := dialect.MSSQLDialect{}
+    colNames := make([]string, len(s.columns))
+    for idx, col := range s.columns {
+        colNames[idx] = mssqlDialect.QuoteIdentifier(col.Name)
+    }
 
-	startingValues := make([]any, len(primaryKeys))
-	endingValues := make([]any, len(primaryKeys))
-	for i, pk := range primaryKeys {
-		pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
-		}
+    startingValues := make([]any, len(primaryKeys))
+    endingValues := make([]any, len(primaryKeys))
+    for i, pk := range primaryKeys {
+        pkStartVal, err := s.parsePrimaryKeyValues(pk.Name, pk.StartingValue)
+        if err != nil {
+            return "", nil, fmt.Errorf("failed to parse start primary key val: %w", err)
+        }
 
-		pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
-		}
+        pkEndVal, err := s.parsePrimaryKeyValues(pk.Name, pk.EndingValue)
+        if err != nil {
+            return "", nil, fmt.Errorf("failed to parse end primary key val: %w", err)
+        }
 
-		startingValues[i] = pkStartVal
-		endingValues[i] = pkEndVal
-	}
+        startingValues[i] = pkStartVal
+        endingValues[i] = pkEndVal
+    }
 
-	quotedKeyNames := make([]string, len(primaryKeys))
-	for i, key := range primaryKeys {
-		quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
-	}
+    quotedKeyNames := make([]string, len(primaryKeys))
+    for i, key := range primaryKeys {
+        quotedKeyNames[i] = mssqlDialect.QuoteIdentifier(key.Name)
+    }
 
-	lowerBoundComparison := ">"
-	if isFirstBatch {
-		lowerBoundComparison = ">="
-	}
+    lowerBoundComparison := ">"
+    if isFirstBatch {
+        lowerBoundComparison = ">="
+    }
 
-	return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
-		// TOP
-		batchSize,
-		// SELECT
-		strings.Join(colNames, ","),
-		// FROM
-		mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
-		// WHERE (pk) > (123)
-		strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
-		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
-		// ORDER BY
-		strings.Join(quotedKeyNames, ","),
-	), slices.Concat(startingValues, endingValues), nil
+    return fmt.Sprintf(`SELECT TOP %d %s FROM %s.%s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s`,
+        // TOP
+        batchSize,
+        // SELECT
+        strings.Join(colNames, ","),
+        // FROM
+        mssqlDialect.QuoteIdentifier(s.schema), mssqlDialect.QuoteIdentifier(s.tableName),
+        // WHERE (pk) > (123)
+        strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
+        strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
+        // ORDER BY
+        strings.Join(quotedKeyNames, ","),
+    ), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {
-	for i, value := range values {
-		parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
-		if err != nil {
-			return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
-		}
+    for i, value := range values {
+        parsedValue, err := parse.ParseValue(s.columns[i].Type, value)
+        if err != nil {
+            return fmt.Errorf("failed to parse column: %q: %w", s.columns[i].Name, err)
+        }
 
-		values[i] = parsedValue
-	}
+        values[i] = parsedValue
+    }
 
-	return nil
+    return nil
 }

--- a/lib/mssql/scanner_test.go
+++ b/lib/mssql/scanner_test.go
@@ -1,0 +1,165 @@
+package mssql
+
+import (
+	"github.com/artie-labs/reader/lib/mssql/schema"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestScanAdapter_ParsePrimaryKeyValues(t *testing.T) {
+	{
+		// schema.Time
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "time",
+					Type: schema.Time,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("time", "12:34:56")
+		assert.NoError(t, err)
+		assert.Equal(t, "12:34:56", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 0, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("time", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "12:34:56", val)
+	}
+	{
+		// Schema.TimeMicro
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "time_micro",
+					Type: schema.TimeMicro,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("time_micro", "12:34:56.789012")
+		assert.NoError(t, err)
+		assert.Equal(t, "12:34:56.789012", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 789012000, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("time_micro", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "12:34:56.789012", val)
+	}
+	{
+		// schema.TimeNano
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "time_nano",
+					Type: schema.TimeNano,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("time_nano", "12:34:56.789012345")
+		assert.NoError(t, err)
+		assert.Equal(t, "12:34:56.789012345", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 789012345, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("time_nano", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "12:34:56.789012345", val)
+	}
+	{
+		// schema.Datetime2
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "datetime2",
+					Type: schema.Datetime2,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("datetime2", "2021-01-01 12:34:56")
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 0, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("datetime2", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56", val)
+	}
+	{
+		// schema.Datetime2Micro
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "datetime2_micro",
+					Type: schema.Datetime2Micro,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("datetime2_micro", "2021-01-01 12:34:56.789012")
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56.789012", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 789012000, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("datetime2_micro", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56.789012", val)
+	}
+	{
+		// schema.Datetime2Nano
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "datetime2_nano",
+					Type: schema.Datetime2Nano,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("datetime2_nano", "2021-01-01 12:34:56.789012345")
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56.789012345", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 789012345, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("datetime2_nano", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56.789012345", val)
+	}
+	{
+		// schema.DatetimeOffset
+		adapter := scanAdapter{
+			columns: []schema.Column{
+				{
+					Name: "datetimeoffset",
+					Type: schema.DatetimeOffset,
+				},
+			},
+		}
+
+		// Able to use string
+		val, err := adapter.parsePrimaryKeyValues("datetimeoffset", "2021-01-01 12:34:56.7890123 +00:00")
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56.7890123 +00:00", val)
+
+		// Able to use time.Time
+		td := time.Date(2021, 1, 1, 12, 34, 56, 789012300, time.UTC)
+		val, err = adapter.parsePrimaryKeyValues("datetimeoffset", td)
+		assert.NoError(t, err)
+		assert.Equal(t, "2021-01-01 12:34:56.7890123 +00:00", val)
+	}
+}

--- a/lib/mssql/scanner_test.go
+++ b/lib/mssql/scanner_test.go
@@ -1,165 +1,165 @@
 package mssql
 
 import (
-	"github.com/artie-labs/reader/lib/mssql/schema"
-	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
+    "github.com/artie-labs/reader/lib/mssql/schema"
+    "github.com/stretchr/testify/assert"
+    "testing"
+    "time"
 )
 
-func TestScanAdapter_ParsePrimaryKeyValues(t *testing.T) {
-	{
-		// schema.Time
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "time",
-					Type: schema.Time,
-				},
-			},
-		}
+func TestScanAdapter_EncodePrimaryKeyValue(t *testing.T) {
+    {
+        // schema.Time
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "time",
+                    Type: schema.Time,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("time", "12:34:56")
-		assert.NoError(t, err)
-		assert.Equal(t, "12:34:56", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("time", "12:34:56")
+        assert.NoError(t, err)
+        assert.Equal(t, "12:34:56", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 0, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("time", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "12:34:56", val)
-	}
-	{
-		// Schema.TimeMicro
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "time_micro",
-					Type: schema.TimeMicro,
-				},
-			},
-		}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 0, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("time", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "12:34:56", val)
+    }
+    {
+        // Schema.TimeMicro
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "time_micro",
+                    Type: schema.TimeMicro,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("time_micro", "12:34:56.789012")
-		assert.NoError(t, err)
-		assert.Equal(t, "12:34:56.789012", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("time_micro", "12:34:56.789012")
+        assert.NoError(t, err)
+        assert.Equal(t, "12:34:56.789012", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 789012000, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("time_micro", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "12:34:56.789012", val)
-	}
-	{
-		// schema.TimeNano
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "time_nano",
-					Type: schema.TimeNano,
-				},
-			},
-		}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 789012000, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("time_micro", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "12:34:56.789012", val)
+    }
+    {
+        // schema.TimeNano
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "time_nano",
+                    Type: schema.TimeNano,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("time_nano", "12:34:56.789012345")
-		assert.NoError(t, err)
-		assert.Equal(t, "12:34:56.789012345", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("time_nano", "12:34:56.789012345")
+        assert.NoError(t, err)
+        assert.Equal(t, "12:34:56.789012345", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 789012345, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("time_nano", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "12:34:56.789012345", val)
-	}
-	{
-		// schema.Datetime2
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "datetime2",
-					Type: schema.Datetime2,
-				},
-			},
-		}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 789012345, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("time_nano", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "12:34:56.789012345", val)
+    }
+    {
+        // schema.Datetime2
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "datetime2",
+                    Type: schema.Datetime2,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("datetime2", "2021-01-01 12:34:56")
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("datetime2", "2021-01-01 12:34:56")
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 0, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("datetime2", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56", val)
-	}
-	{
-		// schema.Datetime2Micro
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "datetime2_micro",
-					Type: schema.Datetime2Micro,
-				},
-			},
-		}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 0, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("datetime2", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56", val)
+    }
+    {
+        // schema.Datetime2Micro
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "datetime2_micro",
+                    Type: schema.Datetime2Micro,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("datetime2_micro", "2021-01-01 12:34:56.789012")
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56.789012", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("datetime2_micro", "2021-01-01 12:34:56.789012")
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56.789012", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 789012000, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("datetime2_micro", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56.789012", val)
-	}
-	{
-		// schema.Datetime2Nano
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "datetime2_nano",
-					Type: schema.Datetime2Nano,
-				},
-			},
-		}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 789012000, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("datetime2_micro", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56.789012", val)
+    }
+    {
+        // schema.Datetime2Nano
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "datetime2_nano",
+                    Type: schema.Datetime2Nano,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("datetime2_nano", "2021-01-01 12:34:56.789012345")
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56.789012345", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("datetime2_nano", "2021-01-01 12:34:56.789012345")
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56.789012345", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 789012345, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("datetime2_nano", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56.789012345", val)
-	}
-	{
-		// schema.DatetimeOffset
-		adapter := scanAdapter{
-			columns: []schema.Column{
-				{
-					Name: "datetimeoffset",
-					Type: schema.DatetimeOffset,
-				},
-			},
-		}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 789012345, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("datetime2_nano", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56.789012345", val)
+    }
+    {
+        // schema.DatetimeOffset
+        adapter := scanAdapter{
+            columns: []schema.Column{
+                {
+                    Name: "datetimeoffset",
+                    Type: schema.DatetimeOffset,
+                },
+            },
+        }
 
-		// Able to use string
-		val, err := adapter.parsePrimaryKeyValues("datetimeoffset", "2021-01-01 12:34:56.7890123 +00:00")
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56.7890123 +00:00", val)
+        // Able to use string
+        val, err := adapter.encodePrimaryKeyValue("datetimeoffset", "2021-01-01 12:34:56.7890123 +00:00")
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56.7890123 +00:00", val)
 
-		// Able to use time.Time
-		td := time.Date(2021, 1, 1, 12, 34, 56, 789012300, time.UTC)
-		val, err = adapter.parsePrimaryKeyValues("datetimeoffset", td)
-		assert.NoError(t, err)
-		assert.Equal(t, "2021-01-01 12:34:56.7890123 +00:00", val)
-	}
+        // Able to use time.Time
+        td := time.Date(2021, 1, 1, 12, 34, 56, 789012300, time.UTC)
+        val, err = adapter.encodePrimaryKeyValue("datetimeoffset", td)
+        assert.NoError(t, err)
+        assert.Equal(t, "2021-01-01 12:34:56.7890123 +00:00", val)
+    }
 }

--- a/lib/mysql/scanner/scanner.go
+++ b/lib/mysql/scanner/scanner.go
@@ -1,168 +1,168 @@
 package scanner
 
 import (
-    "database/sql"
-    "fmt"
-    "slices"
-    "strconv"
-    "strings"
-    "time"
+	"database/sql"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
 
-    "github.com/artie-labs/reader/lib/mysql"
-    "github.com/artie-labs/reader/lib/mysql/schema"
-    "github.com/artie-labs/reader/lib/rdbms"
-    "github.com/artie-labs/reader/lib/rdbms/primary_key"
-    "github.com/artie-labs/reader/lib/rdbms/scan"
+	"github.com/artie-labs/reader/lib/mysql"
+	"github.com/artie-labs/reader/lib/mysql/schema"
+	"github.com/artie-labs/reader/lib/rdbms"
+	"github.com/artie-labs/reader/lib/rdbms/primary_key"
+	"github.com/artie-labs/reader/lib/rdbms/scan"
 )
 
 func NewScanner(db *sql.DB, table mysql.Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-    primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
-    if err != nil {
-        return nil, err
-    }
+	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
+	if err != nil {
+		return nil, err
+	}
 
-    adapter := scanAdapter{tableName: table.Name, columns: columns}
-    return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
+	adapter := scanAdapter{tableName: table.Name, columns: columns}
+	return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
 }
 
 type scanAdapter struct {
-    tableName string
-    columns   []schema.Column
+	tableName string
+	columns   []schema.Column
 }
 
 func (s scanAdapter) ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error) {
-    columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
-    if columnIdx < 0 {
-        return nil, fmt.Errorf("primary key column %q does not exist", columnName)
-    }
-    column := s.columns[columnIdx]
-    switch column.Type {
-    case schema.TinyInt:
-        intValue, err := strconv.ParseInt(value, 10, 8)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a tinyint: %w", value, err)
-        }
-        return int8(intValue), nil
-    case schema.SmallInt:
-        intValue, err := strconv.ParseInt(value, 10, 16)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a smallint: %w", value, err)
-        }
-        return int16(intValue), nil
-    case schema.MediumInt:
-        intValue, err := strconv.ParseInt(value, 10, 24)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a mediumint: %w", value, err)
-        }
-        return int32(intValue), nil
-    case schema.Int:
-        intValue, err := strconv.ParseInt(value, 10, 32)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to an int: %w", value, err)
-        }
-        return int32(intValue), nil
-    case schema.BigInt:
-        intValue, err := strconv.ParseInt(value, 10, 64)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a bigint: %w", value, err)
-        }
-        return intValue, nil
-    case schema.Bit, schema.Boolean:
-        boolValue, err := strconv.ParseBool(value)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a bool: %w", value, err)
-        }
-        return boolValue, nil
-    case schema.Float:
-        floatValue, err := strconv.ParseFloat(value, 32)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a float: %w", value, err)
-        }
-        return float32(floatValue), nil
-    case schema.Double:
-        floatValue, err := strconv.ParseFloat(value, 64)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a double: %w", value, err)
-        }
-        return floatValue, nil
-    case schema.DateTime, schema.Timestamp:
-        timeValue, err := time.Parse(schema.DateTimeFormat, value)
-        if err != nil {
-            return nil, err
-        }
-        return timeValue, nil
-    case schema.Year:
-        intValue, err := strconv.ParseInt(value, 10, 32)
-        if err != nil {
-            return nil, fmt.Errorf("unable to convert %q to a year: %w", value, err)
-        }
-        // MySQL only supports years from 1901 to 2155
-        // https://dev.mysql.com/doc/refman/8.3/en/year.html
-        if intValue < 1901 {
-            return nil, fmt.Errorf("unable to convert %q to a year: value must be >= 1901", value)
-        } else if intValue > 2155 {
-            return nil, fmt.Errorf("unable to convert %q to a year: value must be <= 2155", value)
-        }
-        return int16(intValue), nil
-    case
-        schema.Decimal,
-        schema.Time,
-        schema.Date,
-        schema.Char,
-        schema.Varchar,
-        schema.Text,
-        schema.TinyText,
-        schema.MediumText,
-        schema.LongText,
-        schema.Enum,
-        schema.Set,
-        schema.JSON:
-        return value, nil
-    case schema.Binary, schema.Varbinary, schema.Blob:
-        return nil, fmt.Errorf("primary key value parsing not implemented for binary types")
-    default:
-        return nil, fmt.Errorf("primary key value parsing not implemented for DataType(%d)", column.Type)
-    }
+	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
+	if columnIdx < 0 {
+		return nil, fmt.Errorf("primary key column %q does not exist", columnName)
+	}
+	column := s.columns[columnIdx]
+	switch column.Type {
+	case schema.TinyInt:
+		intValue, err := strconv.ParseInt(value, 10, 8)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a tinyint: %w", value, err)
+		}
+		return int8(intValue), nil
+	case schema.SmallInt:
+		intValue, err := strconv.ParseInt(value, 10, 16)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a smallint: %w", value, err)
+		}
+		return int16(intValue), nil
+	case schema.MediumInt:
+		intValue, err := strconv.ParseInt(value, 10, 24)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a mediumint: %w", value, err)
+		}
+		return int32(intValue), nil
+	case schema.Int:
+		intValue, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to an int: %w", value, err)
+		}
+		return int32(intValue), nil
+	case schema.BigInt:
+		intValue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a bigint: %w", value, err)
+		}
+		return intValue, nil
+	case schema.Bit, schema.Boolean:
+		boolValue, err := strconv.ParseBool(value)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a bool: %w", value, err)
+		}
+		return boolValue, nil
+	case schema.Float:
+		floatValue, err := strconv.ParseFloat(value, 32)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a float: %w", value, err)
+		}
+		return float32(floatValue), nil
+	case schema.Double:
+		floatValue, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a double: %w", value, err)
+		}
+		return floatValue, nil
+	case schema.DateTime, schema.Timestamp:
+		timeValue, err := time.Parse(schema.DateTimeFormat, value)
+		if err != nil {
+			return nil, err
+		}
+		return timeValue, nil
+	case schema.Year:
+		intValue, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("unable to convert %q to a year: %w", value, err)
+		}
+		// MySQL only supports years from 1901 to 2155
+		// https://dev.mysql.com/doc/refman/8.3/en/year.html
+		if intValue < 1901 {
+			return nil, fmt.Errorf("unable to convert %q to a year: value must be >= 1901", value)
+		} else if intValue > 2155 {
+			return nil, fmt.Errorf("unable to convert %q to a year: value must be <= 2155", value)
+		}
+		return int16(intValue), nil
+	case
+		schema.Decimal,
+		schema.Time,
+		schema.Date,
+		schema.Char,
+		schema.Varchar,
+		schema.Text,
+		schema.TinyText,
+		schema.MediumText,
+		schema.LongText,
+		schema.Enum,
+		schema.Set,
+		schema.JSON:
+		return value, nil
+	case schema.Binary, schema.Varbinary, schema.Blob:
+		return nil, fmt.Errorf("primary key value parsing not implemented for binary types")
+	default:
+		return nil, fmt.Errorf("primary key value parsing not implemented for DataType(%d)", column.Type)
+	}
 }
 
 func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
-    colNames := make([]string, len(s.columns))
-    for idx, col := range s.columns {
-        colNames[idx] = schema.QuoteIdentifier(col.Name)
-    }
+	colNames := make([]string, len(s.columns))
+	for idx, col := range s.columns {
+		colNames[idx] = schema.QuoteIdentifier(col.Name)
+	}
 
-    var startingValues = make([]any, len(primaryKeys))
-    var endingValues = make([]any, len(startingValues))
-    for i, pk := range primaryKeys {
-        startingValues[i] = pk.StartingValue
-        endingValues[i] = pk.EndingValue
-    }
+	var startingValues = make([]any, len(primaryKeys))
+	var endingValues = make([]any, len(startingValues))
+	for i, pk := range primaryKeys {
+		startingValues[i] = pk.StartingValue
+		endingValues[i] = pk.EndingValue
+	}
 
-    quotedKeyNames := make([]string, len(primaryKeys))
-    for i, key := range primaryKeys {
-        quotedKeyNames[i] = schema.QuoteIdentifier(key.Name)
-    }
+	quotedKeyNames := make([]string, len(primaryKeys))
+	for i, key := range primaryKeys {
+		quotedKeyNames[i] = schema.QuoteIdentifier(key.Name)
+	}
 
-    lowerBoundComparison := ">"
-    if isFirstBatch {
-        lowerBoundComparison = ">="
-    }
+	lowerBoundComparison := ">"
+	if isFirstBatch {
+		lowerBoundComparison = ">="
+	}
 
-    return fmt.Sprintf(`SELECT %s FROM %s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s LIMIT %d`,
-        // SELECT
-        strings.Join(colNames, ","),
-        // FROM
-        schema.QuoteIdentifier(s.tableName),
-        // WHERE (pk) > (123)
-        strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
-        strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
-        // ORDER BY
-        strings.Join(quotedKeyNames, ","),
-        // LIMIT
-        batchSize,
-    ), slices.Concat(startingValues, endingValues), nil
+	return fmt.Sprintf(`SELECT %s FROM %s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s LIMIT %d`,
+		// SELECT
+		strings.Join(colNames, ","),
+		// FROM
+		schema.QuoteIdentifier(s.tableName),
+		// WHERE (pk) > (123)
+		strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
+		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
+		// ORDER BY
+		strings.Join(quotedKeyNames, ","),
+		// LIMIT
+		batchSize,
+	), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {
-    return schema.ConvertValues(values, s.columns)
+	return schema.ConvertValues(values, s.columns)
 }

--- a/lib/mysql/scanner/scanner.go
+++ b/lib/mysql/scanner/scanner.go
@@ -1,168 +1,168 @@
 package scanner
 
 import (
-	"database/sql"
-	"fmt"
-	"slices"
-	"strconv"
-	"strings"
-	"time"
+    "database/sql"
+    "fmt"
+    "slices"
+    "strconv"
+    "strings"
+    "time"
 
-	"github.com/artie-labs/reader/lib/mysql"
-	"github.com/artie-labs/reader/lib/mysql/schema"
-	"github.com/artie-labs/reader/lib/rdbms"
-	"github.com/artie-labs/reader/lib/rdbms/primary_key"
-	"github.com/artie-labs/reader/lib/rdbms/scan"
+    "github.com/artie-labs/reader/lib/mysql"
+    "github.com/artie-labs/reader/lib/mysql/schema"
+    "github.com/artie-labs/reader/lib/rdbms"
+    "github.com/artie-labs/reader/lib/rdbms/primary_key"
+    "github.com/artie-labs/reader/lib/rdbms/scan"
 )
 
 func NewScanner(db *sql.DB, table mysql.Table, columns []schema.Column, cfg scan.ScannerConfig) (*scan.Scanner, error) {
-	primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
-	if err != nil {
-		return nil, err
-	}
+    primaryKeyBounds, err := table.FetchPrimaryKeysBounds(db)
+    if err != nil {
+        return nil, err
+    }
 
-	adapter := scanAdapter{tableName: table.Name, columns: columns}
-	return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
+    adapter := scanAdapter{tableName: table.Name, columns: columns}
+    return scan.NewScanner(db, primaryKeyBounds, cfg, adapter)
 }
 
 type scanAdapter struct {
-	tableName string
-	columns   []schema.Column
+    tableName string
+    columns   []schema.Column
 }
 
 func (s scanAdapter) ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error) {
-	columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
-	if columnIdx < 0 {
-		return nil, fmt.Errorf("primary key column %q does not exist", columnName)
-	}
-	column := s.columns[columnIdx]
-	switch column.Type {
-	case schema.TinyInt:
-		intValue, err := strconv.ParseInt(value, 10, 8)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a tinyint: %w", value, err)
-		}
-		return int8(intValue), nil
-	case schema.SmallInt:
-		intValue, err := strconv.ParseInt(value, 10, 16)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a smallint: %w", value, err)
-		}
-		return int16(intValue), nil
-	case schema.MediumInt:
-		intValue, err := strconv.ParseInt(value, 10, 24)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a mediumint: %w", value, err)
-		}
-		return int32(intValue), nil
-	case schema.Int:
-		intValue, err := strconv.ParseInt(value, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to an int: %w", value, err)
-		}
-		return int32(intValue), nil
-	case schema.BigInt:
-		intValue, err := strconv.ParseInt(value, 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a bigint: %w", value, err)
-		}
-		return intValue, nil
-	case schema.Bit, schema.Boolean:
-		boolValue, err := strconv.ParseBool(value)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a bool: %w", value, err)
-		}
-		return boolValue, nil
-	case schema.Float:
-		floatValue, err := strconv.ParseFloat(value, 32)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a float: %w", value, err)
-		}
-		return float32(floatValue), nil
-	case schema.Double:
-		floatValue, err := strconv.ParseFloat(value, 64)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a double: %w", value, err)
-		}
-		return floatValue, nil
-	case schema.DateTime, schema.Timestamp:
-		timeValue, err := time.Parse(schema.DateTimeFormat, value)
-		if err != nil {
-			return nil, err
-		}
-		return timeValue, nil
-	case schema.Year:
-		intValue, err := strconv.ParseInt(value, 10, 32)
-		if err != nil {
-			return nil, fmt.Errorf("unable to convert %q to a year: %w", value, err)
-		}
-		// MySQL only supports years from 1901 to 2155
-		// https://dev.mysql.com/doc/refman/8.3/en/year.html
-		if intValue < 1901 {
-			return nil, fmt.Errorf("unable to convert %q to a year: value must be >= 1901", value)
-		} else if intValue > 2155 {
-			return nil, fmt.Errorf("unable to convert %q to a year: value must be <= 2155", value)
-		}
-		return int16(intValue), nil
-	case
-		schema.Decimal,
-		schema.Time,
-		schema.Date,
-		schema.Char,
-		schema.Varchar,
-		schema.Text,
-		schema.TinyText,
-		schema.MediumText,
-		schema.LongText,
-		schema.Enum,
-		schema.Set,
-		schema.JSON:
-		return value, nil
-	case schema.Binary, schema.Varbinary, schema.Blob:
-		return nil, fmt.Errorf("primary key value parsing not implemented for binary types")
-	default:
-		return nil, fmt.Errorf("primary key value parsing not implemented for DataType(%d)", column.Type)
-	}
+    columnIdx := slices.IndexFunc(s.columns, func(x schema.Column) bool { return x.Name == columnName })
+    if columnIdx < 0 {
+        return nil, fmt.Errorf("primary key column %q does not exist", columnName)
+    }
+    column := s.columns[columnIdx]
+    switch column.Type {
+    case schema.TinyInt:
+        intValue, err := strconv.ParseInt(value, 10, 8)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a tinyint: %w", value, err)
+        }
+        return int8(intValue), nil
+    case schema.SmallInt:
+        intValue, err := strconv.ParseInt(value, 10, 16)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a smallint: %w", value, err)
+        }
+        return int16(intValue), nil
+    case schema.MediumInt:
+        intValue, err := strconv.ParseInt(value, 10, 24)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a mediumint: %w", value, err)
+        }
+        return int32(intValue), nil
+    case schema.Int:
+        intValue, err := strconv.ParseInt(value, 10, 32)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to an int: %w", value, err)
+        }
+        return int32(intValue), nil
+    case schema.BigInt:
+        intValue, err := strconv.ParseInt(value, 10, 64)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a bigint: %w", value, err)
+        }
+        return intValue, nil
+    case schema.Bit, schema.Boolean:
+        boolValue, err := strconv.ParseBool(value)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a bool: %w", value, err)
+        }
+        return boolValue, nil
+    case schema.Float:
+        floatValue, err := strconv.ParseFloat(value, 32)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a float: %w", value, err)
+        }
+        return float32(floatValue), nil
+    case schema.Double:
+        floatValue, err := strconv.ParseFloat(value, 64)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a double: %w", value, err)
+        }
+        return floatValue, nil
+    case schema.DateTime, schema.Timestamp:
+        timeValue, err := time.Parse(schema.DateTimeFormat, value)
+        if err != nil {
+            return nil, err
+        }
+        return timeValue, nil
+    case schema.Year:
+        intValue, err := strconv.ParseInt(value, 10, 32)
+        if err != nil {
+            return nil, fmt.Errorf("unable to convert %q to a year: %w", value, err)
+        }
+        // MySQL only supports years from 1901 to 2155
+        // https://dev.mysql.com/doc/refman/8.3/en/year.html
+        if intValue < 1901 {
+            return nil, fmt.Errorf("unable to convert %q to a year: value must be >= 1901", value)
+        } else if intValue > 2155 {
+            return nil, fmt.Errorf("unable to convert %q to a year: value must be <= 2155", value)
+        }
+        return int16(intValue), nil
+    case
+        schema.Decimal,
+        schema.Time,
+        schema.Date,
+        schema.Char,
+        schema.Varchar,
+        schema.Text,
+        schema.TinyText,
+        schema.MediumText,
+        schema.LongText,
+        schema.Enum,
+        schema.Set,
+        schema.JSON:
+        return value, nil
+    case schema.Binary, schema.Varbinary, schema.Blob:
+        return nil, fmt.Errorf("primary key value parsing not implemented for binary types")
+    default:
+        return nil, fmt.Errorf("primary key value parsing not implemented for DataType(%d)", column.Type)
+    }
 }
 
-func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any) {
-	colNames := make([]string, len(s.columns))
-	for idx, col := range s.columns {
-		colNames[idx] = schema.QuoteIdentifier(col.Name)
-	}
+func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
+    colNames := make([]string, len(s.columns))
+    for idx, col := range s.columns {
+        colNames[idx] = schema.QuoteIdentifier(col.Name)
+    }
 
-	var startingValues = make([]any, len(primaryKeys))
-	var endingValues = make([]any, len(startingValues))
-	for i, pk := range primaryKeys {
-		startingValues[i] = pk.StartingValue
-		endingValues[i] = pk.EndingValue
-	}
+    var startingValues = make([]any, len(primaryKeys))
+    var endingValues = make([]any, len(startingValues))
+    for i, pk := range primaryKeys {
+        startingValues[i] = pk.StartingValue
+        endingValues[i] = pk.EndingValue
+    }
 
-	quotedKeyNames := make([]string, len(primaryKeys))
-	for i, key := range primaryKeys {
-		quotedKeyNames[i] = schema.QuoteIdentifier(key.Name)
-	}
+    quotedKeyNames := make([]string, len(primaryKeys))
+    for i, key := range primaryKeys {
+        quotedKeyNames[i] = schema.QuoteIdentifier(key.Name)
+    }
 
-	lowerBoundComparison := ">"
-	if isFirstBatch {
-		lowerBoundComparison = ">="
-	}
+    lowerBoundComparison := ">"
+    if isFirstBatch {
+        lowerBoundComparison = ">="
+    }
 
-	return fmt.Sprintf(`SELECT %s FROM %s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s LIMIT %d`,
-		// SELECT
-		strings.Join(colNames, ","),
-		// FROM
-		schema.QuoteIdentifier(s.tableName),
-		// WHERE (pk) > (123)
-		strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
-		strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
-		// ORDER BY
-		strings.Join(quotedKeyNames, ","),
-		// LIMIT
-		batchSize,
-	), slices.Concat(startingValues, endingValues)
+    return fmt.Sprintf(`SELECT %s FROM %s WHERE (%s) %s (%s) AND (%s) <= (%s) ORDER BY %s LIMIT %d`,
+        // SELECT
+        strings.Join(colNames, ","),
+        // FROM
+        schema.QuoteIdentifier(s.tableName),
+        // WHERE (pk) > (123)
+        strings.Join(quotedKeyNames, ","), lowerBoundComparison, strings.Join(rdbms.QueryPlaceholders("?", len(startingValues)), ","),
+        strings.Join(quotedKeyNames, ","), strings.Join(rdbms.QueryPlaceholders("?", len(endingValues)), ","),
+        // ORDER BY
+        strings.Join(quotedKeyNames, ","),
+        // LIMIT
+        batchSize,
+    ), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {
-	return schema.ConvertValues(values, s.columns)
+    return schema.ConvertValues(values, s.columns)
 }

--- a/lib/mysql/scanner/scanner_test.go
+++ b/lib/mysql/scanner/scanner_test.go
@@ -243,13 +243,15 @@ func TestScanAdapter_BuildQuery(t *testing.T) {
 	}
 	{
 		// exclusive lower bound
-		query, parameters := adapter.BuildQuery(keys, false, 12)
+		query, parameters, err := adapter.BuildQuery(keys, false, 12)
+		assert.NoError(t, err)
 		assert.Equal(t, "SELECT `foo`,`bar` FROM `table` WHERE (`foo`) > (?) AND (`foo`) <= (?) ORDER BY `foo` LIMIT 12", query)
 		assert.Equal(t, []any{"a", "b"}, parameters)
 	}
 	{
 		// inclusive upper and lower bounds
-		query, parameters := adapter.BuildQuery(keys, true, 12)
+		query, parameters, err := adapter.BuildQuery(keys, true, 12)
+		assert.NoError(t, err)
 		assert.Equal(t, "SELECT `foo`,`bar` FROM `table` WHERE (`foo`) >= (?) AND (`foo`) <= (?) ORDER BY `foo` LIMIT 12", query)
 		assert.Equal(t, []any{"a", "b"}, parameters)
 	}

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -162,7 +162,7 @@ func queryPlaceholders(offset, count int) []string {
 	return result
 }
 
-func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any) {
+func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
 	castedColumns := make([]string, len(s.columns))
 	for i, col := range s.columns {
 		castedColumns[i] = castColumn(col)
@@ -198,7 +198,7 @@ func (s scanAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool
 		strings.Join(quotedKeyNames, ","),
 		// LIMIT
 		batchSize,
-	), slices.Concat(startingValues, endingValues)
+	), slices.Concat(startingValues, endingValues), nil
 }
 
 func (s scanAdapter) ParseRow(values []any) error {

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -65,13 +65,15 @@ func TestScanAdapter_BuildQuery(t *testing.T) {
 
 	{
 		// inclusive lower bound
-		query, parameters := adapter.BuildQuery(primaryKeys, true, 1)
+		query, parameters, err := adapter.BuildQuery(primaryKeys, true, 1)
+		assert.NoError(t, err)
 		assert.Equal(t, `SELECT "a","b","c","e","f",ARRAY_TO_JSON("g")::TEXT as "g" FROM "schema"."table" WHERE row("a","b","c") >= row($1,$2,$3) AND row("a","b","c") <= row($4,$5,$6) ORDER BY "a","b","c" LIMIT 1`, query)
 		assert.Equal(t, []any{int64(1), int64(2), "3", int64(4), int64(5), "6"}, parameters)
 	}
 	{
 		// exclusive lower bound
-		query, parameters := adapter.BuildQuery(primaryKeys, false, 2)
+		query, parameters, err := adapter.BuildQuery(primaryKeys, false, 2)
+		assert.NoError(t, err)
 		assert.Equal(t, `SELECT "a","b","c","e","f",ARRAY_TO_JSON("g")::TEXT as "g" FROM "schema"."table" WHERE row("a","b","c") > row($1,$2,$3) AND row("a","b","c") <= row($4,$5,$6) ORDER BY "a","b","c" LIMIT 2`, query)
 		assert.Equal(t, []any{int64(1), int64(2), "3", int64(4), int64(5), "6"}, parameters)
 	}

--- a/lib/rdbms/scan/scan.go
+++ b/lib/rdbms/scan/scan.go
@@ -1,180 +1,184 @@
 package scan
 
 import (
-	"database/sql"
-	"fmt"
-	"log/slog"
+    "database/sql"
+    "fmt"
+    "log/slog"
 
-	"github.com/artie-labs/reader/lib/rdbms/primary_key"
-	"github.com/artie-labs/transfer/lib/retry"
+    "github.com/artie-labs/reader/lib/rdbms/primary_key"
+    "github.com/artie-labs/transfer/lib/retry"
 )
 
 const (
-	jitterBaseMs = 300
-	jitterMaxMs  = 5000
+    jitterBaseMs = 300
+    jitterMaxMs  = 5000
 )
 
 type ScannerConfig struct {
-	BatchSize              uint
-	OptionalStartingValues []string
-	OptionalEndingValues   []string
-	ErrorRetries           int
+    BatchSize              uint
+    OptionalStartingValues []string
+    OptionalEndingValues   []string
+    ErrorRetries           int
 }
 
 type ScanAdapter interface {
-	ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error)
-	BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any)
-	ParseRow(row []any) error
+    ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error)
+    BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error)
+    ParseRow(row []any) error
 }
 
 type Scanner struct {
-	// immutable
-	db        *sql.DB
-	batchSize uint
-	retryCfg  retry.RetryConfig
-	adapter   ScanAdapter
+    // immutable
+    db        *sql.DB
+    batchSize uint
+    retryCfg  retry.RetryConfig
+    adapter   ScanAdapter
 
-	// mutable
-	primaryKeys  *primary_key.Keys
-	isFirstBatch bool
-	done         bool
+    // mutable
+    primaryKeys  *primary_key.Keys
+    isFirstBatch bool
+    done         bool
 }
 
 func NewScanner(db *sql.DB, _primaryKeys []primary_key.Key, cfg ScannerConfig, adapter ScanAdapter) (*Scanner, error) {
-	optionalStartingValues, err := parsePkValueOverrides(cfg.OptionalStartingValues, _primaryKeys, adapter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse optional starting values: %w", err)
-	}
+    optionalStartingValues, err := parsePkValueOverrides(cfg.OptionalStartingValues, _primaryKeys, adapter)
+    if err != nil {
+        return nil, fmt.Errorf("failed to parse optional starting values: %w", err)
+    }
 
-	optionalEndingValues, err := parsePkValueOverrides(cfg.OptionalEndingValues, _primaryKeys, adapter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse optional ending values: %w", err)
-	}
+    optionalEndingValues, err := parsePkValueOverrides(cfg.OptionalEndingValues, _primaryKeys, adapter)
+    if err != nil {
+        return nil, fmt.Errorf("failed to parse optional ending values: %w", err)
+    }
 
-	primaryKeys := primary_key.NewKeys(_primaryKeys)
-	if err := primaryKeys.LoadValues(optionalStartingValues, optionalEndingValues); err != nil {
-		return nil, fmt.Errorf("failed to override primary key values: %w", err)
-	}
+    primaryKeys := primary_key.NewKeys(_primaryKeys)
+    if err := primaryKeys.LoadValues(optionalStartingValues, optionalEndingValues); err != nil {
+        return nil, fmt.Errorf("failed to override primary key values: %w", err)
+    }
 
-	retryCfg, err := retry.NewJitterRetryConfig(jitterBaseMs, jitterMaxMs, cfg.ErrorRetries, retry.AlwaysRetry)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build retry config: %w", err)
-	}
+    retryCfg, err := retry.NewJitterRetryConfig(jitterBaseMs, jitterMaxMs, cfg.ErrorRetries, retry.AlwaysRetry)
+    if err != nil {
+        return nil, fmt.Errorf("failed to build retry config: %w", err)
+    }
 
-	return &Scanner{
-		db:           db,
-		batchSize:    cfg.BatchSize,
-		retryCfg:     retryCfg,
-		adapter:      adapter,
-		primaryKeys:  primaryKeys,
-		isFirstBatch: true,
-		done:         false,
-	}, nil
+    return &Scanner{
+        db:           db,
+        batchSize:    cfg.BatchSize,
+        retryCfg:     retryCfg,
+        adapter:      adapter,
+        primaryKeys:  primaryKeys,
+        isFirstBatch: true,
+        done:         false,
+    }, nil
 }
 
 func (s *Scanner) HasNext() bool {
-	return !s.done
+    return !s.done
 }
 
 func (s *Scanner) Next() ([]map[string]any, error) {
-	if !s.HasNext() {
-		return nil, fmt.Errorf("no more rows to scan")
-	}
+    if !s.HasNext() {
+        return nil, fmt.Errorf("no more rows to scan")
+    }
 
-	rows, err := s.scan()
-	if err != nil {
-		s.done = true
-		return nil, err
-	}
+    rows, err := s.scan()
+    if err != nil {
+        s.done = true
+        return nil, err
+    }
 
-	wasFirstBatch := s.isFirstBatch
-	s.isFirstBatch = false
+    wasFirstBatch := s.isFirstBatch
+    s.isFirstBatch = false
 
-	if len(rows) == 0 || s.primaryKeys.IsExhausted() {
-		s.done = true
-	} else {
-		// Update the starting keys so that the next scan will pick off where we last left off.
-		lastRow := rows[len(rows)-1]
-		var startingValuesChanged bool
-		for _, pk := range s.primaryKeys.Keys() {
-			changed, err := s.primaryKeys.UpdateStartingValue(pk.Name, lastRow[pk.Name])
-			if err != nil {
-				s.done = true
-				return nil, err
-			}
-			startingValuesChanged = startingValuesChanged || changed
-		}
+    if len(rows) == 0 || s.primaryKeys.IsExhausted() {
+        s.done = true
+    } else {
+        // Update the starting keys so that the next scan will pick off where we last left off.
+        lastRow := rows[len(rows)-1]
+        var startingValuesChanged bool
+        for _, pk := range s.primaryKeys.Keys() {
+            changed, err := s.primaryKeys.UpdateStartingValue(pk.Name, lastRow[pk.Name])
+            if err != nil {
+                s.done = true
+                return nil, err
+            }
+            startingValuesChanged = startingValuesChanged || changed
+        }
 
-		if !wasFirstBatch && !startingValuesChanged {
-			// Detect situations where the scanner is stuck in a loop.
-			// Typically, the second batch will use a > comparison instead of a >= comparison for the lower bound.
-			return nil, fmt.Errorf("primarky key start values did not change, scanner is likely stuck in a loop")
-		}
-	}
+        if !wasFirstBatch && !startingValuesChanged {
+            // Detect situations where the scanner is stuck in a loop.
+            // Typically, the second batch will use a > comparison instead of a >= comparison for the lower bound.
+            return nil, fmt.Errorf("primarky key start values did not change, scanner is likely stuck in a loop")
+        }
+    }
 
-	return rows, nil
+    return rows, nil
 }
 
 func (s *Scanner) scan() ([]map[string]any, error) {
-	query, parameters := s.adapter.BuildQuery(s.primaryKeys.Keys(), s.isFirstBatch, s.batchSize)
-	slog.Info("Scan query", slog.String("query", query), slog.Any("parameters", parameters))
+    query, parameters, err := s.adapter.BuildQuery(s.primaryKeys.Keys(), s.isFirstBatch, s.batchSize)
+    if err != nil {
+        return nil, fmt.Errorf("failed to build query: %w", err)
+    }
 
-	rows, err := retry.WithRetriesAndResult(s.retryCfg, func(_ int, _ error) (*sql.Rows, error) {
-		return s.db.Query(query, parameters...)
-	})
-	if err != nil {
-		return nil, fmt.Errorf("scan failed: %w", err)
-	}
+    slog.Info("Scan query", slog.String("query", query), slog.Any("parameters", parameters))
 
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get columns: %w", err)
-	}
+    rows, err := retry.WithRetriesAndResult(s.retryCfg, func(_ int, _ error) (*sql.Rows, error) {
+        return s.db.Query(query, parameters...)
+    })
+    if err != nil {
+        return nil, fmt.Errorf("scan failed: %w", err)
+    }
 
-	values := make([]any, len(columns))
-	valuePtrs := make([]any, len(values))
-	for i := range values {
-		valuePtrs[i] = &values[i]
-	}
+    columns, err := rows.Columns()
+    if err != nil {
+        return nil, fmt.Errorf("failed to get columns: %w", err)
+    }
 
-	var rowsData []map[string]any
-	for rows.Next() {
-		if err := rows.Scan(valuePtrs...); err != nil {
-			return nil, err
-		}
+    values := make([]any, len(columns))
+    valuePtrs := make([]any, len(values))
+    for i := range values {
+        valuePtrs[i] = &values[i]
+    }
 
-		if err := s.adapter.ParseRow(values); err != nil {
-			return nil, err
-		}
+    var rowsData []map[string]any
+    for rows.Next() {
+        if err := rows.Scan(valuePtrs...); err != nil {
+            return nil, err
+        }
 
-		row := make(map[string]any)
-		for i, column := range columns {
-			row[column] = values[i]
-		}
-		rowsData = append(rowsData, row)
-	}
-	return rowsData, nil
+        if err := s.adapter.ParseRow(values); err != nil {
+            return nil, err
+        }
+
+        row := make(map[string]any)
+        for i, column := range columns {
+            row[column] = values[i]
+        }
+        rowsData = append(rowsData, row)
+    }
+    return rowsData, nil
 }
 
 // parsePkValueOverrides converts primary key starting/ending string values coming from db config files into values
 // usable by the db driver.
 func parsePkValueOverrides(values []string, primaryKeys []primary_key.Key, adapter ScanAdapter) ([]any, error) {
-	if len(values) == 0 {
-		return make([]any, 0), nil
-	}
+    if len(values) == 0 {
+        return make([]any, 0), nil
+    }
 
-	if len(values) != len(primaryKeys) {
-		return nil, fmt.Errorf("keys (%d), and override values (%d) length does not match, keys: %v, values: %v",
-			len(primaryKeys), len(values), primaryKeys, values)
-	}
+    if len(values) != len(primaryKeys) {
+        return nil, fmt.Errorf("keys (%d), and override values (%d) length does not match, keys: %v, values: %v",
+            len(primaryKeys), len(values), primaryKeys, values)
+    }
 
-	result := make([]any, len(values))
-	for i, value := range values {
-		parsedValue, err := adapter.ParsePrimaryKeyValueForOverrides(primaryKeys[i].Name, value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse value %q: %w", value, err)
-		}
-		result[i] = parsedValue
-	}
-	return result, nil
+    result := make([]any, len(values))
+    for i, value := range values {
+        parsedValue, err := adapter.ParsePrimaryKeyValueForOverrides(primaryKeys[i].Name, value)
+        if err != nil {
+            return nil, fmt.Errorf("failed to parse value %q: %w", value, err)
+        }
+        result[i] = parsedValue
+    }
+    return result, nil
 }

--- a/lib/rdbms/scan/scan.go
+++ b/lib/rdbms/scan/scan.go
@@ -1,184 +1,184 @@
 package scan
 
 import (
-    "database/sql"
-    "fmt"
-    "log/slog"
+	"database/sql"
+	"fmt"
+	"log/slog"
 
-    "github.com/artie-labs/reader/lib/rdbms/primary_key"
-    "github.com/artie-labs/transfer/lib/retry"
+	"github.com/artie-labs/reader/lib/rdbms/primary_key"
+	"github.com/artie-labs/transfer/lib/retry"
 )
 
 const (
-    jitterBaseMs = 300
-    jitterMaxMs  = 5000
+	jitterBaseMs = 300
+	jitterMaxMs  = 5000
 )
 
 type ScannerConfig struct {
-    BatchSize              uint
-    OptionalStartingValues []string
-    OptionalEndingValues   []string
-    ErrorRetries           int
+	BatchSize              uint
+	OptionalStartingValues []string
+	OptionalEndingValues   []string
+	ErrorRetries           int
 }
 
 type ScanAdapter interface {
-    ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error)
-    BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error)
-    ParseRow(row []any) error
+	ParsePrimaryKeyValueForOverrides(columnName string, value string) (any, error)
+	BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error)
+	ParseRow(row []any) error
 }
 
 type Scanner struct {
-    // immutable
-    db        *sql.DB
-    batchSize uint
-    retryCfg  retry.RetryConfig
-    adapter   ScanAdapter
+	// immutable
+	db        *sql.DB
+	batchSize uint
+	retryCfg  retry.RetryConfig
+	adapter   ScanAdapter
 
-    // mutable
-    primaryKeys  *primary_key.Keys
-    isFirstBatch bool
-    done         bool
+	// mutable
+	primaryKeys  *primary_key.Keys
+	isFirstBatch bool
+	done         bool
 }
 
 func NewScanner(db *sql.DB, _primaryKeys []primary_key.Key, cfg ScannerConfig, adapter ScanAdapter) (*Scanner, error) {
-    optionalStartingValues, err := parsePkValueOverrides(cfg.OptionalStartingValues, _primaryKeys, adapter)
-    if err != nil {
-        return nil, fmt.Errorf("failed to parse optional starting values: %w", err)
-    }
+	optionalStartingValues, err := parsePkValueOverrides(cfg.OptionalStartingValues, _primaryKeys, adapter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse optional starting values: %w", err)
+	}
 
-    optionalEndingValues, err := parsePkValueOverrides(cfg.OptionalEndingValues, _primaryKeys, adapter)
-    if err != nil {
-        return nil, fmt.Errorf("failed to parse optional ending values: %w", err)
-    }
+	optionalEndingValues, err := parsePkValueOverrides(cfg.OptionalEndingValues, _primaryKeys, adapter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse optional ending values: %w", err)
+	}
 
-    primaryKeys := primary_key.NewKeys(_primaryKeys)
-    if err := primaryKeys.LoadValues(optionalStartingValues, optionalEndingValues); err != nil {
-        return nil, fmt.Errorf("failed to override primary key values: %w", err)
-    }
+	primaryKeys := primary_key.NewKeys(_primaryKeys)
+	if err := primaryKeys.LoadValues(optionalStartingValues, optionalEndingValues); err != nil {
+		return nil, fmt.Errorf("failed to override primary key values: %w", err)
+	}
 
-    retryCfg, err := retry.NewJitterRetryConfig(jitterBaseMs, jitterMaxMs, cfg.ErrorRetries, retry.AlwaysRetry)
-    if err != nil {
-        return nil, fmt.Errorf("failed to build retry config: %w", err)
-    }
+	retryCfg, err := retry.NewJitterRetryConfig(jitterBaseMs, jitterMaxMs, cfg.ErrorRetries, retry.AlwaysRetry)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build retry config: %w", err)
+	}
 
-    return &Scanner{
-        db:           db,
-        batchSize:    cfg.BatchSize,
-        retryCfg:     retryCfg,
-        adapter:      adapter,
-        primaryKeys:  primaryKeys,
-        isFirstBatch: true,
-        done:         false,
-    }, nil
+	return &Scanner{
+		db:           db,
+		batchSize:    cfg.BatchSize,
+		retryCfg:     retryCfg,
+		adapter:      adapter,
+		primaryKeys:  primaryKeys,
+		isFirstBatch: true,
+		done:         false,
+	}, nil
 }
 
 func (s *Scanner) HasNext() bool {
-    return !s.done
+	return !s.done
 }
 
 func (s *Scanner) Next() ([]map[string]any, error) {
-    if !s.HasNext() {
-        return nil, fmt.Errorf("no more rows to scan")
-    }
+	if !s.HasNext() {
+		return nil, fmt.Errorf("no more rows to scan")
+	}
 
-    rows, err := s.scan()
-    if err != nil {
-        s.done = true
-        return nil, err
-    }
+	rows, err := s.scan()
+	if err != nil {
+		s.done = true
+		return nil, err
+	}
 
-    wasFirstBatch := s.isFirstBatch
-    s.isFirstBatch = false
+	wasFirstBatch := s.isFirstBatch
+	s.isFirstBatch = false
 
-    if len(rows) == 0 || s.primaryKeys.IsExhausted() {
-        s.done = true
-    } else {
-        // Update the starting keys so that the next scan will pick off where we last left off.
-        lastRow := rows[len(rows)-1]
-        var startingValuesChanged bool
-        for _, pk := range s.primaryKeys.Keys() {
-            changed, err := s.primaryKeys.UpdateStartingValue(pk.Name, lastRow[pk.Name])
-            if err != nil {
-                s.done = true
-                return nil, err
-            }
-            startingValuesChanged = startingValuesChanged || changed
-        }
+	if len(rows) == 0 || s.primaryKeys.IsExhausted() {
+		s.done = true
+	} else {
+		// Update the starting keys so that the next scan will pick off where we last left off.
+		lastRow := rows[len(rows)-1]
+		var startingValuesChanged bool
+		for _, pk := range s.primaryKeys.Keys() {
+			changed, err := s.primaryKeys.UpdateStartingValue(pk.Name, lastRow[pk.Name])
+			if err != nil {
+				s.done = true
+				return nil, err
+			}
+			startingValuesChanged = startingValuesChanged || changed
+		}
 
-        if !wasFirstBatch && !startingValuesChanged {
-            // Detect situations where the scanner is stuck in a loop.
-            // Typically, the second batch will use a > comparison instead of a >= comparison for the lower bound.
-            return nil, fmt.Errorf("primarky key start values did not change, scanner is likely stuck in a loop")
-        }
-    }
+		if !wasFirstBatch && !startingValuesChanged {
+			// Detect situations where the scanner is stuck in a loop.
+			// Typically, the second batch will use a > comparison instead of a >= comparison for the lower bound.
+			return nil, fmt.Errorf("primarky key start values did not change, scanner is likely stuck in a loop")
+		}
+	}
 
-    return rows, nil
+	return rows, nil
 }
 
 func (s *Scanner) scan() ([]map[string]any, error) {
-    query, parameters, err := s.adapter.BuildQuery(s.primaryKeys.Keys(), s.isFirstBatch, s.batchSize)
-    if err != nil {
-        return nil, fmt.Errorf("failed to build query: %w", err)
-    }
+	query, parameters, err := s.adapter.BuildQuery(s.primaryKeys.Keys(), s.isFirstBatch, s.batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build query: %w", err)
+	}
 
-    slog.Info("Scan query", slog.String("query", query), slog.Any("parameters", parameters))
+	slog.Info("Scan query", slog.String("query", query), slog.Any("parameters", parameters))
 
-    rows, err := retry.WithRetriesAndResult(s.retryCfg, func(_ int, _ error) (*sql.Rows, error) {
-        return s.db.Query(query, parameters...)
-    })
-    if err != nil {
-        return nil, fmt.Errorf("scan failed: %w", err)
-    }
+	rows, err := retry.WithRetriesAndResult(s.retryCfg, func(_ int, _ error) (*sql.Rows, error) {
+		return s.db.Query(query, parameters...)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan failed: %w", err)
+	}
 
-    columns, err := rows.Columns()
-    if err != nil {
-        return nil, fmt.Errorf("failed to get columns: %w", err)
-    }
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get columns: %w", err)
+	}
 
-    values := make([]any, len(columns))
-    valuePtrs := make([]any, len(values))
-    for i := range values {
-        valuePtrs[i] = &values[i]
-    }
+	values := make([]any, len(columns))
+	valuePtrs := make([]any, len(values))
+	for i := range values {
+		valuePtrs[i] = &values[i]
+	}
 
-    var rowsData []map[string]any
-    for rows.Next() {
-        if err := rows.Scan(valuePtrs...); err != nil {
-            return nil, err
-        }
+	var rowsData []map[string]any
+	for rows.Next() {
+		if err := rows.Scan(valuePtrs...); err != nil {
+			return nil, err
+		}
 
-        if err := s.adapter.ParseRow(values); err != nil {
-            return nil, err
-        }
+		if err := s.adapter.ParseRow(values); err != nil {
+			return nil, err
+		}
 
-        row := make(map[string]any)
-        for i, column := range columns {
-            row[column] = values[i]
-        }
-        rowsData = append(rowsData, row)
-    }
-    return rowsData, nil
+		row := make(map[string]any)
+		for i, column := range columns {
+			row[column] = values[i]
+		}
+		rowsData = append(rowsData, row)
+	}
+	return rowsData, nil
 }
 
 // parsePkValueOverrides converts primary key starting/ending string values coming from db config files into values
 // usable by the db driver.
 func parsePkValueOverrides(values []string, primaryKeys []primary_key.Key, adapter ScanAdapter) ([]any, error) {
-    if len(values) == 0 {
-        return make([]any, 0), nil
-    }
+	if len(values) == 0 {
+		return make([]any, 0), nil
+	}
 
-    if len(values) != len(primaryKeys) {
-        return nil, fmt.Errorf("keys (%d), and override values (%d) length does not match, keys: %v, values: %v",
-            len(primaryKeys), len(values), primaryKeys, values)
-    }
+	if len(values) != len(primaryKeys) {
+		return nil, fmt.Errorf("keys (%d), and override values (%d) length does not match, keys: %v, values: %v",
+			len(primaryKeys), len(values), primaryKeys, values)
+	}
 
-    result := make([]any, len(values))
-    for i, value := range values {
-        parsedValue, err := adapter.ParsePrimaryKeyValueForOverrides(primaryKeys[i].Name, value)
-        if err != nil {
-            return nil, fmt.Errorf("failed to parse value %q: %w", value, err)
-        }
-        result[i] = parsedValue
-    }
-    return result, nil
+	result := make([]any, len(values))
+	for i, value := range values {
+		parsedValue, err := adapter.ParsePrimaryKeyValueForOverrides(primaryKeys[i].Name, value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse value %q: %w", value, err)
+		}
+		result[i] = parsedValue
+	}
+	return result, nil
 }

--- a/lib/rdbms/scan/scan_test.go
+++ b/lib/rdbms/scan/scan_test.go
@@ -20,7 +20,7 @@ func (m mockAdapter) ParsePrimaryKeyValueForOverrides(columnName string, value s
 	}
 }
 
-func (mockAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any) {
+func (mockAdapter) BuildQuery(primaryKeys []primary_key.Key, isFirstBatch bool, batchSize uint) (string, []any, error) {
 	panic("not implemented")
 }
 


### PR DESCRIPTION
MSSQL now supports all data types as primary keys.

I also modified the signature of `BuildQuery` to return an error as the MySQL SDK requires us to explicitly parse out `time.Time` 