### PR TITLE
Skip empty fieldTypes

### DIFF
--- a/lib/dynamo/message.go
+++ b/lib/dynamo/message.go
@@ -106,6 +106,10 @@ func (m *Message) artieMessage() *util.SchemaEventPayload {
 	if len(m.afterSchema) > 0 {
 		var fields []debezium.Field
 		for colName, fieldType := range m.afterSchema {
+			if fieldType == "" {
+				continue
+			}
+			
 			fields = append(fields, debezium.Field{
 				Type:      fieldType,
 				Optional:  true,

--- a/lib/dynamo/message.go
+++ b/lib/dynamo/message.go
@@ -109,7 +109,7 @@ func (m *Message) artieMessage() *util.SchemaEventPayload {
 			if fieldType == "" {
 				continue
 			}
-			
+
 			fields = append(fields, debezium.Field{
 				Type:      fieldType,
 				Optional:  true,


### PR DESCRIPTION
DynamoDB has an attribute called [NULL](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html#:~:text=Required%3A%20No-,NULL,-An%20attribute%20of) which does not map to any data type.

We shouldn't add this to the schema if there's no actual data type