### PR TITLE
[DynamoDB] Pass after schema objects

### DIFF
--- a/lib/dynamo/message_test.go
+++ b/lib/dynamo/message_test.go
@@ -1,6 +1,7 @@
 package dynamo
 
 import (
+	"github.com/artie-labs/transfer/lib/debezium"
 	"github.com/artie-labs/transfer/lib/ptr"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/stretchr/testify/assert"
@@ -8,120 +9,117 @@ import (
 )
 
 func TestTransformAttributeValue(t *testing.T) {
-	type _tc struct {
-		name          string
-		attr          *dynamodb.AttributeValue
-		expectedValue any
+	{
+		// String
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			S: ptr.ToString("hello"),
+		})
+		assert.NoError(t, err, err)
+		assert.Equal(t, "hello", actualValue)
+		assert.Equal(t, debezium.String, fieldType)
 	}
-
-	tcs := []_tc{
-		{
-			name: "string",
-			attr: &dynamodb.AttributeValue{
-				S: ptr.ToString("hello"),
-			},
-			expectedValue: "hello",
-		},
-		{
-			name: "number",
-			attr: &dynamodb.AttributeValue{
-				N: ptr.ToString("123"),
-			},
-			expectedValue: float64(123),
-		},
-		{
-			name: "boolean",
-			attr: &dynamodb.AttributeValue{
-				BOOL: ptr.ToBool(true),
-			},
-			expectedValue: true,
-		},
-		{
-			name: "map",
-			attr: &dynamodb.AttributeValue{
-				M: map[string]*dynamodb.AttributeValue{
-					"foo": {
-						S: ptr.ToString("bar"),
-					},
-					"bar": {
-						N: ptr.ToString("123"),
-					},
-					"nested_map": {
-						M: map[string]*dynamodb.AttributeValue{
-							"foo": {
-								S: ptr.ToString("bar"),
-							},
+	{
+		// Number
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			N: ptr.ToString("123"),
+		})
+		assert.NoError(t, err, err)
+		assert.Equal(t, float64(123), actualValue)
+		assert.Equal(t, debezium.Float, fieldType)
+	}
+	{
+		// Boolean
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			BOOL: ptr.ToBool(true),
+		})
+		assert.NoError(t, err, err)
+		assert.Equal(t, true, actualValue)
+		assert.Equal(t, debezium.Boolean, fieldType)
+	}
+	{
+		// Map
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			M: map[string]*dynamodb.AttributeValue{
+				"foo": {
+					S: ptr.ToString("bar"),
+				},
+				"bar": {
+					N: ptr.ToString("123"),
+				},
+				"nested_map": {
+					M: map[string]*dynamodb.AttributeValue{
+						"foo": {
+							S: ptr.ToString("bar"),
 						},
 					},
 				},
 			},
-			expectedValue: map[string]any{
+		})
+
+		assert.NoError(t, err, err)
+		assert.Equal(t, map[string]any{
+			"foo": "bar",
+			"bar": float64(123),
+			"nested_map": map[string]any{
 				"foo": "bar",
-				"bar": float64(123),
-				"nested_map": map[string]any{
-					"foo": "bar",
-				},
 			},
-		},
-		{
-			name: "list",
-			attr: &dynamodb.AttributeValue{
-				L: []*dynamodb.AttributeValue{
-					{
-						S: ptr.ToString("foo"),
-					},
-					{
-						N: ptr.ToString("123"),
-					},
-					{
-						M: map[string]*dynamodb.AttributeValue{
-							"foo": {
-								S: ptr.ToString("bar"),
-							},
+		}, actualValue)
+		assert.Equal(t, debezium.Map, fieldType)
+	}
+	{
+		// List
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			L: []*dynamodb.AttributeValue{
+				{
+					S: ptr.ToString("foo"),
+				},
+				{
+					N: ptr.ToString("123"),
+				},
+				{
+					M: map[string]*dynamodb.AttributeValue{
+						"foo": {
+							S: ptr.ToString("bar"),
 						},
 					},
 				},
 			},
-			expectedValue: []any{
-				"foo",
-				float64(123),
-				map[string]any{
-					"foo": "bar",
-				},
-			},
-		},
-		{
-			name: "string set",
-			attr: &dynamodb.AttributeValue{
-				SS: []*string{
-					ptr.ToString("foo"),
-					ptr.ToString("bar"),
-				},
-			},
-			expectedValue: []string{
-				"foo",
-				"bar",
-			},
-		},
-		{
-			name: "number set",
-			attr: &dynamodb.AttributeValue{
-				NS: []*string{
-					ptr.ToString("123"),
-					ptr.ToString("456"),
-				},
-			},
-			expectedValue: []float64{
-				123,
-				456,
-			},
-		},
-	}
+		})
 
-	for _, tc := range tcs {
-		// TODO: Rewrite this whole thing
-		actualValue, _, err := transformAttributeValue(tc.attr)
-		assert.NoError(t, err, tc.name)
-		assert.Equal(t, tc.expectedValue, actualValue, tc.name)
+		assert.NoError(t, err, err)
+		assert.Equal(t, []any{
+			"foo",
+			float64(123),
+			map[string]any{
+				"foo": "bar",
+			},
+		}, actualValue)
+		assert.Equal(t, debezium.Array, fieldType)
+	}
+	{
+		// String set
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			SS: []*string{
+				ptr.ToString("foo"),
+				ptr.ToString("bar"),
+			},
+		})
+
+		assert.NoError(t, err, err)
+		assert.Equal(t, []string{"foo", "bar"}, actualValue)
+		assert.Equal(t, debezium.Array, fieldType)
+	}
+	{
+		// Number set
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			NS: []*string{
+				ptr.ToString("123"),
+				ptr.ToString("456"),
+			},
+		})
+
+		assert.NoError(t, err, err)
+		assert.Equal(t, []float64{123, 456}, actualValue)
+		assert.Equal(t, debezium.Array, fieldType)
 	}
 }

--- a/lib/dynamo/message_test.go
+++ b/lib/dynamo/message_test.go
@@ -119,7 +119,8 @@ func TestTransformAttributeValue(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		actualValue, err := transformAttributeValue(tc.attr)
+		// TODO: Rewrite this whole thing
+		actualValue, _, err := transformAttributeValue(tc.attr)
 		assert.NoError(t, err, tc.name)
 		assert.Equal(t, tc.expectedValue, actualValue, tc.name)
 	}

--- a/lib/dynamo/parse_message.go
+++ b/lib/dynamo/parse_message.go
@@ -17,7 +17,7 @@ func NewMessageFromExport(item dynamodb.ItemResponse, keys []string, tableName s
 		return nil, fmt.Errorf("keys is nil")
 	}
 
-	rowData, fields, err := transformImage(item.Item)
+	rowData, afterSchema, err := transformImage(item.Item)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform item: %w", err)
 	}
@@ -39,7 +39,7 @@ func NewMessageFromExport(item dynamodb.ItemResponse, keys []string, tableName s
 		// Perhaps we can have it inferred from the manifest file in the future.
 		executionTime: time.Now(),
 		afterRowData:  rowData,
-		afterSchema:   fields,
+		afterSchema:   afterSchema,
 		primaryKey:    primaryKeys,
 	}, nil
 }
@@ -75,7 +75,7 @@ func NewMessage(record *dynamodbstreams.Record, tableName string) (*Message, err
 		return nil, fmt.Errorf("failed to transform old image: %w", err)
 	}
 
-	afterData, schema, err := transformImage(record.Dynamodb.NewImage)
+	afterData, afterSchema, err := transformImage(record.Dynamodb.NewImage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform new image: %w", err)
 	}
@@ -91,7 +91,7 @@ func NewMessage(record *dynamodbstreams.Record, tableName string) (*Message, err
 		executionTime: executionTime,
 		beforeRowData: beforeData,
 		afterRowData:  afterData,
-		afterSchema:   schema,
+		afterSchema:   afterSchema,
 		primaryKey:    primaryKey,
 	}, nil
 }

--- a/lib/dynamo/parse_message.go
+++ b/lib/dynamo/parse_message.go
@@ -17,7 +17,7 @@ func NewMessageFromExport(item dynamodb.ItemResponse, keys []string, tableName s
 		return nil, fmt.Errorf("keys is nil")
 	}
 
-	rowData, err := transformImage(item.Item)
+	rowData, fields, err := transformImage(item.Item)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform item: %w", err)
 	}
@@ -39,6 +39,7 @@ func NewMessageFromExport(item dynamodb.ItemResponse, keys []string, tableName s
 		// Perhaps we can have it inferred from the manifest file in the future.
 		executionTime: time.Now(),
 		afterRowData:  rowData,
+		afterSchema:   fields,
 		primaryKey:    primaryKeys,
 	}, nil
 }
@@ -69,17 +70,17 @@ func NewMessage(record *dynamodbstreams.Record, tableName string) (*Message, err
 		}
 	}
 
-	beforeData, err := transformImage(record.Dynamodb.OldImage)
+	beforeData, _, err := transformImage(record.Dynamodb.OldImage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform old image: %w", err)
 	}
 
-	afterData, err := transformImage(record.Dynamodb.NewImage)
+	afterData, schema, err := transformImage(record.Dynamodb.NewImage)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform new image: %w", err)
 	}
 
-	primaryKey, err := transformImage(record.Dynamodb.Keys)
+	primaryKey, _, err := transformImage(record.Dynamodb.Keys)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transform keys: %w", err)
 	}
@@ -90,6 +91,7 @@ func NewMessage(record *dynamodbstreams.Record, tableName string) (*Message, err
 		executionTime: executionTime,
 		beforeRowData: beforeData,
 		afterRowData:  afterData,
+		afterSchema:   schema,
 		primaryKey:    primaryKey,
 	}, nil
 }


### PR DESCRIPTION
We are not passing the after schema object from DynamoDB right now. A side effect of not passing this is that we are not creating primary keys in Dynamo.

This PR adds support of this.