### PR TITLE
[Kafka] Supporting SCRAM-SHA-512

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,11 +13,36 @@ import (
 )
 
 type Kafka struct {
+	// Required
 	BootstrapServers string `yaml:"bootstrapServers"`
 	TopicPrefix      string `yaml:"topicPrefix"`
-	AwsEnabled       bool   `yaml:"awsEnabled"`
-	PublishSize      uint   `yaml:"publishSize,omitempty"`
-	MaxRequestSize   uint64 `yaml:"maxRequestSize,omitempty"`
+	// Optional
+	AwsEnabled     bool   `yaml:"awsEnabled"`
+	PublishSize    uint   `yaml:"publishSize,omitempty"`
+	MaxRequestSize uint64 `yaml:"maxRequestSize,omitempty"`
+	// If username and password are passed in, we'll use SCRAM w/ SHA512.
+	Username string `yaml:"username,omitempty"`
+	Password string `yaml:"password,omitempty"`
+}
+
+type Mechanism string
+
+const (
+	None        Mechanism = ""
+	ScramSha512 Mechanism = "SCRAM-SHA-512"
+	AwsMskIam   Mechanism = "AWS-MSK-IAM"
+)
+
+func (k *Kafka) Mechanism() Mechanism {
+	if k.Username != "" {
+		return ScramSha512
+	}
+
+	if k.AwsEnabled {
+		return AwsMskIam
+	}
+
+	return None
 }
 
 func (k *Kafka) BootstrapAddresses() []string {

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ const (
 )
 
 func (k *Kafka) Mechanism() Mechanism {
-	if k.Username != "" {
+	if k.Username != "" && k.Password != "" {
 		return ScramSha512
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ type Kafka struct {
 	BootstrapServers string `yaml:"bootstrapServers"`
 	TopicPrefix      string `yaml:"topicPrefix"`
 	// Optional
-	AwsEnabled     bool   `yaml:"awsEnabled"`
+	AwsEnabled     bool   `yaml:"awsEnabled,omitempty"`
 	PublishSize    uint   `yaml:"publishSize,omitempty"`
 	MaxRequestSize uint64 `yaml:"maxRequestSize,omitempty"`
 	// If username and password are passed in, we'll use SCRAM w/ SHA512.

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib"
-	"github.com/artie-labs/reader/lib/logger"
 	"github.com/artie-labs/reader/lib/mtr"
 	"github.com/artie-labs/transfer/lib/jitter"
 	"github.com/artie-labs/transfer/lib/size"
@@ -58,7 +57,7 @@ func newWriter(ctx context.Context, cfg config.Kafka) (*kafka.Writer, error) {
 		// If username and password are provided, we'll use SCRAM w/ SHA512.
 		mechanism, err := scram.Mechanism(scram.SHA512, cfg.Username, cfg.Password)
 		if err != nil {
-			logger.Panic("Failed to create SCRAM mechanism", slog.Any("err", err))
+			return nil, fmt.Errorf("failed to create scram mechanism: %w", err)
 		}
 
 		writer.Transport = &kafka.Transport{

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -54,7 +54,6 @@ func newWriter(ctx context.Context, cfg config.Kafka) (*kafka.Writer, error) {
 			TLS:         &tls.Config{},
 		}
 	case config.ScramSha512:
-		// If username and password are provided, we'll use SCRAM w/ SHA512.
 		mechanism, err := scram.Mechanism(scram.SHA512, cfg.Username, cfg.Password)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create scram mechanism: %w", err)

--- a/lib/kafkalib/writer.go
+++ b/lib/kafkalib/writer.go
@@ -64,6 +64,10 @@ func newWriter(ctx context.Context, cfg config.Kafka) (*kafka.Writer, error) {
 			SASL:        mechanism,
 			TLS:         &tls.Config{},
 		}
+	case config.None:
+		// No mechanism
+	default:
+		return nil, fmt.Errorf("unsupported kafka mechanism: %s", cfg.Mechanism())
 	}
 
 	return writer, nil

--- a/main.go
+++ b/main.go
@@ -62,8 +62,9 @@ func buildDestinationWriter(ctx context.Context, cfg *config.Settings, statsD mt
 		if kafkaCfg == nil {
 			return nil, fmt.Errorf("kafka configuration is not set")
 		}
+
 		slog.Info("Kafka config",
-			slog.Bool("aws", kafkaCfg.AwsEnabled),
+			slog.Any("authMechanism", kafkaCfg.Mechanism()),
 			slog.String("kafkaBootstrapServer", kafkaCfg.BootstrapServers),
 			slog.Any("publishSize", kafkaCfg.GetPublishSize()),
 			slog.Uint64("maxRequestSize", kafkaCfg.MaxRequestSize),


### PR DESCRIPTION
By doing this, we will now be able to produce Kafka messages to a Kafka cluster w/ SHA 512 enabled. 

This is required when we're rolling our own Kafka clusters