### PR TITLE
[MongoDB] Support replace

### DIFF
--- a/sources/mongo/change_event.go
+++ b/sources/mongo/change_event.go
@@ -121,7 +121,7 @@ func (c ChangeEvent) ToMessage() (*Message, error) {
 		}
 
 		return msg, nil
-	case "update":
+	case "update", "replace":
 		fullDocument, err := c.getFullDocument()
 		if err != nil {
 			return nil, fmt.Errorf("failed to get fullDocument from change event: %v", c)

--- a/sources/mongo/streaming.go
+++ b/sources/mongo/streaming.go
@@ -39,7 +39,7 @@ func newStreamingIterator(ctx context.Context, db *mongo.Database, cfg config.Mo
 	pipeline := mongo.Pipeline{
 		{{"$match", bson.D{
 			{"operationType", bson.D{
-				{"$in", bson.A{"insert", "update", "delete"}},
+				{"$in", bson.A{"insert", "update", "delete", "replace"}},
 			}},
 		}}},
 	}


### PR DESCRIPTION
[replace](https://www.mongodb.com/docs/manual/reference/change-events/replace/) is functionally the same as update, but separate action in MongoDB streams