### PR TITLE
Throttle processing of dynamo shards to avoid cpu spikes

### DIFF
--- a/lib/throttler/throttler.go
+++ b/lib/throttler/throttler.go
@@ -1,11 +1,22 @@
 package throttler
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 type Throttler struct {
-	Limit   int64
+	limit   int64
 	running int64
 	mu      sync.Mutex
+}
+
+func NewThrottler(limit int64) (*Throttler, error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("Throttler limit should be greater than 0")
+	}
+
+	return &Throttler{limit: limit}, nil
 }
 
 func (t *Throttler) Start() {
@@ -21,5 +32,5 @@ func (t *Throttler) Done() {
 }
 
 func (t *Throttler) Allowed() bool {
-	return t.running < t.Limit
+	return t.running < t.limit
 }

--- a/lib/throttler/throttler.go
+++ b/lib/throttler/throttler.go
@@ -13,7 +13,7 @@ type Throttler struct {
 
 func NewThrottler(limit int64) (*Throttler, error) {
 	if limit <= 0 {
-		return nil, fmt.Errorf("Throttler limit should be greater than 0")
+		return nil, fmt.Errorf("throttler limit should be greater than 0")
 	}
 
 	return &Throttler{limit: limit}, nil

--- a/lib/throttler/throttler.go
+++ b/lib/throttler/throttler.go
@@ -1,0 +1,25 @@
+package throttler
+
+import "sync"
+
+type Throttler struct {
+	Limit   int64
+	running int64
+	mu      sync.Mutex
+}
+
+func (t *Throttler) Start() {
+	t.mu.Lock()
+	t.running++
+	t.mu.Unlock()
+}
+
+func (t *Throttler) Done() {
+	t.mu.Lock()
+	t.running--
+	t.mu.Unlock()
+}
+
+func (t *Throttler) Allowed() bool {
+	return t.running < t.Limit
+}

--- a/lib/throttler/throttler_test.go
+++ b/lib/throttler/throttler_test.go
@@ -9,7 +9,7 @@ import (
 func TestThrottler(t *testing.T) {
 	{
 		_, err := NewThrottler(0)
-		assert.ErrorContains(t, err, "Throttler limit should be greater than 0")
+		assert.ErrorContains(t, err, "throttler limit should be greater than 0")
 	}
 	{
 		throttler, err := NewThrottler(1)

--- a/lib/throttler/throttler_test.go
+++ b/lib/throttler/throttler_test.go
@@ -1,0 +1,34 @@
+package throttler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThrottler(t *testing.T) {
+	{
+		_, err := NewThrottler(0)
+		assert.ErrorContains(t, err, "Throttler limit should be greater than 0")
+	}
+	{
+		throttler, err := NewThrottler(1)
+		assert.NoError(t, err)
+		assert.True(t, throttler.Allowed())
+		throttler.Start()
+		assert.False(t, throttler.Allowed())
+		throttler.Done()
+		assert.True(t, throttler.Allowed())
+	}
+	{
+		throttler, err := NewThrottler(2)
+		assert.NoError(t, err)
+		assert.True(t, throttler.Allowed())
+		throttler.Start()
+		assert.True(t, throttler.Allowed())
+		throttler.Start()
+		assert.False(t, throttler.Allowed())
+		throttler.Done()
+		assert.True(t, throttler.Allowed())
+	}
+}

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib/s3lib"
+	"github.com/artie-labs/reader/lib/throttler"
 	"github.com/artie-labs/reader/sources"
 	"github.com/artie-labs/reader/sources/dynamodb/offsets"
 )
@@ -48,7 +49,7 @@ func Load(cfg config.DynamoDB) (sources.Source, bool, error) {
 			storage:   offsets.NewStorage(cfg.OffsetFile, nil, nil),
 			streams:   dynamodbstreams.New(sess),
 			shardChan: make(chan *dynamodbstreams.Shard),
-			throttler: &Throttler{limit: concurrencyLimit},
+			throttler: &throttler.Throttler{Limit: concurrencyLimit},
 		}, true, nil
 	}
 }

--- a/sources/dynamodb/shard.go
+++ b/sources/dynamodb/shard.go
@@ -66,6 +66,14 @@ func (s *StreamStore) processShard(ctx context.Context, shard *dynamodbstreams.S
 		return
 	}
 
+	for !s.throttler.Allowed() {
+		slog.Warn("Throttler limit reached, waiting for a slot to open up...", slog.String("shardId", *shard.ShardId))
+		time.Sleep(1 * time.Second)
+	}
+
+	s.throttler.Start()
+	defer s.throttler.Done()
+
 	slog.Info("Processing shard...", slog.String("shardId", *shard.ShardId))
 
 	iteratorType := "TRIM_HORIZON"

--- a/sources/dynamodb/stream.go
+++ b/sources/dynamodb/stream.go
@@ -4,37 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"sync"
 	"time"
 
 	"github.com/artie-labs/reader/config"
+	"github.com/artie-labs/reader/lib/throttler"
 	"github.com/artie-labs/reader/sources/dynamodb/offsets"
 	"github.com/artie-labs/reader/writers"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 )
-
-type Throttler struct {
-	limit   int64
-	running int64
-	mu      sync.Mutex
-}
-
-func (t *Throttler) Start() {
-	t.mu.Lock()
-	t.running++
-	t.mu.Unlock()
-}
-
-func (t *Throttler) Done() {
-	t.mu.Lock()
-	t.running--
-	t.mu.Unlock()
-}
-
-func (t *Throttler) Allowed() bool {
-	return t.running < t.limit
-}
 
 type StreamStore struct {
 	tableName string
@@ -44,7 +22,7 @@ type StreamStore struct {
 	streams   *dynamodbstreams.DynamoDBStreams
 	storage   *offsets.OffsetStorage
 	shardChan chan *dynamodbstreams.Shard
-	throttler *Throttler
+	throttler *throttler.Throttler
 }
 
 func (s *StreamStore) Close() error {


### PR DESCRIPTION
The limit is set to 20 for now; we can monitor lag time (added in https://github.com/artie-labs/reader/pull/452) and adjust the limit if needed.