### PR TITLE
[MongoDB] Improve casting primary key efficiency

### DIFF
--- a/sources/mongo/message.go
+++ b/sources/mongo/message.go
@@ -3,6 +3,7 @@ package mongo
 import (
 	"encoding/json"
 	"fmt"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"time"
 
 	"github.com/artie-labs/reader/config"
@@ -45,25 +46,39 @@ func ParseMessage(result bson.M, op string) (*Message, error) {
 		return nil, fmt.Errorf("failed to marshal document to JSON extended: %w", err)
 	}
 
-	var jsonExtendedMap map[string]any
-	if err = json.Unmarshal(jsonExtendedBytes, &jsonExtendedMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal JSON extended to map: %w", err)
-	}
-
-	pk, isOk := jsonExtendedMap["_id"]
+	bsonPk, isOk := result["_id"]
 	if !isOk {
-		return nil, fmt.Errorf("failed to get partition key, row: %v", jsonExtendedMap)
+		return nil, fmt.Errorf("failed to get partition key, row: %v", result)
 	}
 
-	pkBytes, err := json.Marshal(pk)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal ext json: %w", err)
+	var idString string
+	switch castedPk := bsonPk.(type) {
+	case primitive.ObjectID:
+		idString = fmt.Sprintf(`{"$oid":"%s"}`, castedPk.Hex())
+	default:
+		var jsonExtendedMap map[string]any
+		if err = json.Unmarshal(jsonExtendedBytes, &jsonExtendedMap); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal JSON extended to map: %w", err)
+		}
+
+		pk, isOk := jsonExtendedMap["_id"]
+		if !isOk {
+			return nil, fmt.Errorf("failed to get partition key, row: %v", jsonExtendedMap)
+		}
+
+		pkBytes, err := json.Marshal(pk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal ext json: %w", err)
+		}
+
+		idString = string(pkBytes)
 	}
+
 	return &Message{
 		jsonExtendedString: string(jsonExtendedBytes),
 		operation:          op,
 		pkMap: map[string]any{
-			"id": string(pkBytes),
+			"id": idString,
 		},
 	}, nil
 }

--- a/sources/mongo/message.go
+++ b/sources/mongo/message.go
@@ -3,7 +3,6 @@ package mongo
 import (
 	"encoding/json"
 	"fmt"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"time"
 
 	"github.com/artie-labs/reader/config"
@@ -11,6 +10,7 @@ import (
 	"github.com/artie-labs/transfer/lib/cdc/mongo"
 	"github.com/artie-labs/transfer/lib/debezium"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Message struct {

--- a/sources/mongo/message.go
+++ b/sources/mongo/message.go
@@ -41,15 +41,15 @@ func (m *Message) ToRawMessage(collection config.Collection, database string) (l
 }
 
 func ParseMessage(result bson.M, op string) (*Message, error) {
+	bsonPk, isOk := result["_id"]
+	if !isOk {
+		return nil, fmt.Errorf("failed to get partition key, row: %v", result)
+	}
+
 	// When canonical is enabled, it will emphasize type preservation
 	jsonExtendedBytes, err := bson.MarshalExtJSON(result, true, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal document to JSON extended: %w", err)
-	}
-
-	bsonPk, isOk := result["_id"]
-	if !isOk {
-		return nil, fmt.Errorf("failed to get partition key, row: %v", result)
 	}
 
 	var idString string

--- a/sources/mongo/message.go
+++ b/sources/mongo/message.go
@@ -55,6 +55,10 @@ func ParseMessage(result bson.M, op string) (*Message, error) {
 	switch castedPk := bsonPk.(type) {
 	case primitive.ObjectID:
 		idString = fmt.Sprintf(`{"$oid":"%s"}`, castedPk.Hex())
+	case string:
+		idString = castedPk
+	case int, int32, int64:
+		idString = fmt.Sprintf("%d", castedPk)
 	default:
 		var jsonExtendedMap map[string]any
 		if err = json.Unmarshal(jsonExtendedBytes, &jsonExtendedMap); err != nil {

--- a/sources/mongo/message_test.go
+++ b/sources/mongo/message_test.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
@@ -16,22 +17,39 @@ import (
 )
 
 func TestParseMessagePartitionKey(t *testing.T) {
-	objId, err := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
-	assert.NoError(t, err)
-	msg, err := ParseMessage(bson.M{"_id": objId}, "r")
-	assert.NoError(t, err)
-	assert.Equal(t, `{"$oid":"507f1f77bcf86cd799439011"}`, msg.pkMap["id"])
+	{
+		// Primary key as object ID
+		objId, err := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
+		assert.NoError(t, err)
+		msg, err := ParseMessage(bson.M{"_id": objId}, "r")
+		assert.NoError(t, err)
+		assert.Equal(t, `{"$oid":"507f1f77bcf86cd799439011"}`, msg.pkMap["id"])
 
-	rawMsg, err := msg.ToRawMessage(config.Collection{}, "database")
-	assert.NoError(t, err)
+		rawMsg, err := msg.ToRawMessage(config.Collection{}, "database")
+		assert.NoError(t, err)
 
-	rawMsgBytes, err := json.Marshal(rawMsg.PartitionKey())
-	assert.NoError(t, err)
+		rawMsgBytes, err := json.Marshal(rawMsg.PartitionKey())
+		assert.NoError(t, err)
 
-	var dbz transferMongo.Debezium
-	pkMap, err := dbz.GetPrimaryKey(rawMsgBytes, &kafkalib.TopicConfig{CDCKeyFormat: kafkalib.JSONKeyFmt})
-	assert.NoError(t, err)
-	assert.Equal(t, "507f1f77bcf86cd799439011", pkMap["_id"])
+		var dbz transferMongo.Debezium
+		pkMap, err := dbz.GetPrimaryKey(rawMsgBytes, &kafkalib.TopicConfig{CDCKeyFormat: kafkalib.JSONKeyFmt})
+		assert.NoError(t, err)
+		assert.Equal(t, "507f1f77bcf86cd799439011", pkMap["_id"])
+	}
+	{
+		// Primary key as string
+		msg, err := ParseMessage(bson.M{"_id": "hello world"}, "r")
+		assert.NoError(t, err)
+		assert.Equal(t, "hello world", msg.pkMap["id"])
+	}
+	{
+		// Primary key as ints
+		for _, val := range []any{1001, int32(1002), int64(1003)} {
+			msg, err := ParseMessage(bson.M{"_id": val}, "r")
+			assert.NoError(t, err)
+			assert.Equal(t, fmt.Sprint(val), msg.pkMap["id"])
+		}
+	}
 }
 
 func TestParseMessage(t *testing.T) {


### PR DESCRIPTION
This PR works to minimize the amount of marshalling and unmarshalling we need to do just to generate the JSON extended string for the primary key.

We are doing this by natively supporting and converting the most common data types and falling back to marshaling if we need to