### PR TITLE
[MongoDB] Adding an option to disable TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Artie Reader reads from databases to perform historical snapshots and also reads
 
 ## Supports:
 
-|            | Snapshot | Streaming       |
-|------------|----------|-----------------|
-| DynamoDB   | ✅        | ✅               |
-| MongoDB    | ✅        | 🚧 Experimental |
-| MySQL      | ✅        | ❌               |
-| PostgreSQL | ✅        | ❌               |
-| SQL Server | ✅        | ❌               |
+|            | Snapshot | Streaming |
+|------------|----------|-----------|
+| DynamoDB   | ✅        | ✅         |
+| MongoDB    | ✅        | ✅         |
+| MySQL      | ✅        | ❌         |
+| PostgreSQL | ✅        | ❌         |
+| SQL Server | ✅        | ❌         |
 
 
 ## Running

--- a/config/mongodb.go
+++ b/config/mongodb.go
@@ -33,6 +33,7 @@ type MongoDB struct {
 	Database          string            `yaml:"database"`
 	Collections       []Collection      `yaml:"collections"`
 	StreamingSettings StreamingSettings `yaml:"streamingSettings,omitempty"`
+	DisableTLS        bool              `yaml:"disableTLS"`
 }
 
 type Collection struct {

--- a/sources/mongo/mongo.go
+++ b/sources/mongo/mongo.go
@@ -26,7 +26,11 @@ func Load(cfg config.MongoDB) (*Source, bool, error) {
 		Password: cfg.Password,
 	}
 
-	opts := options.Client().ApplyURI(cfg.Host).SetAuth(creds).SetTLSConfig(&tls.Config{})
+	opts := options.Client().ApplyURI(cfg.Host).SetAuth(creds)
+	if !cfg.DisableTLS {
+		opts.SetTLSConfig(&tls.Config{})
+	}
+
 	ctx := context.Background()
 	client, err := mongo.Connect(ctx, opts)
 	if err != nil {

--- a/sources/mongo/mongo.go
+++ b/sources/mongo/mongo.go
@@ -28,7 +28,7 @@ func Load(cfg config.MongoDB) (*Source, bool, error) {
 
 	opts := options.Client().ApplyURI(cfg.Host).SetAuth(creds)
 	if !cfg.DisableTLS {
-		opts.SetTLSConfig(&tls.Config{})
+		opts = opts.SetTLSConfig(&tls.Config{})
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
We need the ability to disable TLS so we can support DocumentDB.
