### PR TITLE
[DynamoDB] Increase shard buffer from 26h => 48h.

### DIFF
--- a/sources/dynamodb/offsets/offsets.go
+++ b/sources/dynamodb/offsets/offsets.go
@@ -7,7 +7,8 @@ import (
 	"github.com/artie-labs/reader/lib/ttlmap"
 )
 
-const ShardExpirationAndBuffer = 26 * time.Hour
+// ShardExpirationAndBuffer - Buffer for when a shard is closed as the records have a TTL of 24h. However, garbage collection is async.
+const ShardExpirationAndBuffer = 2 * 24 * time.Hour
 
 type OffsetStorage struct {
 	ttlMap *ttlmap.TTLMap


### PR DESCRIPTION
The current buffer is too short as it only gives 2 hours for garbage collection to run