### PR TITLE
[Postgres] Native support for `TIME WITH TIME ZONE`

### DIFF
--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -508,11 +508,11 @@ const expectedPayloadTemplate = `{
 						"parameters": null
 					},
 					{
-						"type": "int32",
+						"type": "string",
 						"optional": false,
 						"default": null,
 						"field": "c_time_with_timezone",
-						"name": "io.debezium.time.Time",
+						"name": "io.debezium.time.ZonedTime",
 						"parameters": null
 					},
 					{
@@ -693,7 +693,7 @@ const expectedPayloadTemplate = `{
 			"c_serial": 1000000123,
 			"c_smallint": 32767,
 			"c_text": "QWERTYUIOP",
-			"c_time_with_timezone": 38057000,
+			"c_time_with_timezone": "10:34:17.000000Z",
 			"c_time_without_timezone": 45296000,
 			"c_timestamp_with_timezone": "2001-02-16T13:38:40Z",
 			"c_timestamp_without_timezone": 982355920000000,

--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -217,7 +217,7 @@ INSERT INTO %s VALUES (
 	-- c_time_without_timezone
 		'12:34:56',
 	-- c_time_with_timezone
-		time with time zone '05:34:17-05',
+		time with time zone '05:34:17.746572-05',
 	-- c_timestamp_without_timezone
 		'2001-02-16 20:38:40',
 	-- c_timestamp_with_timezone
@@ -693,7 +693,7 @@ const expectedPayloadTemplate = `{
 			"c_serial": 1000000123,
 			"c_smallint": 32767,
 			"c_text": "QWERTYUIOP",
-			"c_time_with_timezone": "10:34:17.000000000Z",
+			"c_time_with_timezone": "10:34:17.746572",
 			"c_time_without_timezone": 45296000,
 			"c_timestamp_with_timezone": "2001-02-16T13:38:40Z",
 			"c_timestamp_without_timezone": 982355920000000,

--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -693,7 +693,7 @@ const expectedPayloadTemplate = `{
 			"c_serial": 1000000123,
 			"c_smallint": 32767,
 			"c_text": "QWERTYUIOP",
-			"c_time_with_timezone": "10:34:17.000000Z",
+			"c_time_with_timezone": "10:34:17.000000000Z",
 			"c_time_without_timezone": 45296000,
 			"c_timestamp_with_timezone": "2001-02-16T13:38:40Z",
 			"c_timestamp_without_timezone": 982355920000000,

--- a/lib/postgres/parse/parse.go
+++ b/lib/postgres/parse/parse.go
@@ -45,7 +45,14 @@ func ParseValue(colKind schema.DataType, value any) (any, error) {
 		}
 
 		return nil, fmt.Errorf("value: %v not of string type for Numeric or VariableNumeric", value)
-	case schema.Time, schema.TimeWithTimeZone:
+	case schema.TimeWithTimeZone:
+		stringValue, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
+		}
+
+		return stringValue, nil
+	case schema.Time:
 		stringValue, ok := value.(string)
 		if !ok {
 			return nil, fmt.Errorf("expected string got %T with value: %v", value, value)

--- a/lib/postgres/parse/parse_test.go
+++ b/lib/postgres/parse/parse_test.go
@@ -65,19 +65,13 @@ func TestParse(t *testing.T) {
 			name:          "time with time zone - one second",
 			dataType:      schema.TimeWithTimeZone,
 			value:         "00:00:01",
-			expectedValue: pgtype.Time{Microseconds: 100_0000, Valid: true},
+			expectedValue: "00:00:01",
 		},
 		{
 			name:          "time with time zone  - 24 hours",
 			dataType:      schema.TimeWithTimeZone,
 			value:         "24:00:00",
-			expectedValue: pgtype.Time{Microseconds: 86_400_000_000, Valid: true},
-		},
-		{
-			name:        "time with time zone  - malformed",
-			dataType:    schema.TimeWithTimeZone,
-			value:       "blah",
-			expectedErr: `failed to parse time value "blah": cannot decode blah into Time`,
+			expectedValue: "24:00:00",
 		},
 		{
 			name:          "interval",

--- a/lib/postgres/scanner.go
+++ b/lib/postgres/scanner.go
@@ -142,11 +142,6 @@ func (s scanAdapter) ParsePrimaryKeyValueForOverrides(columnName string, value s
 func castColumn(col schema.Column) string {
 	colName := pgx.Identifier{col.Name}.Sanitize()
 	switch col.Type {
-	case schema.TimeWithTimeZone:
-		// If we don't convert `time with time zone` to UTC we end up with strings like `10:23:54-02`
-		// And pgtype.Time doesn't parse the offset properly.
-		// See https://github.com/jackc/pgx/issues/1940
-		return fmt.Sprintf(`%s AT TIME ZONE 'UTC' AS %q`, colName, col.Name)
 	case schema.Array:
 		return fmt.Sprintf(`ARRAY_TO_JSON(%s)::TEXT as %q`, colName, col.Name)
 	default:

--- a/lib/postgres/scanner_test.go
+++ b/lib/postgres/scanner_test.go
@@ -28,11 +28,6 @@ func TestCastColumn(t *testing.T) {
 			dataType: schema.Text,
 			expected: `"foo"`,
 		},
-		{
-			name:     "time with time zone",
-			dataType: schema.TimeWithTimeZone,
-			expected: `"foo" AT TIME ZONE 'UTC' AS "foo"`,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/lib/timeutil/exact.go
+++ b/lib/timeutil/exact.go
@@ -1,0 +1,19 @@
+package timeutil
+
+import (
+	"fmt"
+	"time"
+)
+
+func ParseExact(value string, layouts []string) (time.Time, error) {
+	for _, layout := range layouts {
+		// If the value is parsed successfully and the parsed value is the same as the original value, return the parsed value.
+		parsed, err := time.Parse(layout, value)
+		if err == nil && parsed.Format(layout) == value {
+			return parsed, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("failed to parse exact time value: %q", value)
+
+}

--- a/lib/timeutil/exact_test.go
+++ b/lib/timeutil/exact_test.go
@@ -1,0 +1,22 @@
+package timeutil
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestParseExact(t *testing.T) {
+	{
+		// Bad
+		layouts := []string{time.TimeOnly}
+		_, err := ParseExact("2021-01-01", layouts)
+		assert.Error(t, err)
+	}
+	{
+		// Expected
+		layouts := []string{time.DateOnly}
+		_, err := ParseExact("2021-01-01", layouts)
+		assert.NoError(t, err)
+	}
+}

--- a/lib/timeutil/exact_test.go
+++ b/lib/timeutil/exact_test.go
@@ -11,11 +11,17 @@ func TestParseExact(t *testing.T) {
 		// Bad
 		layouts := []string{time.TimeOnly}
 		_, err := ParseExact("2021-01-01", layouts)
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, `failed to parse exact time value: "2021-01-01"`)
 	}
 	{
-		// Expected
-		layouts := []string{time.DateOnly}
+		// Both should be bad.
+		layouts := []string{time.DateTime, time.TimeOnly}
+		_, err := ParseExact("2021-01-01", layouts)
+		assert.ErrorContains(t, err, `failed to parse exact time value: "2021-01-01"`)
+	}
+	{
+		// Good
+		layouts := []string{time.DateTime, time.DateOnly, time.TimeOnly}
 		_, err := ParseExact("2021-01-01", layouts)
 		assert.NoError(t, err)
 	}

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -103,7 +103,9 @@ func valueConverterForType(dataType schema.DataType, opts *schema.Opts) (convert
 		return converters.BytesPassthrough{}, nil
 	case schema.Text, schema.UserDefinedText:
 		return converters.StringPassthrough{}, nil
-	case schema.Time, schema.TimeWithTimeZone:
+	case schema.TimeWithTimeZone:
+		return TimeWithTimezoneConverter{}, nil
+	case schema.Time:
 		return PgTimeConverter{}, nil
 	case schema.Date:
 		return converters.DateConverter{}, nil

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -207,8 +207,8 @@ func TestValueConverterForType_Convert(t *testing.T) {
 		{
 			name:          "time with time zone (postgres.Date)",
 			col:           schema.Column{Name: "t_w_tz", Type: schema.TimeWithTimeZone},
-			value:         "12:00:00+07",
-			expectedValue: "05:00:00.000000Z",
+			value:         "12:00:00.123456789+07",
+			expectedValue: "05:00:00.123456789Z",
 		},
 		{
 			name: "numeric (postgres.Numeric)",

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -208,7 +208,7 @@ func TestValueConverterForType_Convert(t *testing.T) {
 			name:          "time with time zone (postgres.Date)",
 			col:           schema.Column{Name: "t_w_tz", Type: schema.TimeWithTimeZone},
 			value:         "12:00:00.123456789+07",
-			expectedValue: "05:00:00.123456789Z",
+			expectedValue: "05:00:00.123456",
 		},
 		{
 			name: "numeric (postgres.Numeric)",

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -146,9 +146,9 @@ func TestValueConverterForType_ToField(t *testing.T) {
 			colName:  "time",
 			dataType: schema.TimeWithTimeZone,
 			expected: debezium.Field{
-				Type:         "int32",
+				Type:         "string",
 				FieldName:    "time",
-				DebeziumType: debezium.Time,
+				DebeziumType: debezium.TimeWithTimezone,
 			},
 		},
 		{

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -207,7 +207,7 @@ func TestValueConverterForType_Convert(t *testing.T) {
 		{
 			name:          "time with time zone (postgres.Date)",
 			col:           schema.Column{Name: "t_w_tz", Type: schema.TimeWithTimeZone},
-			value:         "12:00:00.123456789+07",
+			value:         "12:00:00.123456+07",
 			expectedValue: "05:00:00.123456",
 		},
 		{

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -205,6 +205,12 @@ func TestValueConverterForType_Convert(t *testing.T) {
 			expectedValue: int32(19480),
 		},
 		{
+			name:          "time with time zone (postgres.Date)",
+			col:           schema.Column{Name: "t_w_tz", Type: schema.TimeWithTimeZone},
+			value:         "12:00:00+07",
+			expectedValue: "05:00:00.000000Z",
+		},
+		{
 			name: "numeric (postgres.Numeric)",
 			col: schema.Column{Name: "numeric_col", Type: schema.Numeric, Opts: &schema.Opts{
 				Scale:     2,

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/artie-labs/reader/lib/timeutil"
 	"github.com/artie-labs/transfer/lib/debezium"
+	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -26,11 +27,11 @@ func (TimeWithTimezoneConverter) Convert(value any) (any, error) {
 		return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
 	}
 
+	// No nanosecond precision because the data type only goes to ms.
 	layouts := []string{
-		"15:04:05-07",           // w/o fractional seconds
-		"15:04:05.000-07",       // ms
-		"15:04:05.000000-07",    // microseconds
-		"15:04:05.000000000-07", // ns
+		"15:04:05-07",        // w/o fractional seconds
+		"15:04:05.000-07",    // ms
+		"15:04:05.000000-07", // microseconds
 	}
 
 	timeValue, err := timeutil.ParseExact(stringValue, layouts)
@@ -40,8 +41,7 @@ func (TimeWithTimezoneConverter) Convert(value any) (any, error) {
 
 	// Convert `time.Time` into GMT
 	// Then convert back into a string with ns precision
-	outputLayout := "15:04:05.000000000Z"
-	return timeValue.UTC().Format(outputLayout), nil
+	return timeValue.UTC().Format(ext.PostgresTimeFormatNoTZ), nil
 }
 
 type PgTimeConverter struct{}

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -38,9 +38,9 @@ func (TimeWithTimezoneConverter) Convert(value any) (any, error) {
 		return nil, fmt.Errorf("failed to parse time value %q: %w", stringValue, err)
 	}
 
-	// We need to parse this value into `time.Time`
-	// Then convert it back into a string where the timezone is GMT to match Debezium.
-	outputLayout := "15:04:05.000000Z"
+	// Convert `time.Time` into GMT
+	// Then convert back into a string with ns precision
+	outputLayout := "15:04:05.000000000Z"
 	return timeValue.UTC().Format(outputLayout), nil
 }
 

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -2,10 +2,10 @@ package adapter
 
 import (
 	"fmt"
-	"github.com/artie-labs/reader/lib/timeutil"
 	"math"
 	"time"
 
+	"github.com/artie-labs/reader/lib/timeutil"
 	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/jackc/pgx/v5/pgtype"
 )

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"fmt"
+	"github.com/artie-labs/reader/lib/timeutil"
 	"math"
 	"time"
 
@@ -25,8 +26,14 @@ func (TimeWithTimezoneConverter) Convert(value any) (any, error) {
 		return nil, fmt.Errorf("expected string got %T with value: %v", value, value)
 	}
 
-	inputLayout := "15:04:05.000000-07"
-	timeValue, err := time.Parse(inputLayout, stringValue)
+	layouts := []string{
+		"15:04:05-07",           // w/o fractional seconds
+		"15:04:05.000-07",       // ms
+		"15:04:05.000000-07",    // microseconds
+		"15:04:05.000000000-07", // ns
+	}
+
+	timeValue, err := timeutil.ParseExact(stringValue, layouts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse time value %q: %w", stringValue, err)
 	}


### PR DESCRIPTION
As per title. This is following the same spec as Debezium.