### PR TITLE
Adding PersistedMap

### DIFF
--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -64,12 +64,12 @@ func (p *PersistedMap) flushRoutine() {
 }
 
 func (p *PersistedMap) flush() error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
 	if !p.shouldSave {
 		return nil
 	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	file, err := os.Create(p.filePath)
 	if err != nil {

--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -1,0 +1,120 @@
+package persistedmap
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v3"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/artie-labs/reader/lib/logger"
+)
+
+type PersistedMap struct {
+	filePath    string
+	shouldSave  bool
+	mu          sync.RWMutex
+	data        map[string]any
+	flushTicker *time.Ticker
+}
+
+func NewPersistedMap(filePath string) *PersistedMap {
+	persistedMap := &PersistedMap{
+		filePath: filePath,
+		data:     make(map[string]any),
+	}
+
+	if err := persistedMap.loadFromFile(); err != nil {
+		slog.Warn("Failed to load persisted map from filepath, starting a new one...", slog.Any("err", err))
+	}
+
+	persistedMap.flushTicker = time.NewTicker(30 * time.Second)
+	go persistedMap.flushRoutine()
+
+	return persistedMap
+}
+
+func (p *PersistedMap) Set(key string, value any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.data[key] = value
+	p.shouldSave = true
+}
+
+func (p *PersistedMap) Get(key string) (any, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	value, isOk := p.data[key]
+	return value, isOk
+}
+
+func (p *PersistedMap) flushRoutine() {
+	for {
+		select {
+		case <-p.flushTicker.C:
+			if err := p.flush(); err != nil {
+				logger.Panic("failed to flush data", slog.Any("err", err))
+			}
+		}
+	}
+}
+
+func (p *PersistedMap) flush() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.shouldSave {
+		return nil
+	}
+
+	file, err := os.Create(p.filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+
+	yamlBytes, err := yaml.Marshal(p.data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	if _, err = file.Write(yamlBytes); err != nil {
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+
+	defer file.Close()
+
+	p.shouldSave = false
+	return nil
+}
+
+func (p *PersistedMap) loadFromFile() error {
+	file, err := os.Open(p.filePath)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	readBytes, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var data map[string]any
+	if err = yaml.Unmarshal(readBytes, &data); err != nil {
+		return fmt.Errorf("failed to unmarshal data: %w", err)
+	}
+
+	if data == nil {
+		data = make(map[string]any)
+	}
+
+	p.mu.Lock()
+	p.data = data
+	p.mu.Unlock()
+	return nil
+}

--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -53,12 +53,9 @@ func (p *PersistedMap) Get(key string) (any, bool) {
 }
 
 func (p *PersistedMap) flushRoutine() {
-	for {
-		select {
-		case <-p.flushTicker.C:
-			if err := p.flush(); err != nil {
-				logger.Panic("failed to flush data", slog.Any("err", err))
-			}
+	for range p.flushTicker.C {
+		if err := p.flush(); err != nil {
+			logger.Panic("Failed to flush data", slog.Any("err", err))
 		}
 	}
 }

--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -62,12 +62,11 @@ func (p *PersistedMap) flushRoutine() {
 
 func (p *PersistedMap) flush() error {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	if !p.shouldSave {
 		return nil
 	}
-
-	defer p.mu.Unlock()
 
 	file, err := os.Create(p.filePath)
 	if err != nil {

--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -28,7 +28,7 @@ func NewPersistedMap(filePath string) *PersistedMap {
 
 	data, err := loadFromFile(filePath)
 	if err != nil {
-		logger.Panic("Failed to load persisted map from filepath", err)
+		logger.Panic("Failed to load persisted map from filepath", slog.Any("err", err))
 	}
 
 	if len(data) > 0 {

--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -61,11 +61,12 @@ func (p *PersistedMap) flushRoutine() {
 }
 
 func (p *PersistedMap) flush() error {
+	p.mu.Lock()
+
 	if !p.shouldSave {
 		return nil
 	}
 
-	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	file, err := os.Create(p.filePath)

--- a/lib/persistedmap/persistedmap.go
+++ b/lib/persistedmap/persistedmap.go
@@ -73,6 +73,8 @@ func (p *PersistedMap) flush() error {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
 
+	defer file.Close()
+
 	yamlBytes, err := yaml.Marshal(p.data)
 	if err != nil {
 		return fmt.Errorf("failed to marshal data: %w", err)
@@ -81,8 +83,6 @@ func (p *PersistedMap) flush() error {
 	if _, err = file.Write(yamlBytes); err != nil {
 		return fmt.Errorf("failed to write to file: %w", err)
 	}
-
-	defer file.Close()
 
 	p.shouldSave = false
 	return nil

--- a/lib/persistedmap/persistedmap_test.go
+++ b/lib/persistedmap/persistedmap_test.go
@@ -1,0 +1,60 @@
+package persistedmap
+
+import (
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+	"os"
+	"testing"
+)
+
+func TestPersistedMap_LoadFromFile(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "persistedmap_test")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	// Write initial data to the file
+	initialData := map[string]any{"key1": "value1", "key2": 2}
+	yamlBytes, err := yaml.Marshal(initialData)
+	assert.NoError(t, err)
+	_, err = tmpFile.Write(yamlBytes)
+	assert.NoError(t, err)
+	tmpFile.Close()
+
+	// Load the data from the file into PersistedMap
+	pMap := NewPersistedMap(tmpFile.Name())
+	pMap.mu.Lock()
+	defer pMap.mu.Unlock()
+	assert.Equal(t, initialData, pMap.data)
+}
+
+func TestPersistedMap_Flush(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "persistedmap_test")
+	assert.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+
+	pMap := NewPersistedMap(tmpFile.Name())
+	pMap.Set("key1", "value1")
+	pMap.Set("key2", 2)
+
+	assert.NoError(t, pMap.flush())
+
+	// Does the data exist?
+
+	val, isOk := pMap.Get("key1")
+	assert.True(t, isOk)
+	assert.Equal(t, "value1", val)
+
+	val, isOk = pMap.Get("key2")
+	assert.Equal(t, 2, val)
+	assert.True(t, isOk)
+
+	// If I load a new persisted map, does it come back?
+	pMap2 := NewPersistedMap(tmpFile.Name())
+	val, isOk = pMap2.Get("key1")
+	assert.True(t, isOk)
+	assert.Equal(t, "value1", val)
+
+	val, isOk = pMap2.Get("key2")
+	assert.Equal(t, 2, val)
+	assert.True(t, isOk)
+}

--- a/lib/persistedmap/persistedmap_test.go
+++ b/lib/persistedmap/persistedmap_test.go
@@ -39,7 +39,6 @@ func TestPersistedMap_Flush(t *testing.T) {
 	assert.NoError(t, pMap.flush())
 
 	// Does the data exist?
-
 	val, isOk := pMap.Get("key1")
 	assert.True(t, isOk)
 	assert.Equal(t, "value1", val)
@@ -48,7 +47,7 @@ func TestPersistedMap_Flush(t *testing.T) {
 	assert.Equal(t, 2, val)
 	assert.True(t, isOk)
 
-	// If I load a new persisted map, does it come back?
+	// If I load a new PersistedMap, does it come back?
 	pMap2 := NewPersistedMap(tmpFile.Name())
 	val, isOk = pMap2.Get("key1")
 	assert.True(t, isOk)

--- a/lib/persistedmap/persistedmap_test.go
+++ b/lib/persistedmap/persistedmap_test.go
@@ -28,10 +28,9 @@ func TestPersistedMap_LoadFromFile(t *testing.T) {
 }
 
 func TestPersistedMap_Flush(t *testing.T) {
-	tmpFile, err := os.Create(fmt.Sprintf("%s/persistedmap_test", t.TempDir()))
-	assert.NoError(t, err)
+	tmpFile := fmt.Sprintf("%s/persistedmap_test", t.TempDir())
 
-	pMap := NewPersistedMap(tmpFile.Name())
+	pMap := NewPersistedMap(tmpFile)
 	pMap.Set("key1", "value1")
 	pMap.Set("key2", 2)
 
@@ -47,7 +46,7 @@ func TestPersistedMap_Flush(t *testing.T) {
 	assert.True(t, isOk)
 
 	// If I load a new PersistedMap, does it come back?
-	pMap2 := NewPersistedMap(tmpFile.Name())
+	pMap2 := NewPersistedMap(tmpFile)
 	val, isOk = pMap2.Get("key1")
 	assert.True(t, isOk)
 	assert.Equal(t, "value1", val)

--- a/lib/persistedmap/persistedmap_test.go
+++ b/lib/persistedmap/persistedmap_test.go
@@ -1,6 +1,7 @@
 package persistedmap
 
 import (
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 	"os"
@@ -8,9 +9,8 @@ import (
 )
 
 func TestPersistedMap_LoadFromFile(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "persistedmap_test")
+	tmpFile, err := os.Create(fmt.Sprintf("%s/foo", t.TempDir()))
 	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
 
 	// Write initial data to the file
 	initialData := map[string]any{"key1": "value1", "key2": 2}
@@ -28,9 +28,8 @@ func TestPersistedMap_LoadFromFile(t *testing.T) {
 }
 
 func TestPersistedMap_Flush(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "persistedmap_test")
+	tmpFile, err := os.Create(fmt.Sprintf("%s/persistedmap_test", t.TempDir()))
 	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
 
 	pMap := NewPersistedMap(tmpFile.Name())
 	pMap.Set("key1", "value1")

--- a/lib/ttlmap/ttlmap.go
+++ b/lib/ttlmap/ttlmap.go
@@ -126,6 +126,8 @@ func (t *TTLMap) flush() error {
 		return fmt.Errorf("failed to create file: %w", err)
 	}
 
+	defer file.Close()
+
 	dataToSave := make(map[string]*ItemWrapper)
 	for key, val := range t.data {
 		if val.DoNotFlushToDisk {
@@ -144,7 +146,6 @@ func (t *TTLMap) flush() error {
 		return fmt.Errorf("failed to write to file: %w", err)
 	}
 
-	defer file.Close()
 	t.shouldSave = false
 	return nil
 }


### PR DESCRIPTION
Adding a new storage option called PersistedMap which is necessary for storing offsets for different databases when we implement streaming