### PR TITLE
Add version to GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,7 @@
 project_name: artie-reader
 
-# .goreleaser.yaml
+version: 2
+
 before:
   hooks:
     # You may remove this if you don't use go modules.
@@ -66,8 +67,3 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
-
-# The lines beneath this are called `modelines`. See `:help modeline`
-# Feel free to remove those if you don't want/use them.
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
-# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
Fixes:
> only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration

See https://goreleaser.com/blog/goreleaser-v2/