### PR TITLE
[Postgres] Adding Column allowlist

### DIFF
--- a/config/postgres.go
+++ b/config/postgres.go
@@ -43,6 +43,8 @@ type PostgreSQLTable struct {
 	OptionalPrimaryKeyValStart string   `yaml:"optionalPrimaryKeyValStart,omitempty"`
 	OptionalPrimaryKeyValEnd   string   `yaml:"optionalPrimaryKeyValEnd,omitempty"`
 	ExcludeColumns             []string `yaml:"excludeColumns,omitempty"`
+	// IncludeColumns - List of columns that should be included in the change event record.
+	IncludeColumns []string `yaml:"includeColumns,omitempty"`
 }
 
 func (p *PostgreSQLTable) GetBatchSize() uint {
@@ -98,6 +100,11 @@ func (p *PostgreSQL) Validate() error {
 
 		if table.Schema == "" {
 			return fmt.Errorf("schema must be passed in")
+		}
+
+		// You should not be able to filter and exclude columns at the same time
+		if len(table.ExcludeColumns) > 0 && len(table.IncludeColumns) > 0 {
+			return fmt.Errorf("cannot exclude and include columns at the same time")
 		}
 	}
 

--- a/config/postgres_test.go
+++ b/config/postgres_test.go
@@ -118,6 +118,26 @@ func TestPostgreSQL_Validate(t *testing.T) {
 		assert.ErrorContains(t, p.Validate(), "schema must be passed in")
 	}
 	{
+		// Filtering and excluding at the same time
+		p := &PostgreSQL{
+			Host:     "host",
+			Port:     1,
+			Username: "username",
+			Password: "password",
+			Database: "database",
+			Tables: []*PostgreSQLTable{
+				{
+					Name:           "name",
+					Schema:         "schema",
+					ExcludeColumns: []string{"a"},
+					IncludeColumns: []string{"b"},
+				},
+			},
+		}
+
+		assert.ErrorContains(t, p.Validate(), "cannot exclude and include columns at the same time")
+	}
+	{
 		// Valid
 		p := &PostgreSQL{
 			Host:     "host",

--- a/lib/rdbms/column/column.go
+++ b/lib/rdbms/column/column.go
@@ -51,9 +51,17 @@ func FilterOutExcludedColumns[T ~int, O any](columns []Column[T, O], excludeName
 }
 
 // FilterForIncludedColumns returns a list of columns including only those that match `includeNames`.
-func FilterForIncludedColumns[T ~int, O any](columns []Column[T, O], includeNames []string) ([]Column[T, O], error) {
+// All primary keys must be included, else it'll return an error.
+func FilterForIncludedColumns[T ~int, O any](columns []Column[T, O], includeNames []string, primaryKeys []string) ([]Column[T, O], error) {
 	if len(includeNames) == 0 {
 		return columns, nil
+	}
+
+	// All primary keys must be included
+	for _, key := range primaryKeys {
+		if !slices.Contains(includeNames, key) {
+			return nil, fmt.Errorf("primary key column %q must be included", key)
+		}
 	}
 
 	var result []Column[T, O]

--- a/lib/rdbms/column/column.go
+++ b/lib/rdbms/column/column.go
@@ -49,3 +49,18 @@ func FilterOutExcludedColumns[T ~int, O any](columns []Column[T, O], excludeName
 	}
 	return result, nil
 }
+
+// FilterForIncludedColumns returns a list of columns including only those that match `includeNames`.
+func FilterForIncludedColumns[T ~int, O any](columns []Column[T, O], includeNames []string) ([]Column[T, O], error) {
+	if len(includeNames) == 0 {
+		return columns, nil
+	}
+
+	var result []Column[T, O]
+	for _, column := range columns {
+		if slices.Contains(includeNames, column.Name) {
+			result = append(result, column)
+		}
+	}
+	return result, nil
+}

--- a/lib/rdbms/column/column_test.go
+++ b/lib/rdbms/column/column_test.go
@@ -162,20 +162,31 @@ func TestFilterOutExcludedColumns(t *testing.T) {
 func TestFilterForIncludedColumns(t *testing.T) {
 	{
 		// Empty `includeNames`
-		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}}, []string{})
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}}, []string{}, []string{})
 		assert.NoError(t, err)
 		assert.Equal(t, value, []mockColumn{{Name: "foo"}})
 	}
 	{
 		// Non-empty `includeNames`, included column is not in list
-		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}}, []string{"bar"})
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}}, []string{"bar"}, []string{})
 		assert.NoError(t, err)
 		assert.Equal(t, value, []mockColumn(nil))
 	}
 	{
 		// Non-empty `includeNames`, included column is in list
-		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}, {Name: "bar"}}, []string{"bar"})
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}, {Name: "bar"}}, []string{"bar"}, []string{})
 		assert.NoError(t, err)
 		assert.Equal(t, value, []mockColumn{{Name: "bar"}})
+	}
+	{
+		// Non-empty `includeNames`, included column is in list, primary key is not included
+		_, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}, {Name: "bar"}}, []string{"bar"}, []string{"foo"})
+		assert.ErrorContains(t, err, `primary key column "foo" must be included`)
+	}
+	{
+		// Non-empty `includeNames`, included column is in list, primary key is included
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}, {Name: "bar"}}, []string{"foo", "bar"}, []string{"foo"})
+		assert.NoError(t, err)
+		assert.Equal(t, value, []mockColumn{{Name: "foo"}, {Name: "bar"}})
 	}
 }

--- a/lib/rdbms/column/column_test.go
+++ b/lib/rdbms/column/column_test.go
@@ -158,3 +158,24 @@ func TestFilterOutExcludedColumns(t *testing.T) {
 		assert.ErrorContains(t, err, `cannot exclude primary key column "bar"`)
 	}
 }
+
+func TestFilterForIncludedColumns(t *testing.T) {
+	{
+		// Empty `includeNames`
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}}, []string{})
+		assert.NoError(t, err)
+		assert.Equal(t, value, []mockColumn{{Name: "foo"}})
+	}
+	{
+		// Non-empty `includeNames`, included column is not in list
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}}, []string{"bar"})
+		assert.NoError(t, err)
+		assert.Equal(t, value, []mockColumn(nil))
+	}
+	{
+		// Non-empty `includeNames`, included column is in list
+		value, err := FilterForIncludedColumns([]mockColumn{{Name: "foo"}, {Name: "bar"}}, []string{"bar"})
+		assert.NoError(t, err)
+		assert.Equal(t, value, []mockColumn{{Name: "bar"}})
+	}
+}

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -38,7 +38,7 @@ func NewPostgresAdapter(db *sql.DB, tableCfg config.PostgreSQLTable) (PostgresAd
 	}
 
 	// Include columns (if any) from the table metadata
-	columns, err = column.FilterForIncludedColumns(columns, tableCfg.IncludeColumns)
+	columns, err = column.FilterForIncludedColumns(columns, tableCfg.IncludeColumns, table.PrimaryKeys)
 	if err != nil {
 		return PostgresAdapter{}, err
 	}

--- a/sources/postgres/adapter/adapter.go
+++ b/sources/postgres/adapter/adapter.go
@@ -31,7 +31,14 @@ func NewPostgresAdapter(db *sql.DB, tableCfg config.PostgreSQLTable) (PostgresAd
 		return PostgresAdapter{}, fmt.Errorf("failed to load metadata for table %s.%s: %w", tableCfg.Schema, tableCfg.Name, err)
 	}
 
+	// Exclude columns (if any) from the table metadata
 	columns, err := column.FilterOutExcludedColumns(table.Columns, tableCfg.ExcludeColumns, table.PrimaryKeys)
+	if err != nil {
+		return PostgresAdapter{}, err
+	}
+
+	// Include columns (if any) from the table metadata
+	columns, err = column.FilterForIncludedColumns(columns, tableCfg.IncludeColumns)
 	if err != nil {
 		return PostgresAdapter{}, err
 	}


### PR DESCRIPTION
Adding the ability to filter out columns that were not on the include list.

Following a similar pattern to [Debezium](https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-property-column-include-list)