### PR TITLE
[MySQL] Get Create Table DDL

### DIFF
--- a/lib/mysql/schema/schema.go
+++ b/lib/mysql/schema/schema.go
@@ -68,6 +68,17 @@ func QuoteIdentifier(s string) string {
 	return fmt.Sprintf("`%s`", strings.ReplaceAll(s, "`", "``"))
 }
 
+func GetCreateTableDDL(db *sql.DB, table string) (string, error) {
+	row := db.QueryRow("SHOW CREATE TABLE " + QuoteIdentifier(table))
+	var unused string
+	var createTableDDL string
+	if err := row.Scan(&unused, &createTableDDL); err != nil {
+		return "", fmt.Errorf("failed to get create table DDL: %w", err)
+	}
+
+	return createTableDDL, nil
+}
+
 func DescribeTable(db *sql.DB, table string) ([]Column, error) {
 	r, err := db.Query("DESCRIBE " + QuoteIdentifier(table))
 	if err != nil {


### PR DESCRIPTION
This function is needed so that we can download the schema definition in the case where the table definition does not exist in the binlog.