### PR TITLE
[MySQL] Read MySQL bit size

### DIFF
--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -2,10 +2,10 @@ package schema
 
 import (
 	"encoding/base64"
-	"github.com/artie-labs/transfer/lib/typing"
 	"testing"
 	"time"
 
+	"github.com/artie-labs/transfer/lib/typing"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"encoding/base64"
+	"github.com/artie-labs/transfer/lib/typing"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ func TestConvertValue(t *testing.T) {
 	tests := []struct {
 		name        string
 		dataType    DataType
+		opts        *Opts
 		value       any
 		expected    any
 		expectedErr string
@@ -34,24 +36,28 @@ func TestConvertValue(t *testing.T) {
 			name:     "bit - 0 value",
 			dataType: Bit,
 			value:    []byte{byte(0)},
+			opts:     &Opts{Size: typing.ToPtr(1)},
 			expected: false,
 		},
 		{
 			name:     "bit - 1 value",
 			dataType: Bit,
 			value:    []byte{byte(1)},
+			opts:     &Opts{Size: typing.ToPtr(1)},
 			expected: true,
 		},
 		{
 			name:        "bit - 2 value",
 			dataType:    Bit,
 			value:       []byte{byte(2)},
+			opts:        &Opts{Size: typing.ToPtr(1)},
 			expectedErr: "bit value is invalid",
 		},
 		{
 			name:        "bit - 2 bytes",
 			dataType:    Bit,
 			value:       []byte{byte(1), byte(1)},
+			opts:        &Opts{Size: typing.ToPtr(1)},
 			expectedErr: "bit value is invalid",
 		},
 		{
@@ -279,7 +285,7 @@ func TestConvertValue(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		value, err := ConvertValue(tc.value, tc.dataType)
+		value, err := ConvertValue(tc.value, tc.dataType, tc.opts)
 		if tc.expectedErr == "" {
 			assert.NoError(t, err, tc.name)
 			assert.Equal(t, tc.expected, value, tc.name)
@@ -293,7 +299,7 @@ func TestConvertValues(t *testing.T) {
 	columns := []Column{
 		{Name: "a", Type: Int},
 		{Name: "b", Type: Varchar},
-		{Name: "c", Type: Bit},
+		{Name: "c", Type: Bit, Opts: &Opts{Size: typing.ToPtr(1)}},
 	}
 
 	{

--- a/lib/mysql/schema/schema.go
+++ b/lib/mysql/schema/schema.go
@@ -176,7 +176,12 @@ func parseColumnDataType(originalS string) (DataType, *Opts, error) {
 	case "double":
 		return Double, nil, nil
 	case "bit":
-		return Bit, nil, nil
+		size, err := strconv.Atoi(metadata)
+		if err != nil {
+			return -1, nil, fmt.Errorf("failed to parse metadata value %q: %w", s, err)
+		}
+
+		return Bit, &Opts{Size: typing.ToPtr(size)}, nil
 	case "date":
 		return Date, nil, nil
 	case "datetime":

--- a/sources/mysql/adapter/adapter.go
+++ b/sources/mysql/adapter/adapter.go
@@ -83,7 +83,17 @@ func (m MySQLAdapter) PartitionKeys() []string {
 
 func valueConverterForType(d schema.DataType, opts *schema.Opts) (converters.ValueConverter, error) {
 	switch d {
-	case schema.Bit, schema.Boolean:
+	case schema.Bit:
+		if opts == nil || opts.Size == nil {
+			return nil, fmt.Errorf("size is required for bit type")
+		}
+
+		if *opts.Size == 1 {
+			return converters.BooleanPassthrough{}, nil
+		}
+
+		return converters.BytesPassthrough{}, nil
+	case schema.Boolean:
 		return converters.BooleanPassthrough{}, nil
 	case schema.TinyInt, schema.SmallInt:
 		return converters.Int16Passthrough{}, nil

--- a/sources/mysql/adapter/adapter_test.go
+++ b/sources/mysql/adapter/adapter_test.go
@@ -85,7 +85,7 @@ func TestValueConverterForType(t *testing.T) {
 				Size: typing.ToPtr(5),
 			},
 			expected: debezium.Field{
-				Type:      debezium.Bytes,
+				Type:      "bytes",
 				FieldName: colName,
 			},
 		},

--- a/sources/mysql/adapter/adapter_test.go
+++ b/sources/mysql/adapter/adapter_test.go
@@ -68,10 +68,24 @@ func TestValueConverterForType(t *testing.T) {
 			expectedErr: "unable get value converter for DataType(-1)",
 		},
 		{
-			name:     "bit",
+			name:     "bit(1)",
 			dataType: schema.Bit,
+			opts: &schema.Opts{
+				Size: typing.ToPtr(1),
+			},
 			expected: debezium.Field{
 				Type:      "boolean",
+				FieldName: colName,
+			},
+		},
+		{
+			name:     "bit(5)",
+			dataType: schema.Bit,
+			opts: &schema.Opts{
+				Size: typing.ToPtr(5),
+			},
+			expected: debezium.Field{
+				Type:      debezium.Bytes,
 				FieldName: colName,
 			},
 		},


### PR DESCRIPTION
We previously treated `bit` as `bit(1)`. However, bit is actually `bit(M)`, where M can range from 1 to 64.

https://dev.mysql.com/doc/refman/8.4/en/bit-type.html