### PR TITLE
[DynamoDB] Improve snapshot capabilities

### DIFF
--- a/sources/dynamodb/snapshot.go
+++ b/sources/dynamodb/snapshot.go
@@ -71,6 +71,7 @@ func (s *SnapshotStore) streamAndPublish(ctx context.Context, writer writers.Wri
 		return fmt.Errorf("failed to retrieve primary keys: %w", err)
 	}
 
+	writer.SetRunOnComplete(false)
 	for _, file := range s.cfg.SnapshotSettings.SpecifiedFiles {
 		logFields := []any{
 			slog.String("fileName", *file.Key),
@@ -101,5 +102,5 @@ func (s *SnapshotStore) streamAndPublish(ctx context.Context, writer writers.Wri
 		slog.Info("Successfully processed file...", logFields...)
 	}
 
-	return nil
+	return writer.OnComplete()
 }


### PR DESCRIPTION
## Changes

* Some JSON gzipped rows can be larger than 64 kb (which is the default buffer size), which caused this codepath to crash.

* Currently code is running dedupe at the end of every JSON file which is very expensive, instead, we should run it at the very end.