### PR TITLE
MySQL datetime guardrail

### DIFF
--- a/lib/mysql/schema/convert.go
+++ b/lib/mysql/schema/convert.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strings"
 	"time"
 )
 
@@ -82,9 +83,8 @@ func ConvertValue(value any, colType DataType) (any, error) {
 			return nil, fmt.Errorf("expected []byte got %T for value: %v", value, value)
 		}
 
-		if string(bytesValue) == "0000-00-00 00:00:00" {
-			// MySQL supports '0000-00-00 00:00:00' for datetime columns.
-			// We are returning `nil` here because this will fail most Time parsers.
+		if strings.HasSuffix(string(bytesValue), "-00-00 00:00:00") {
+			// If MySQL strict mode isn't turned on, it can allow invalid dates like 2020-00-00 00:00:00 or 0000-00-00 00:00:00
 			return nil, nil
 		}
 

--- a/lib/mysql/schema/convert.go
+++ b/lib/mysql/schema/convert.go
@@ -83,12 +83,13 @@ func ConvertValue(value any, colType DataType) (any, error) {
 			return nil, fmt.Errorf("expected []byte got %T for value: %v", value, value)
 		}
 
-		if strings.HasSuffix(string(bytesValue), "-00-00 00:00:00") {
+		stringValue := string(bytesValue)
+		if strings.HasSuffix(stringValue, "-00-00 00:00:00") {
 			// If MySQL strict mode isn't turned on, it can allow invalid dates like 2020-00-00 00:00:00 or 0000-00-00 00:00:00
 			return nil, nil
 		}
 
-		timeValue, err := time.Parse(DateTimeFormat, string(bytesValue))
+		timeValue, err := time.Parse(DateTimeFormat, stringValue)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/mysql/schema/convert.go
+++ b/lib/mysql/schema/convert.go
@@ -85,7 +85,7 @@ func ConvertValue(value any, colType DataType) (any, error) {
 		}
 
 		stringValue := string(bytesValue)
-		if hasNonStrictModeDate(stringValue) {
+		if hasNonStrictModeInvalidDate(stringValue) {
 			return nil, nil
 		}
 
@@ -186,8 +186,8 @@ func ConvertValues(values []any, cols []Column) error {
 	return nil
 }
 
-// hasNonStrictModeDate - if strict mode is not enabled, we can end up having invalid datetimes
-func hasNonStrictModeDate(d string) bool {
+// hasNonStrictModeInvalidDate - if strict mode is not enabled, we can end up having invalid datetimes
+func hasNonStrictModeInvalidDate(d string) bool {
 	if len(d) < 10 {
 		return false
 	}

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -318,3 +318,13 @@ func TestConvertValues(t *testing.T) {
 		assert.Equal(t, []any{int64(1234), "hello world", true}, values)
 	}
 }
+
+func TestHasNonStrictModeDate(t *testing.T) {
+	assert.False(t, hasNonStrictModeDate("2021-01-02"))
+	assert.False(t, hasNonStrictModeDate("2021-01-02 03:04:05"))
+
+	assert.True(t, hasNonStrictModeDate("2009-00-00"))
+	assert.True(t, hasNonStrictModeDate("0000-00-00"))
+	assert.True(t, hasNonStrictModeDate("0000-00-00 00:00:00"))
+	assert.True(t, hasNonStrictModeDate("2009-00-00 00:00:00"))
+}

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -320,7 +320,10 @@ func TestConvertValues(t *testing.T) {
 }
 
 func TestHasNonStrictModeDate(t *testing.T) {
+	assert.False(t, hasNonStrictModeDate(""))
+	assert.False(t, hasNonStrictModeDate("hello world"))
 	assert.False(t, hasNonStrictModeDate("2021-01-02"))
+	assert.False(t, hasNonStrictModeDate("2021--01-02"))
 	assert.False(t, hasNonStrictModeDate("2021-01-02 03:04:05"))
 
 	assert.True(t, hasNonStrictModeDate("2009-00-00"))

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -319,15 +319,15 @@ func TestConvertValues(t *testing.T) {
 	}
 }
 
-func TestHasNonStrictModeDate(t *testing.T) {
-	assert.False(t, hasNonStrictModeDate(""))
-	assert.False(t, hasNonStrictModeDate("hello world"))
-	assert.False(t, hasNonStrictModeDate("2021-01-02"))
-	assert.False(t, hasNonStrictModeDate("2021--01-02"))
-	assert.False(t, hasNonStrictModeDate("2021-01-02 03:04:05"))
+func TestHasNonStrictModeInvalidDate(t *testing.T) {
+	assert.False(t, hasNonStrictModeInvalidDate(""))
+	assert.False(t, hasNonStrictModeInvalidDate("hello world"))
+	assert.False(t, hasNonStrictModeInvalidDate("2021-01-02"))
+	assert.False(t, hasNonStrictModeInvalidDate("2021--01-02"))
+	assert.False(t, hasNonStrictModeInvalidDate("2021-01-02 03:04:05"))
 
-	assert.True(t, hasNonStrictModeDate("2009-00-00"))
-	assert.True(t, hasNonStrictModeDate("0000-00-00"))
-	assert.True(t, hasNonStrictModeDate("0000-00-00 00:00:00"))
-	assert.True(t, hasNonStrictModeDate("2009-00-00 00:00:00"))
+	assert.True(t, hasNonStrictModeInvalidDate("2009-00-00"))
+	assert.True(t, hasNonStrictModeInvalidDate("0000-00-00"))
+	assert.True(t, hasNonStrictModeInvalidDate("0000-00-00 00:00:00"))
+	assert.True(t, hasNonStrictModeInvalidDate("2009-00-00 00:00:00"))
 }


### PR DESCRIPTION
If strict mode isn't enabled, MySQL may allow invalid datetime / timestamps.