### PR TITLE
[Postgres] Refactor `ZonedTimestampConverter`

### DIFF
--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -122,6 +122,7 @@ CREATE TABLE %s (
 	c_time_with_timezone time WITH TIME ZONE,
 	c_timestamp_without_timezone timestamp WITHOUT TIME ZONE,
 	c_timestamp_with_timezone timestamp WITH TIME ZONE,
+	c_timestamp_with_timezone_utc timestamp WITH TIME ZONE,
 	-- c_tsquery tsquery,
 	-- c_tsvector tsvector,
 	-- c_txid_snapshot txid_snapshot,
@@ -241,6 +242,7 @@ INSERT INTO %s VALUES (
 		'2001-02-16 20:38:40',
 	-- c_timestamp_with_timezone
 		'2001-02-16 20:38:40' AT TIME ZONE 'America/Denver',
+        '2001-02-16 20:38:40' AT TIME ZONE 'UTC',
 	-- c_tsquery
 		-- Not supported
 	-- c_tsvector
@@ -615,6 +617,14 @@ const expectedPayloadTemplate = `{
 						"type": "string",
 						"optional": false,
 						"default": null,
+						"field": "c_timestamp_with_timezone_utc",
+						"name": "io.debezium.time.ZonedTimestamp",
+						"parameters": null
+					},
+					{
+						"type": "string",
+						"optional": false,
+						"default": null,
 						"field": "c_uuid",
 						"name": "io.debezium.data.Uuid",
 						"parameters": null
@@ -783,6 +793,7 @@ const expectedPayloadTemplate = `{
 			"c_time_with_timezone": "10:34:17.746572Z",
 			"c_time_without_timezone": 45296000,
 			"c_timestamp_with_timezone": "2001-02-16T13:38:40Z",
+			"c_timestamp_with_timezone_utc": "2001-02-16T20:38:40Z",
 			"c_timestamp_without_timezone": 982355920000000,
 			"c_tsrange": "[\"2010-01-01 14:30:00\",\"2010-01-01 15:30:00\")",
 			"c_tstzrange": "[\"2001-02-16 08:38:40+00\",\"2001-03-20 08:38:40+00\")",

--- a/integration_tests/postgres/main.go
+++ b/integration_tests/postgres/main.go
@@ -242,7 +242,7 @@ INSERT INTO %s VALUES (
 		'2001-02-16 20:38:40',
 	-- c_timestamp_with_timezone
 		'2001-02-16 20:38:40' AT TIME ZONE 'America/Denver',
-        '2001-02-16 20:38:40' AT TIME ZONE 'UTC',
+		'2001-02-16 20:38:40' AT TIME ZONE 'UTC',
 	-- c_tsquery
 		-- Not supported
 	-- c_tsvector

--- a/lib/debezium/converters/time.go
+++ b/lib/debezium/converters/time.go
@@ -178,7 +178,7 @@ func (ZonedTimestampConverter) ToField(name string) debezium.Field {
 func (ZonedTimestampConverter) Convert(value any) (any, error) {
 	timeValue, ok := value.(time.Time)
 	if !ok {
-		return nil, fmt.Errorf("expected time.Time got %T with value: %v", value, value)
+		return nil, fmt.Errorf("expected time.Time got %T with value: '%v'", value, value)
 	}
 
 	if timeValue.Year() > 9999 || timeValue.Year() < 0 {
@@ -188,10 +188,7 @@ func (ZonedTimestampConverter) Convert(value any) (any, error) {
 		return nil, nil
 	}
 
-	// A string representation of a timestamp with timezone information, where the timezone is GMT.
-	// This layout supports upto microsecond precision.
-	layout := "2006-01-02T15:04:05.999999Z"
-	return timeValue.UTC().Format(layout), nil
+	return timeValue.Format(time.RFC3339Nano), nil
 }
 
 type YearConverter struct{}

--- a/lib/debezium/converters/time_test.go
+++ b/lib/debezium/converters/time_test.go
@@ -270,7 +270,7 @@ func TestZonedTimestampConverter_Convert(t *testing.T) {
 	{
 		// Invalid type
 		_, err := converter.Convert(1234)
-		assert.ErrorContains(t, err, "expected time.Time got int with value: 1234")
+		assert.ErrorContains(t, err, "expected time.Time got int with value: '1234'")
 	}
 	{
 		// Date > 9999
@@ -322,15 +322,15 @@ func TestZonedTimestampConverter_Convert(t *testing.T) {
 	}
 	{
 		// Different timezone
-		_ts := time.Date(2001, 2, 3, 4, 5, 0, 0, time.FixedZone("CET", 1*60*60))
+		_ts := time.Date(2001, 2, 3, 4, 5, 0, 0, time.FixedZone("", 1*60*60))
 		value, err := converter.Convert(_ts)
 		assert.NoError(t, err)
-		assert.Equal(t, "2001-02-03T03:05:00Z", value)
+		assert.Equal(t, "2001-02-03T04:05:00+01:00", value)
 
 		// Check Transfer to ensure no precision loss
 		ts, err := converters.ZonedTimestamp{}.Convert(value)
 		assert.NoError(t, err)
-		assert.Equal(t, _ts.UTC(), ts.(*ext.ExtendedTime).GetTime())
+		assert.Equal(t, _ts, ts.(*ext.ExtendedTime).GetTime())
 	}
 }
 


### PR DESCRIPTION
Following the same rationale as https://github.com/artie-labs/transfer/pull/987