### PR TITLE
github: run tests just once

### DIFF
--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -20,9 +20,7 @@ jobs:
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"
           wget -q ${SC_URL} -O - | tar -xzf - --strip-components 1 -C /usr/local/bin staticcheck/staticcheck
           make static
-      - name: Run tests
-        run: make test
-      - name: Run race condition check
+      - name: Run tests + race condition check
         run: make race
       - name: Check Go files are properly formatted
         run: test -z $(gofmt -l .)

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -14,7 +14,7 @@ jobs:
         run: make vet
       - name: Run staticcheck
         env:
-          SC_VERSION: "2024.1"
+          SC_VERSION: "2024.1.1"
         run: |
           make generate
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"


### PR DESCRIPTION
`make race` already runs tests, so we don't need to run tests a second time.