### PR TITLE
[DynamoDB] Increase concurrency limit + refactor S3 bucket name

### DIFF
--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -55,5 +55,9 @@ func (s *SnapshotSettings) Validate() error {
 		return fmt.Errorf("folder is empty")
 	}
 
+	if s.S3Bucket == "" {
+		return fmt.Errorf("s3Bucket is empty")
+	}
+
 	return nil
 }

--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -39,7 +39,8 @@ func (d *DynamoDB) Validate() error {
 }
 
 type SnapshotSettings struct {
-	Folder string `yaml:"folder"`
+	S3Bucket string `yaml:"s3Bucket"`
+	Folder   string `yaml:"folder"`
 	// If the files are not specified, that's okay.
 	// We will scan the folder and then load into `specifiedFiles`
 	SpecifiedFiles []s3lib.S3File `yaml:"specifiedFiles"`

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -39,7 +39,7 @@ func Load(cfg config.DynamoDB) (sources.Source, bool, error) {
 			streamArn:      cfg.StreamArn,
 			cfg:            &cfg,
 			dynamoDBClient: dynamodb.New(sess),
-			s3Client:       s3lib.NewClient(sess),
+			s3Client:       s3lib.NewClient(cfg.SnapshotSettings.S3Bucket, sess),
 		}, false, nil
 	} else {
 		_throttler, err := throttler.NewThrottler(concurrencyLimit)

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -18,11 +18,12 @@ import (
 	"github.com/artie-labs/reader/sources/dynamodb/offsets"
 )
 
-const jitterSleepBaseMs = 100
-const shardScannerInterval = 5 * time.Minute
-
-// concurrencyLimit is the maximum number of shards we should be processing at once
-const concurrencyLimit = 20
+const (
+	jitterSleepBaseMs    = 100
+	shardScannerInterval = 5 * time.Minute
+	// concurrencyLimit is the maximum number of shards we should be processing at once
+	concurrencyLimit = 30
+)
 
 func Load(cfg config.DynamoDB) (sources.Source, bool, error) {
 	sess, err := session.NewSession(&aws.Config{


### PR DESCRIPTION
## Changes

1. Increasing limit from 20 -> 30 (I'm increasing this because I'm seeing quite a bit of throttling happening in our logs)
2. Moving bucket name to be higher level, so if we do decide to use `specifiedFiles`, it's less repetitive