### PR TITLE
[MongoDB] Address edge case with `fullDocumentBeforeChange`

### DIFF
--- a/lib/mongo/change_event.go
+++ b/lib/mongo/change_event.go
@@ -92,7 +92,7 @@ func NewChangeEvent(rawChangeEvent bson.M) (*ChangeEvent, error) {
 		case bson.M:
 			changeEvent.fullDocumentBeforeChange = &castedFullDoc
 		case nil:
-			// TODO: Look into why this happens.
+			// This may happen if the row was purged before we can read it
 			changeEvent.fullDocumentBeforeChange = &bson.M{
 				"_id": objectID,
 			}

--- a/lib/mongo/change_event.go
+++ b/lib/mongo/change_event.go
@@ -97,7 +97,7 @@ func NewChangeEvent(rawChangeEvent bson.M) (*ChangeEvent, error) {
 				"_id": objectID,
 			}
 		default:
-			return nil, fmt.Errorf("expected fullDocument to be bson.M or nil, got: %T", fullDoc)
+			return nil, fmt.Errorf("expected fullDocumentBeforeChange to be bson.M or nil, got: %T", fullDoc)
 		}
 	}
 

--- a/lib/mongo/change_event.go
+++ b/lib/mongo/change_event.go
@@ -88,12 +88,17 @@ func NewChangeEvent(rawChangeEvent bson.M) (*ChangeEvent, error) {
 
 	fullDocumentBeforeChange, isOk := rawChangeEvent["fullDocumentBeforeChange"]
 	if isOk {
-		castedFullDocumentBeforeChange, isOk := fullDocumentBeforeChange.(bson.M)
-		if !isOk {
-			return nil, fmt.Errorf("expected fullDocumentBeforeChange to be bson.M, got: %T", fullDocumentBeforeChange)
+		switch castedFullDoc := fullDocumentBeforeChange.(type) {
+		case bson.M:
+			changeEvent.fullDocumentBeforeChange = &castedFullDoc
+		case nil:
+			// TODO: Look into why this happens.
+			changeEvent.fullDocumentBeforeChange = &bson.M{
+				"_id": objectID,
+			}
+		default:
+			return nil, fmt.Errorf("expected fullDocument to be bson.M or nil, got: %T", fullDoc)
 		}
-
-		changeEvent.fullDocumentBeforeChange = &castedFullDocumentBeforeChange
 	}
 
 	return changeEvent, nil


### PR DESCRIPTION
Similar to https://github.com/artie-labs/reader/pull/461.

Sometimes the `fullDocumentBeforeChange` may be nil