### PR TITLE
DynamoDB - Respect lineage

### DIFF
--- a/sources/dynamodb/offsets/offsets.go
+++ b/sources/dynamodb/offsets/offsets.go
@@ -14,6 +14,23 @@ type OffsetStorage struct {
 	ttlMap *ttlmap.TTLMap
 }
 
+func shardSeenKey(shardId string) string {
+	return fmt.Sprintf("seen#shardId#%s", shardId)
+}
+
+func (o *OffsetStorage) SetShardSeen(shardID string) {
+	o.ttlMap.Set(ttlmap.SetArgs{
+		Key:              shardSeenKey(shardID),
+		Value:            true,
+		DoNotFlushToDisk: true,
+	}, ShardExpirationAndBuffer)
+}
+
+func (o *OffsetStorage) GetShardSeen(shardID string) bool {
+	_, isOk := o.ttlMap.Get(shardSeenKey(shardID))
+	return isOk
+}
+
 func shardProcessingKey(shardId string) string {
 	return fmt.Sprintf("processing#shardId#%s", shardId)
 }

--- a/sources/dynamodb/shard.go
+++ b/sources/dynamodb/shard.go
@@ -30,10 +30,9 @@ func (s *StreamStore) processShard(ctx context.Context, shard *dynamodbstreams.S
 
 	if shard.ParentShardId != nil {
 		parentID := *shard.ParentShardId
-		if !s.storage.GetShardProcessed(parentID) && s.storage.GetShardProcessing(parentID) {
-			slog.Info("Parent shard is being processed, let's sleep and retry", slog.String("shardId", *shard.ShardId))
-
-			time.Sleep(jitter.Jitter(500, jitter.DefaultMaxMs, 0))
+		if s.storage.GetShardProcessing(parentID) && !s.storage.GetShardProcessed(parentID) {
+			slog.Info("Parent shard is being processed, let's sleep 3s and retry", slog.String("shardId", *shard.ShardId))
+			time.Sleep(3 * time.Second)
 			s.processShard(ctx, shard, writer)
 			return
 		}

--- a/sources/dynamodb/stream.go
+++ b/sources/dynamodb/stream.go
@@ -65,6 +65,11 @@ func (s *StreamStore) scanForNewShards() error {
 			return fmt.Errorf("failed to describe stream: %w", err)
 		}
 
+		// We need two loops because we need to mark all the shards as "SEEN" before we process.
+		for _, shard := range result.StreamDescription.Shards {
+			s.storage.SetShardSeen(*shard.ShardId)
+		}
+
 		for _, shard := range result.StreamDescription.Shards {
 			s.shardChan <- shard
 		}


### PR DESCRIPTION
There is an edge case with DynamoDB where if the same record appeared in two different DynamoDB shards (parent -> child), we are processing them in parallel as opposed to sequentially.

This is mainly an issue if a DynamoDB stream hasn't been consumed in a while since shards are records and time based.


Per [SDK docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html#Streams.Processing):

> Because shards have a lineage (parent and children), **an application must always process a parent shard before it processes a child shard**. This helps ensure that the stream records are also processed in the correct order. (If you use the DynamoDB Streams Kinesis Adapter, this is handled for you. Your application processes the shards and stream records in the correct order. It automatically handles new or expired shards, in addition to shards that split while the application is running. For more information, see [Using the DynamoDB Streams Kinesis adapter to process stream records](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.KCLAdapter.html).)