### PR TITLE
[MongoDB] Clean up + support `FullDocumentBeforeChange`

### DIFF
--- a/config/mongodb.go
+++ b/config/mongodb.go
@@ -56,8 +56,8 @@ func (m MongoDB) GetStreamingBatchSize() int32 {
 }
 
 func (m MongoDB) Validate() error {
-	if stringutil.Empty(m.Host, m.Database, m.Username, m.Password) {
-		return fmt.Errorf("one of the MongoDB settings is empty: host, username, password, database")
+	if stringutil.Empty(m.Host, m.Database) {
+		return fmt.Errorf("one of the MongoDB settings is empty: host, database")
 	}
 
 	if len(m.Collections) == 0 {

--- a/config/mongodb.go
+++ b/config/mongodb.go
@@ -28,12 +28,12 @@ type StreamingSettings struct {
 
 type MongoDB struct {
 	Host              string            `yaml:"host"`
-	Username          string            `yaml:"username"`
-	Password          string            `yaml:"password"`
+	Username          string            `yaml:"username,omitempty"`
+	Password          string            `yaml:"password,omitempty"`
 	Database          string            `yaml:"database"`
 	Collections       []Collection      `yaml:"collections"`
 	StreamingSettings StreamingSettings `yaml:"streamingSettings,omitempty"`
-	DisableTLS        bool              `yaml:"disableTLS"`
+	DisableTLS        bool              `yaml:"disableTLS,omitempty"`
 }
 
 type Collection struct {
@@ -57,7 +57,7 @@ func (m MongoDB) GetStreamingBatchSize() int32 {
 
 func (m MongoDB) Validate() error {
 	if stringutil.Empty(m.Host, m.Database) {
-		return fmt.Errorf("one of the MongoDB settings is empty: host, database")
+		return fmt.Errorf("one of the MongoDB settings is empty: host or database")
 	}
 
 	if len(m.Collections) == 0 {

--- a/lib/mongo/config.go
+++ b/lib/mongo/config.go
@@ -1,0 +1,23 @@
+package mongo
+
+import (
+	"crypto/tls"
+	"github.com/artie-labs/reader/config"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+func OptsFromConfig(cfg config.MongoDB) *options.ClientOptions {
+	opts := options.Client().ApplyURI(cfg.Host)
+	if !cfg.DisableTLS {
+		opts = opts.SetTLSConfig(&tls.Config{})
+	}
+
+	if cfg.Username != "" && cfg.Password != "" {
+		opts = opts.SetAuth(options.Credential{
+			Username: cfg.Username,
+			Password: cfg.Password,
+		})
+	}
+
+	return opts
+}

--- a/lib/mongo/config_test.go
+++ b/lib/mongo/config_test.go
@@ -1,0 +1,41 @@
+package mongo
+
+import (
+	"github.com/artie-labs/reader/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestOptsFromConfig(t *testing.T) {
+	{
+		cfg := config.MongoDB{
+			Host:     "localhost",
+			Username: "user",
+			Password: "password",
+		}
+
+		opts := OptsFromConfig(cfg)
+		assert.NotNil(t, opts.TLSConfig)
+		assert.Equal(t, "user", opts.Auth.Username)
+		assert.Equal(t, "password", opts.Auth.Password)
+	}
+	{
+		// No username and password
+		cfg := config.MongoDB{
+			Host: "localhost",
+		}
+
+		opts := OptsFromConfig(cfg)
+		assert.Nil(t, opts.Auth)
+	}
+	{
+		// Disable TLS
+		cfg := config.MongoDB{
+			Host:       "localhost",
+			DisableTLS: true,
+		}
+
+		opts := OptsFromConfig(cfg)
+		assert.Nil(t, opts.TLSConfig)
+	}
+}

--- a/lib/ptr/ptr.go
+++ b/lib/ptr/ptr.go
@@ -3,3 +3,7 @@ package ptr
 func ToUint16(val uint16) *uint16 {
 	return &val
 }
+
+func ToPtr[T any](val T) *T {
+	return &val
+}

--- a/sources/mongo/change_event_test.go
+++ b/sources/mongo/change_event_test.go
@@ -55,7 +55,7 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.Nil(t, msg.beforeJSONExtendedString)
 
 		var actualDoc bson.M
-		assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &actualDoc))
+		assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJSONExtendedString), false, &actualDoc))
 		assert.Equal(t, fullDocument, actualDoc)
 	}
 	{
@@ -113,7 +113,7 @@ func TestNewChangeEvent(t *testing.T) {
 			assert.Equal(t, "u", msg.operation)
 
 			var expectedObj bson.M
-			assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &expectedObj))
+			assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJSONExtendedString), false, &expectedObj))
 			assert.Equal(t, fullDocument, expectedObj)
 
 			{
@@ -191,7 +191,7 @@ func TestNewChangeEvent(t *testing.T) {
 			{
 				// Full Document
 				var actualDoc bson.M
-				assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &actualDoc))
+				assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJSONExtendedString), false, &actualDoc))
 				assert.Equal(t, fullDocument, actualDoc)
 			}
 			{
@@ -247,7 +247,7 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66834270bd422bc9b54b2be6"}`}, msg.pkMap)
 		assert.Equal(t, "d", msg.operation)
-		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJsonExtendedString)
+		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJSONExtendedString)
 		assert.Nil(t, msg.beforeJSONExtendedString)
 	}
 	{
@@ -294,7 +294,7 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66834270bd422bc9b54b2be6"}`}, msg.pkMap)
 		assert.Equal(t, "d", msg.operation)
-		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJsonExtendedString)
+		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJSONExtendedString)
 
 		var actualBeforeDoc bson.M
 		assert.NoError(t, bson.UnmarshalExtJSON([]byte(*msg.beforeJSONExtendedString), false, &actualBeforeDoc))

--- a/sources/mongo/change_event_test.go
+++ b/sources/mongo/change_event_test.go
@@ -45,16 +45,18 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.Equal(t, "customers", changeEvent.collection)
 		assert.Equal(t, objectID, changeEvent.objectID)
 		assert.Equal(t, fullDocument, *changeEvent.fullDocument)
+		assert.Nil(t, changeEvent.fullDocumentBeforeChange)
 
 		// ToMessage
 		msg, err := changeEvent.ToMessage()
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66a7f5fe65e80fad9c4773e7"}`}, msg.pkMap)
 		assert.Equal(t, "c", msg.operation)
+		assert.Nil(t, msg.beforeJSONExtendedString)
 
-		var expectedObj bson.M
-		assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &expectedObj))
-		assert.Equal(t, fullDocument, expectedObj)
+		var actualDoc bson.M
+		assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &actualDoc))
+		assert.Equal(t, fullDocument, actualDoc)
 	}
 	{
 		// Update
@@ -102,6 +104,7 @@ func TestNewChangeEvent(t *testing.T) {
 			assert.Equal(t, "customers", changeEvent.collection)
 			assert.Equal(t, objectID, changeEvent.objectID)
 			assert.Equal(t, fullDocument, *changeEvent.fullDocument)
+			assert.Nil(t, changeEvent.fullDocumentBeforeChange)
 
 			// ToMessage
 			msg, err := changeEvent.ToMessage()
@@ -122,7 +125,91 @@ func TestNewChangeEvent(t *testing.T) {
 				assert.Equal(t, bson.M{"_id": objectID}, *changeEvent.fullDocument)
 			}
 		}
+	}
+	{
+		// Update (w fullDocumentBeforeChange)
+		for _, action := range []string{"update", "replace"} {
+			objectID, err := primitive.ObjectIDFromHex("66834270bd422bc9b54b2be7")
+			assert.NoError(t, err)
 
+			beforeFullDoc := bson.M{
+				"_id":        objectID,
+				"email":      "ilbwm.kzlhlza@example.com",
+				"first_name": "Old Robin",
+				"last_name":  "Old Kzlhlza",
+			}
+
+			fullDocument := bson.M{
+				"_id":        objectID,
+				"email":      "ilbwm.kzlhlza@example.com",
+				"first_name": "Robin",
+				"last_name":  "Kzlhlza",
+			}
+
+			rawMsg := bson.M{
+				"_id": bson.M{
+					"_data": "8266A7F95F000000072B042C0100296E5A1004778E391F64D84D65A154AA02089381C9463C6F7065726174696F6E54797065003C7570646174650046646F63756D656E744B65790046645F6964006466834270BD422BC9B54B2BE7000004",
+				},
+				"clusterTime": bson.M{
+					"ts": primitive.Timestamp{T: 1722284383, I: 7},
+				},
+				"documentKey": bson.M{
+					"_id": objectID,
+				},
+				"fullDocument":             fullDocument,
+				"fullDocumentBeforeChange": beforeFullDoc,
+				"ns": bson.M{
+					"coll": "customers",
+					"db":   "inventory",
+				},
+				"operationType": action,
+				"updateDescription": bson.M{
+					"removedFields":   []interface{}{},
+					"truncatedArrays": []interface{}{},
+					"updatedFields": bson.M{
+						"first_name": "Robin",
+					},
+				},
+				"wallTime": 1722284383120,
+			}
+
+			changeEvent, err := NewChangeEvent(rawMsg)
+			assert.NoError(t, err)
+			assert.NotNil(t, changeEvent)
+			assert.Equal(t, action, changeEvent.operationType)
+			assert.Equal(t, "customers", changeEvent.collection)
+			assert.Equal(t, objectID, changeEvent.objectID)
+			assert.Equal(t, fullDocument, *changeEvent.fullDocument)
+			assert.Equal(t, beforeFullDoc, *changeEvent.fullDocumentBeforeChange)
+
+			// ToMessage
+			msg, err := changeEvent.ToMessage()
+			assert.NoError(t, err)
+			assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66834270bd422bc9b54b2be7"}`}, msg.pkMap)
+			assert.Equal(t, "u", msg.operation)
+
+			{
+				// Full Document
+				var actualDoc bson.M
+				assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &actualDoc))
+				assert.Equal(t, fullDocument, actualDoc)
+			}
+			{
+				// Before Full Document
+				var actualBeforeDoc bson.M
+				assert.NoError(t, bson.UnmarshalExtJSON([]byte(*msg.beforeJSONExtendedString), false, &actualBeforeDoc))
+				assert.Equal(t, beforeFullDoc, actualBeforeDoc)
+			}
+
+			{
+				// Edge case with update where `fullDocument` is present, but it's null
+				rawMsg["fullDocument"] = nil
+				changeEvent, err = NewChangeEvent(rawMsg)
+				assert.NoError(t, err)
+				assert.NotNil(t, changeEvent.fullDocument)
+				assert.Equal(t, bson.M{"_id": objectID}, *changeEvent.fullDocument)
+			}
+		}
 	}
 	{
 		// Delete
@@ -153,6 +240,7 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.Equal(t, "customers", changeEvent.collection)
 		assert.Equal(t, objectID, changeEvent.objectID)
 		assert.Nil(t, changeEvent.fullDocument)
+		assert.Nil(t, changeEvent.fullDocumentBeforeChange)
 
 		// ToMessage
 		msg, err := changeEvent.ToMessage()
@@ -160,5 +248,56 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66834270bd422bc9b54b2be6"}`}, msg.pkMap)
 		assert.Equal(t, "d", msg.operation)
 		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJsonExtendedString)
+		assert.Nil(t, msg.beforeJSONExtendedString)
+	}
+	{
+		// Delete (w fullDocumentBeforeChange)
+		objectID, err := primitive.ObjectIDFromHex("66834270bd422bc9b54b2be6")
+		assert.NoError(t, err)
+
+		fullDocument := bson.M{
+			"_id":        objectID,
+			"email":      "dusty@artie.com",
+			"first_name": "Dusty",
+			"last_name":  "The mini aussie",
+		}
+
+		changeEvent, err := NewChangeEvent(bson.M{
+			"_id": bson.M{
+				"_data": "8266A7F8BB000000062B042C0100296E5A1004778E391F64D84D65A154AA02089381C9463C6F7065726174696F6E54797065003C64656C6574650046646F63756D656E744B65790046645F6964006466834270BD422BC9B54B2BE6000004",
+			},
+			"clusterTime": bson.M{
+				"ts": primitive.Timestamp{T: 1722284219, I: 6},
+			},
+			"documentKey": bson.M{
+				"_id": objectID,
+			},
+			"fullDocumentBeforeChange": fullDocument,
+			"ns": bson.M{
+				"coll": "customers",
+				"db":   "inventory",
+			},
+			"operationType": "delete",
+			"wallTime":      1722284219184,
+		})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, changeEvent)
+		assert.Equal(t, "delete", changeEvent.operationType)
+		assert.Equal(t, "customers", changeEvent.collection)
+		assert.Equal(t, objectID, changeEvent.objectID)
+		assert.Nil(t, changeEvent.fullDocument)
+		assert.Equal(t, fullDocument, *changeEvent.fullDocumentBeforeChange)
+
+		// ToMessage
+		msg, err := changeEvent.ToMessage()
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66834270bd422bc9b54b2be6"}`}, msg.pkMap)
+		assert.Equal(t, "d", msg.operation)
+		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJsonExtendedString)
+
+		var actualBeforeDoc bson.M
+		assert.NoError(t, bson.UnmarshalExtJSON([]byte(*msg.beforeJSONExtendedString), false, &actualBeforeDoc))
+		assert.Equal(t, fullDocument, actualBeforeDoc)
 	}
 }

--- a/sources/mongo/change_event_test.go
+++ b/sources/mongo/change_event_test.go
@@ -53,7 +53,7 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.Equal(t, "c", msg.operation)
 
 		var expectedObj bson.M
-		assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.jsonExtendedString), false, &expectedObj))
+		assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &expectedObj))
 		assert.Equal(t, fullDocument, expectedObj)
 	}
 	{
@@ -110,7 +110,7 @@ func TestNewChangeEvent(t *testing.T) {
 			assert.Equal(t, "u", msg.operation)
 
 			var expectedObj bson.M
-			assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.jsonExtendedString), false, &expectedObj))
+			assert.NoError(t, bson.UnmarshalExtJSON([]byte(msg.afterJsonExtendedString), false, &expectedObj))
 			assert.Equal(t, fullDocument, expectedObj)
 
 			{
@@ -159,6 +159,6 @@ func TestNewChangeEvent(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]interface{}{"id": `{"$oid":"66834270bd422bc9b54b2be6"}`}, msg.pkMap)
 		assert.Equal(t, "d", msg.operation)
-		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.jsonExtendedString)
+		assert.Equal(t, `{"_id":{"$oid":"66834270bd422bc9b54b2be6"}}`, msg.afterJsonExtendedString)
 	}
 }

--- a/sources/mongo/message.go
+++ b/sources/mongo/message.go
@@ -14,16 +14,18 @@ import (
 )
 
 type Message struct {
-	jsonExtendedString string
-	operation          string
-	pkMap              map[string]any
+	afterJsonExtendedString  string
+	beforeJSONExtendedString *string
+	operation                string
+	pkMap                    map[string]any
 }
 
 func (m *Message) ToRawMessage(collection config.Collection, database string) (lib.RawMessage, error) {
 	evt := &mongo.SchemaEventPayload{
 		Schema: debezium.Schema{},
 		Payload: mongo.Payload{
-			After: &m.jsonExtendedString,
+			After:  &m.afterJsonExtendedString,
+			Before: m.beforeJSONExtendedString,
 			Source: mongo.Source{
 				Database:   database,
 				Collection: collection.Name,
@@ -40,14 +42,14 @@ func (m *Message) ToRawMessage(collection config.Collection, database string) (l
 	return lib.NewRawMessage(collection.TopicSuffix(database), pkMap, evt), nil
 }
 
-func ParseMessage(result bson.M, op string) (*Message, error) {
-	bsonPk, isOk := result["_id"]
+func ParseMessage(after bson.M, op string) (*Message, error) {
+	bsonPk, isOk := after["_id"]
 	if !isOk {
-		return nil, fmt.Errorf("failed to get partition key, row: %v", result)
+		return nil, fmt.Errorf("failed to get partition key, row: %v", after)
 	}
 
 	// When canonical is enabled, it will emphasize type preservation
-	jsonExtendedBytes, err := bson.MarshalExtJSON(result, true, false)
+	afterRow, err := bson.MarshalExtJSON(after, true, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal document to JSON extended: %w", err)
 	}
@@ -62,7 +64,7 @@ func ParseMessage(result bson.M, op string) (*Message, error) {
 		idString = fmt.Sprintf("%d", castedPk)
 	default:
 		var jsonExtendedMap map[string]any
-		if err = json.Unmarshal(jsonExtendedBytes, &jsonExtendedMap); err != nil {
+		if err = json.Unmarshal(afterRow, &jsonExtendedMap); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal JSON extended to map: %w", err)
 		}
 
@@ -80,8 +82,8 @@ func ParseMessage(result bson.M, op string) (*Message, error) {
 	}
 
 	return &Message{
-		jsonExtendedString: string(jsonExtendedBytes),
-		operation:          op,
+		afterJsonExtendedString: string(afterRow),
+		operation:               op,
 		pkMap: map[string]any{
 			"id": idString,
 		},

--- a/sources/mongo/message.go
+++ b/sources/mongo/message.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Message struct {
-	afterJsonExtendedString  string
+	afterJSONExtendedString  string
 	beforeJSONExtendedString *string
 	operation                string
 	pkMap                    map[string]any
@@ -26,7 +26,7 @@ func (m *Message) ToRawMessage(collection config.Collection, database string) (l
 	evt := &mongo.SchemaEventPayload{
 		Schema: debezium.Schema{},
 		Payload: mongo.Payload{
-			After:  &m.afterJsonExtendedString,
+			After:  &m.afterJSONExtendedString,
 			Before: m.beforeJSONExtendedString,
 			Source: mongo.Source{
 				Database:   database,
@@ -84,7 +84,7 @@ func ParseMessage(after bson.M, before *bson.M, op string) (*Message, error) {
 	}
 
 	msg := &Message{
-		afterJsonExtendedString: string(afterRow),
+		afterJSONExtendedString: string(afterRow),
 		operation:               op,
 		pkMap: map[string]any{
 			"id": idString,

--- a/sources/mongo/message_test.go
+++ b/sources/mongo/message_test.go
@@ -20,7 +20,7 @@ func TestParseMessagePartitionKey(t *testing.T) {
 		// Primary key as object ID
 		objId, err := primitive.ObjectIDFromHex("507f1f77bcf86cd799439011")
 		assert.NoError(t, err)
-		msg, err := ParseMessage(bson.M{"_id": objId}, "r")
+		msg, err := ParseMessage(bson.M{"_id": objId}, nil, "r")
 		assert.NoError(t, err)
 		assert.Equal(t, `{"$oid":"507f1f77bcf86cd799439011"}`, msg.pkMap["id"])
 
@@ -37,14 +37,14 @@ func TestParseMessagePartitionKey(t *testing.T) {
 	}
 	{
 		// Primary key as string
-		msg, err := ParseMessage(bson.M{"_id": "hello world"}, "r")
+		msg, err := ParseMessage(bson.M{"_id": "hello world"}, nil, "r")
 		assert.NoError(t, err)
 		assert.Equal(t, "hello world", msg.pkMap["id"])
 	}
 	{
 		// Primary key as ints
 		for _, val := range []any{1001, int32(1002), int64(1003)} {
-			msg, err := ParseMessage(bson.M{"_id": val}, "r")
+			msg, err := ParseMessage(bson.M{"_id": val}, nil, "r")
 			assert.NoError(t, err)
 			assert.Equal(t, fmt.Sprint(val), msg.pkMap["id"])
 		}
@@ -78,7 +78,7 @@ func TestParseMessage(t *testing.T) {
 			"trueValue":  true,
 			"falseValue": false,
 			"nullValue":  nil,
-		}, "r")
+		}, nil, "r")
 	assert.NoError(t, err)
 
 	rawMsg, err := msg.ToRawMessage(config.Collection{}, "database")

--- a/sources/mongo/mongo.go
+++ b/sources/mongo/mongo.go
@@ -2,16 +2,15 @@ package mongo
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/mongo"
-	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 
 	"github.com/artie-labs/reader/config"
+	mongoLib "github.com/artie-labs/reader/lib/mongo"
 	"github.com/artie-labs/reader/writers"
 )
 
@@ -21,18 +20,8 @@ type Source struct {
 }
 
 func Load(cfg config.MongoDB) (*Source, bool, error) {
-	creds := options.Credential{
-		Username: cfg.Username,
-		Password: cfg.Password,
-	}
-
-	opts := options.Client().ApplyURI(cfg.Host).SetAuth(creds)
-	if !cfg.DisableTLS {
-		opts = opts.SetTLSConfig(&tls.Config{})
-	}
-
 	ctx := context.Background()
-	client, err := mongo.Connect(ctx, opts)
+	client, err := mongo.Connect(ctx, mongoLib.OptsFromConfig(cfg))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to connect to MongoDB: %w", err)
 	}

--- a/sources/mongo/snapshot.go
+++ b/sources/mongo/snapshot.go
@@ -79,7 +79,7 @@ func (s *snapshotIterator) Next() ([]lib.RawMessage, error) {
 			return nil, fmt.Errorf("failed to decode document: %w", err)
 		}
 
-		mgoMsg, err := ParseMessage(result, "r")
+		mgoMsg, err := ParseMessage(result, nil, "r")
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse message: %w", err)
 		}

--- a/sources/mongo/streaming.go
+++ b/sources/mongo/streaming.go
@@ -44,9 +44,12 @@ func newStreamingIterator(ctx context.Context, db *mongo.Database, cfg config.Mo
 		}}},
 	}
 
-	// Setting `updateLookup` will emit the whole document for updates
-	// Ref: https://www.mongodb.com/docs/manual/reference/change-events/update/#description
-	opts := options.ChangeStream().SetFullDocument(options.UpdateLookup).SetFullDocumentBeforeChange(options.WhenAvailable)
+	opts := options.ChangeStream().
+		// Setting `updateLookup` will emit the whole document for updates
+		// Ref: https://www.mongodb.com/docs/manual/reference/change-events/update/#description
+		SetFullDocument(options.UpdateLookup).
+		// FullDocumentBeforeChange will kick in if the db + collection enabled `changeStreamPreAndPostImages`
+		SetFullDocumentBeforeChange(options.WhenAvailable)
 
 	storage := persistedmap.NewPersistedMap(filePath)
 	if encodedResumeToken, exists := storage.Get(offsetKey); exists {

--- a/sources/mongo/streaming.go
+++ b/sources/mongo/streaming.go
@@ -46,7 +46,7 @@ func newStreamingIterator(ctx context.Context, db *mongo.Database, cfg config.Mo
 
 	// Setting `updateLookup` will emit the whole document for updates
 	// Ref: https://www.mongodb.com/docs/manual/reference/change-events/update/#description
-	opts := options.ChangeStream().SetFullDocument(options.UpdateLookup)
+	opts := options.ChangeStream().SetFullDocument(options.UpdateLookup).SetFullDocumentBeforeChange(options.WhenAvailable)
 
 	storage := persistedmap.NewPersistedMap(filePath)
 	if encodedResumeToken, exists := storage.Get(offsetKey); exists {

--- a/writers/transfer/writer_test.go
+++ b/writers/transfer/writer_test.go
@@ -22,7 +22,7 @@ func TestWriter_MessageToEvent(t *testing.T) {
 		"string": "Hello, world!",
 		"int64":  int64(1234567890),
 		"double": 3.14159,
-	}, "r")
+	}, nil, "r")
 	assert.NoError(t, err)
 
 	message, err := msg.ToRawMessage(config.Collection{Name: "collection"}, "database")


### PR DESCRIPTION
Refactoring our MongoDB client to support pre-image.

## Changes

* Allowing no username / password to be specified
* Pulled building `opts` into a separate package and added tests
* Support `FullDocumentBeforeChange` 