### PR TITLE
github: stop generating unused mocks

### DIFF
--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -1,6 +1,7 @@
 name: Go tests
-run-name: Running tests
+
 on: [push]
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/gha-go-test.yaml
+++ b/.github/workflows/gha-go-test.yaml
@@ -16,7 +16,6 @@ jobs:
         env:
           SC_VERSION: "2024.1.1"
         run: |
-          make generate
           SC_URL="https://github.com/dominikh/go-tools/releases/download/$SC_VERSION/staticcheck_linux_amd64.tar.gz"
           wget -q ${SC_URL} -O - | tar -xzf - --strip-components 1 -C /usr/local/bin staticcheck/staticcheck
           make static

--- a/.github/workflows/gha-integration-tests.yaml
+++ b/.github/workflows/gha-integration-tests.yaml
@@ -1,6 +1,7 @@
 name: Integration tests
-run-name: Running integration tests
+
 on: [push]
+
 jobs:
   Postgres:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,6 @@ release:
 clean:
 	go clean -testcache
 
-.PHONY: generate
-generate:
-	go get github.com/maxbrunsfeld/counterfeiter/v6
-	go generate ./...
-	go mod tidy
-
 .PHONY: upgrade
 upgrade:
 	go get github.com/artie-labs/transfer

--- a/lib/mocks/generate.go
+++ b/lib/mocks/generate.go
@@ -1,4 +1,0 @@
-package mocks
-
-//go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
-//counterfeiter:generate -o=client.mock.go ../mtr Client


### PR DESCRIPTION
We're generating mocks (`FakeClient`) that we aren't using anywhere.