### PR TITLE
github: add step to install Go dependencies

### DIFF
--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -18,7 +18,6 @@ jobs:
         env:
           SC_VERSION: "2024.1.1"
         run: |
-          make generate
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"
           wget -q ${SC_URL} -O - | tar -xzf - --strip-components 1 -C /usr/local/bin staticcheck/staticcheck
           make static

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -18,6 +18,7 @@ jobs:
         env:
           SC_VERSION: "2024.1.1"
         run: |
+          make generate
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"
           wget -q ${SC_URL} -O - | tar -xzf - --strip-components 1 -C /usr/local/bin staticcheck/staticcheck
           make static

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -10,6 +10,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.23
+      - name: Install dependencies
+        run: go mod download
       - name: Run vet
         run: make vet
       - name: Run staticcheck


### PR DESCRIPTION
So that the duration of the GitHub actions steps are more predictable, otherwise the dependencies are installed in the next step.