### PR TITLE
[DynamoDB] Increase concurrency limit

### DIFF
--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -15,6 +15,7 @@ type DynamoDB struct {
 	AwsSecretAccessKey string `yaml:"awsSecretAccessKey"`
 	StreamArn          string `yaml:"streamArn"`
 	TableName          string `yaml:"tableName"`
+	MaxConcurrency     int64  `yaml:"__maxConcurrency"`
 
 	Snapshot         bool              `yaml:"snapshot"`
 	SnapshotSettings *SnapshotSettings `yaml:"snapshotSettings"`

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -22,7 +22,7 @@ const (
 	jitterSleepBaseMs    = 100
 	shardScannerInterval = 5 * time.Minute
 	// concurrencyLimit is the maximum number of shards we should be processing at once
-	concurrencyLimit = 30
+	concurrencyLimit = 100
 )
 
 func Load(cfg config.DynamoDB) (sources.Source, bool, error) {


### PR DESCRIPTION
Running at a limit of 30 is still too low as there could be idle shards that are still being processed [1]. And there may be more "active" shards that we should be able to process. 

However, these idle shards are taking up our throttler's quota. 

I think we might want to rethink the way we're handling throttling by throttling the rate of messages with a buffered channel as opposed to throttle concurrency (or maybe we need both ?)

For now, I've increased the default limit, allowed an override and added a TODO for us to come back to this.


----
[1] - We are still processing because the shard hasn't been closed yet, however there is no data
