### PR TITLE
Reimplement `kafkalib.batched` using `slices.Chunk`

### DIFF
--- a/lib/kafkalib/batch.go
+++ b/lib/kafkalib/batch.go
@@ -1,13 +1,8 @@
 package kafkalib
 
+import "slices"
+
 // batched splits a slice of items into a slice of step-sized slices.
 func batched[T any](items []T, step int) [][]T {
-	step = max(step, 1)
-	var result [][]T
-	for index := 0; index < len(items); {
-		end := min(index+step, len(items))
-		result = append(result, items[index:end])
-		index = end
-	}
-	return result
+	return slices.Collect(slices.Chunk(items, max(step, 1)))
 }


### PR DESCRIPTION
With the goal of inlining `batched` in the next PR. Existing [tests](https://github.com/artie-labs/reader/blob/9082ca125337d65d86b0d783108e2f94e14df8c8/lib/kafkalib/batch_test.go#L9) ensure that this is functionally equivlelent. 