### PR TITLE
Simplifying PersistedMap

### DIFF
--- a/lib/iterator/iterator.go
+++ b/lib/iterator/iterator.go
@@ -7,7 +7,7 @@ type Iterator[T any] interface {
 
 type StreamingIterator[T any] interface {
 	Iterator[T]
-	CommitOffset()
+	CommitOffset() error
 }
 
 // Collect returns a new slice containing all the items from an [Iterator].

--- a/lib/storage/persistedmap/persistedmap.go
+++ b/lib/storage/persistedmap/persistedmap.go
@@ -2,11 +2,12 @@ package persistedmap
 
 import (
 	"fmt"
-	"github.com/artie-labs/reader/lib/logger"
 	"gopkg.in/yaml.v3"
 	"io"
 	"log/slog"
 	"os"
+
+	"github.com/artie-labs/reader/lib/logger"
 )
 
 type PersistedMap[T any] struct {
@@ -34,7 +35,7 @@ func NewPersistedMap[T any](filePath string) *PersistedMap[T] {
 
 func (p *PersistedMap[T]) Set(key string, value T) error {
 	p.data[key] = value
-	
+
 	file, err := os.Create(p.filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/lib/storage/persistedmap/persistedmap.go
+++ b/lib/storage/persistedmap/persistedmap.go
@@ -34,8 +34,7 @@ func NewPersistedMap[T any](filePath string) *PersistedMap[T] {
 
 func (p *PersistedMap[T]) Set(key string, value T) error {
 	p.data[key] = value
-
-	// Open the file
+	
 	file, err := os.Create(p.filePath)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/lib/storage/persistedmap/persistedmap_test.go
+++ b/lib/storage/persistedmap/persistedmap_test.go
@@ -22,8 +22,6 @@ func TestPersistedMap_LoadFromFile(t *testing.T) {
 
 	// Load the data from the file into PersistedMap
 	pMap := NewPersistedMap[any](tmpFile.Name())
-	pMap.mu.Lock()
-	defer pMap.mu.Unlock()
 	assert.Equal(t, initialData, pMap.data)
 }
 
@@ -31,10 +29,8 @@ func TestPersistedMap_Flush(t *testing.T) {
 	tmpFile := fmt.Sprintf("%s/persistedmap_test", t.TempDir())
 
 	pMap := NewPersistedMap[any](tmpFile)
-	pMap.Set("key1", "value1")
-	pMap.Set("key2", 2)
-
-	assert.NoError(t, pMap.flush())
+	assert.NoError(t, pMap.Set("key1", "value1"))
+	assert.NoError(t, pMap.Set("key2", 2))
 
 	// Does the data exist?
 	val, isOk := pMap.Get("key1")
@@ -54,4 +50,19 @@ func TestPersistedMap_Flush(t *testing.T) {
 	val, isOk = pMap2.Get("key2")
 	assert.Equal(t, 2, val)
 	assert.True(t, isOk)
+}
+
+func BenchmarkNewPersistedMap(b *testing.B) {
+	// Seed the persisted map with 100 values
+	pMap := NewPersistedMap[any](fmt.Sprintf("%s/persistedmap_test", b.TempDir()))
+	for i := 0; i < 100; i++ {
+		assert.NoError(b, pMap.Set(fmt.Sprintf("key%d", i), i))
+	}
+
+	b.ResetTimer()
+
+	// Now randomly update 100 values
+	for i := 0; i < b.N; i++ {
+		assert.NoError(b, pMap.Set(fmt.Sprintf("key%d", i%100), i))
+	}
 }

--- a/sources/mongo/streaming.go
+++ b/sources/mongo/streaming.go
@@ -90,10 +90,10 @@ func (s *streaming) HasNext() bool {
 	return true
 }
 
-func (s *streaming) CommitOffset() {
+func (s *streaming) CommitOffset() error {
 	offset := base64.StdEncoding.EncodeToString(s.changeStream.ResumeToken())
 	slog.Info("Committing offset", slog.String("offset", offset))
-	s.offsets.Set(offsetKey, offset)
+	return s.offsets.Set(offsetKey, offset)
 }
 
 func (s *streaming) Next() ([]lib.RawMessage, error) {

--- a/sources/mysql/streaming/iterator.go
+++ b/sources/mysql/streaming/iterator.go
@@ -111,12 +111,13 @@ func (i *Iterator) HasNext() bool {
 	return true
 }
 
-func (i *Iterator) CommitOffset() {
+func (i *Iterator) CommitOffset() error {
 	slog.Info("Committing offset",
 		slog.String("position", i.position.String()),
 		slog.Int64("unixTs", i.position.UnixTs),
 	)
-	i.offsets.Set(offsetKey, i.position)
+
+	return i.offsets.Set(offsetKey, i.position)
 }
 
 func (i *Iterator) Close() error {

--- a/writers/writer.go
+++ b/writers/writer.go
@@ -3,6 +3,7 @@ package writers
 import (
 	"context"
 	"fmt"
+	"github.com/artie-labs/reader/lib/logger"
 	"log/slog"
 	"time"
 
@@ -43,7 +44,9 @@ func (w *Writer) Write(ctx context.Context, iter iterator.Iterator[[]lib.RawMess
 
 			// Is it a streaming iterator? if so, let's commit the offset.
 			if streamingIter, isOk := iter.(iterator.StreamingIterator[[]lib.RawMessage]); isOk {
-				streamingIter.CommitOffset()
+				if err = streamingIter.CommitOffset(); err != nil {
+					logger.Panic("Failed to commit offset", slog.Any("err", err))
+				}
 			}
 
 			count += len(msgs)

--- a/writers/writer.go
+++ b/writers/writer.go
@@ -3,7 +3,6 @@ package writers
 import (
 	"context"
 	"fmt"
-	"github.com/artie-labs/reader/lib/logger"
 	"log/slog"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 
 	"github.com/artie-labs/reader/lib"
 	"github.com/artie-labs/reader/lib/iterator"
+	"github.com/artie-labs/reader/lib/logger"
 )
 
 type DestinationWriter interface {


### PR DESCRIPTION
This PR simplifies our implementation of `PersistedMap`. 

Before, we had an async go-routine that would save the contents of the persisted map every 15 seconds if it needed to be saved.

Now we are saving it whenever `Set` gets called, removing the go-routines and the need for mutexes.