### PR TITLE
Aligning `TimeWithTimeZone` to Debezium

### DIFF
--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -693,7 +693,7 @@ const expectedPayloadTemplate = `{
 			"c_serial": 1000000123,
 			"c_smallint": 32767,
 			"c_text": "QWERTYUIOP",
-			"c_time_with_timezone": "10:34:17.746572",
+			"c_time_with_timezone": "10:34:17.746572Z",
 			"c_time_without_timezone": 45296000,
 			"c_timestamp_with_timezone": "2001-02-16T13:38:40Z",
 			"c_timestamp_without_timezone": 982355920000000,

--- a/sources/postgres/adapter/adapter_test.go
+++ b/sources/postgres/adapter/adapter_test.go
@@ -208,7 +208,7 @@ func TestValueConverterForType_Convert(t *testing.T) {
 			name:          "time with time zone (postgres.Date)",
 			col:           schema.Column{Name: "t_w_tz", Type: schema.TimeWithTimeZone},
 			value:         "12:00:00.123456+07",
-			expectedValue: "05:00:00.123456",
+			expectedValue: "05:00:00.123456Z",
 		},
 		{
 			name: "numeric (postgres.Numeric)",

--- a/sources/postgres/adapter/converters.go
+++ b/sources/postgres/adapter/converters.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/artie-labs/reader/lib/timeutil"
 	"github.com/artie-labs/transfer/lib/debezium"
-	"github.com/artie-labs/transfer/lib/typing/ext"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -41,7 +40,7 @@ func (TimeWithTimezoneConverter) Convert(value any) (any, error) {
 
 	// Convert `time.Time` into GMT
 	// Then convert back into a string with ns precision
-	return timeValue.UTC().Format(ext.PostgresTimeFormatNoTZ), nil
+	return timeValue.UTC().Format("15:04:05.000000Z"), nil
 }
 
 type PgTimeConverter struct{}


### PR DESCRIPTION
We are currently omitting the `Z` from the output and is not consistent with Debezium.

This PR ensures we are using the same layout.