### PR TITLE
[DynamoDB] Supporting bytes and bytes set

### DIFF
--- a/lib/dynamo/message.go
+++ b/lib/dynamo/message.go
@@ -39,6 +39,10 @@ func transformAttributeValue(attr *dynamodb.AttributeValue) (any, debezium.Field
 		}
 
 		return number, debezium.Float, nil
+	case attr.B != nil:
+		return attr.B, debezium.Bytes, nil
+	case attr.BS != nil:
+		return attr.BS, debezium.Array, nil
 	case attr.BOOL != nil:
 		return *attr.BOOL, debezium.Boolean, nil
 	case attr.M != nil:

--- a/lib/dynamo/message_test.go
+++ b/lib/dynamo/message_test.go
@@ -28,6 +28,26 @@ func TestTransformAttributeValue(t *testing.T) {
 		assert.Equal(t, debezium.Float, fieldType)
 	}
 	{
+		// Bytes
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			B: []byte("hello"),
+		})
+		assert.NoError(t, err, err)
+		assert.Equal(t, []byte("hello"), actualValue)
+		assert.Equal(t, debezium.Bytes, fieldType)
+	}
+	{
+		// Bytes set
+		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
+			BS: [][]byte{
+				[]byte("hello"),
+			},
+		})
+		assert.NoError(t, err, err)
+		assert.Equal(t, [][]byte{[]byte("hello")}, actualValue)
+		assert.Equal(t, debezium.Array, fieldType)
+	}
+	{
 		// Boolean
 		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
 			BOOL: ptr.ToBool(true),

--- a/lib/dynamo/message_test.go
+++ b/lib/dynamo/message_test.go
@@ -41,10 +41,11 @@ func TestTransformAttributeValue(t *testing.T) {
 		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
 			BS: [][]byte{
 				[]byte("hello"),
+				[]byte("world"),
 			},
 		})
 		assert.NoError(t, err, err)
-		assert.Equal(t, [][]byte{[]byte("hello")}, actualValue)
+		assert.Equal(t, [][]byte{[]byte("hello"), []byte("world")}, actualValue)
 		assert.Equal(t, debezium.Array, fieldType)
 	}
 	{

--- a/lib/dynamo/message_test.go
+++ b/lib/dynamo/message_test.go
@@ -14,7 +14,7 @@ func TestTransformAttributeValue(t *testing.T) {
 		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
 			S: ptr.ToString("hello"),
 		})
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, "hello", actualValue)
 		assert.Equal(t, debezium.String, fieldType)
 	}
@@ -23,7 +23,7 @@ func TestTransformAttributeValue(t *testing.T) {
 		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
 			N: ptr.ToString("123"),
 		})
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, float64(123), actualValue)
 		assert.Equal(t, debezium.Float, fieldType)
 	}
@@ -32,7 +32,7 @@ func TestTransformAttributeValue(t *testing.T) {
 		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
 			B: []byte("hello"),
 		})
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, []byte("hello"), actualValue)
 		assert.Equal(t, debezium.Bytes, fieldType)
 	}
@@ -44,7 +44,7 @@ func TestTransformAttributeValue(t *testing.T) {
 				[]byte("world"),
 			},
 		})
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, [][]byte{[]byte("hello"), []byte("world")}, actualValue)
 		assert.Equal(t, debezium.Array, fieldType)
 	}
@@ -53,7 +53,7 @@ func TestTransformAttributeValue(t *testing.T) {
 		actualValue, fieldType, err := transformAttributeValue(&dynamodb.AttributeValue{
 			BOOL: ptr.ToBool(true),
 		})
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, true, actualValue)
 		assert.Equal(t, debezium.Boolean, fieldType)
 	}
@@ -77,7 +77,7 @@ func TestTransformAttributeValue(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, map[string]any{
 			"foo": "bar",
 			"bar": float64(123),
@@ -107,7 +107,7 @@ func TestTransformAttributeValue(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, []any{
 			"foo",
 			float64(123),
@@ -126,7 +126,7 @@ func TestTransformAttributeValue(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, []string{"foo", "bar"}, actualValue)
 		assert.Equal(t, debezium.Array, fieldType)
 	}
@@ -139,7 +139,7 @@ func TestTransformAttributeValue(t *testing.T) {
 			},
 		})
 
-		assert.NoError(t, err, err)
+		assert.NoError(t, err)
 		assert.Equal(t, []float64{123, 456}, actualValue)
 		assert.Equal(t, debezium.Array, fieldType)
 	}

--- a/scripts/dynamo/load.go
+++ b/scripts/dynamo/load.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -116,6 +117,9 @@ func main() {
 			slog.Error(fmt.Sprintf("Failed to write batch starting at index %d", i), slog.Any("err", err))
 			continue
 		}
+
+		// Our test DDB has low WCUs
+		time.Sleep(2 * time.Second)
 		rowsWritten += len(writeRequests)
 		slog.Info(fmt.Sprintf("Inserted batch of items starting from index %d", i))
 	}

--- a/scripts/dynamo/load.go
+++ b/scripts/dynamo/load.go
@@ -53,6 +53,12 @@ func main() {
 				"user_id": {
 					S: aws.String(userID),
 				},
+				"b": {
+					B: []byte("hello world"),
+				},
+				"bs": {
+					BS: [][]byte{[]byte("hello"), []byte("world")},
+				},
 				"random_number": {
 					N: aws.String(fmt.Sprintf("%v", rand.Int63())), // Example number
 				},


### PR DESCRIPTION
While reviewing https://github.com/artie-labs/reader/pull/438, I noticed that we do not support `B` or `BS`. 

As such, this PR adds support for it. I also improved our test script to be easier to run.