### PR TITLE
Parse DynamoDB ARN

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,7 +15,6 @@ import (
 func dynamoDBCfg() *DynamoDB {
 	return &DynamoDB{
 		OffsetFile:         "offset.txt",
-		AwsRegion:          "us-east-1",
 		AwsAccessKeyID:     "key-id",
 		AwsSecretAccessKey: "secret-access-key",
 		StreamArn:          "arn:aws:dynamodb:us-east-1:123456789012:table/TableName/stream/2020-01-01T00:00:00.000",

--- a/config/dynamodb.go
+++ b/config/dynamodb.go
@@ -10,7 +10,6 @@ import (
 
 type DynamoDB struct {
 	OffsetFile         string `yaml:"offsetFile"`
-	AwsRegion          string `yaml:"awsRegion"`
 	AwsAccessKeyID     string `yaml:"awsAccessKeyId"`
 	AwsSecretAccessKey string `yaml:"awsSecretAccessKey"`
 	StreamArn          string `yaml:"streamArn"`
@@ -26,8 +25,8 @@ func (d *DynamoDB) Validate() error {
 		return fmt.Errorf("dynamodb config is nil")
 	}
 
-	if stringutil.Empty(d.OffsetFile, d.AwsRegion, d.AwsAccessKeyID, d.AwsSecretAccessKey, d.StreamArn, d.TableName) {
-		return fmt.Errorf("one of the dynamoDB configs is empty: offsetFile, awsRegion, awsAccessKeyID, awsSecretAccessKey, streamArn or tableName")
+	if stringutil.Empty(d.OffsetFile, d.AwsAccessKeyID, d.AwsSecretAccessKey, d.StreamArn, d.TableName) {
+		return fmt.Errorf("one of the dynamoDB configs is empty: offsetFile, awsAccessKeyID, awsSecretAccessKey, streamArn or tableName")
 	}
 
 	if d.Snapshot {

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"time"
 
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
@@ -26,9 +27,13 @@ const (
 )
 
 func Load(ctx context.Context, cfg config.DynamoDB) (sources.Source, bool, error) {
-	// TODO: Parse `arn` to get the region.
+	parsedArn, err := arn.Parse(cfg.StreamArn)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to parse stream ARN: %w", err)
+	}
+
 	_awsCfg, err := awsCfg.LoadDefaultConfig(ctx,
-		awsCfg.WithRegion(cfg.AwsRegion),
+		awsCfg.WithRegion(parsedArn.Region),
 		awsCfg.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(cfg.AwsAccessKeyID, cfg.AwsSecretAccessKey, "")),
 	)
 

--- a/sources/dynamodb/dynamodb.go
+++ b/sources/dynamodb/dynamodb.go
@@ -4,9 +4,9 @@ import (
 	"cmp"
 	"context"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsCfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"

--- a/sources/dynamodb/dynamodb_test.go
+++ b/sources/dynamodb/dynamodb_test.go
@@ -1,0 +1,29 @@
+package dynamodb
+
+import (
+	"context"
+	"github.com/artie-labs/reader/config"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLoad(t *testing.T) {
+	cfg := config.DynamoDB{
+		OffsetFile:         "",
+		AwsAccessKeyID:     "",
+		AwsSecretAccessKey: "",
+		StreamArn:          "arn:aws:dynamodb:us-east-1:99999:table/ddb-test/stream/2024-04-26T00:54:24.794",
+		TableName:          "",
+		MaxConcurrency:     0,
+		Snapshot:           false,
+		SnapshotSettings:   nil,
+	}
+
+	_, _, err := Load(context.Background(), cfg)
+	assert.NoError(t, err)
+
+	parsedArn, err := arn.Parse(cfg.StreamArn)
+	assert.NoError(t, err)
+	assert.Equal(t, "us-east-1", parsedArn.Region)
+}


### PR DESCRIPTION
We can parse the AWS region from the ARN, so we don't need them to specify the region.