### PR TITLE
Bump staticcheck to `2024.1`

### DIFF
--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -12,7 +12,7 @@ jobs:
           go-version: 1.22
       - name: Run staticcheck
         env:
-          SC_VERSION: 2023.1.7
+          SC_VERSION: "2024.1"
         run: |
           make generate
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"


### PR DESCRIPTION
https://github.com/dominikh/go-tools/releases/tag/2024.1