### PR TITLE
Return error if value scale is different from schema scale

### DIFF
--- a/lib/debezium/converters/money.go
+++ b/lib/debezium/converters/money.go
@@ -56,5 +56,5 @@ func (m MoneyConverter) Convert(value any) (any, error) {
 		return nil, fmt.Errorf(`unable to use %q as a money value: %w`, valString, err)
 	}
 
-	return encodeDecimalWithScale(decimal, int32(m.Scale())), nil
+	return encodeDecimalWithScale(decimal, int32(m.Scale()))
 }

--- a/lib/debezium/converters/money_test.go
+++ b/lib/debezium/converters/money_test.go
@@ -70,11 +70,9 @@ func TestMoneyConverter_Convert(t *testing.T) {
 			assert.Equal(t, "1234.56", decodeValue(converted))
 		}
 		{
-			// string with $, comma, and no cents
-			converted, err := converter.Convert("$1000,234")
-			assert.NoError(t, err)
-			assert.Equal(t, []byte{0x5, 0xf6, 0x3c, 0x68}, converted)
-			assert.Equal(t, "1000234.00", decodeValue(converted))
+			// string no cents
+			_, err := converter.Convert("$1000,234")
+			assert.ErrorContains(t, err, "value scale (0) is different from schema scale (2)")
 		}
 		{
 			// Malformed string - empty string.

--- a/lib/debezium/converters/money_test.go
+++ b/lib/debezium/converters/money_test.go
@@ -70,7 +70,7 @@ func TestMoneyConverter_Convert(t *testing.T) {
 			assert.Equal(t, "1234.56", decodeValue(converted))
 		}
 		{
-			// string no cents
+			// string with missing cents
 			_, err := converter.Convert("$1000,234")
 			assert.ErrorContains(t, err, "value scale (0) is different from schema scale (2)")
 		}


### PR DESCRIPTION
We haven't seen `Warn if value scale is different from schema scale` in the logs in the past three weeks.