### PR TITLE
Add Artie generated columns

### DIFF
--- a/writers/transfer/writer.go
+++ b/writers/transfer/writer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/artie-labs/reader/lib/mtr"
 )
 
+// buildColumns - This will append additional columns based on [kafkalib.TopicConfig]
 func buildColumns(cols []columns.Column, tc kafkalib.TopicConfig) []columns.Column {
 	if tc.IncludeArtieUpdatedAt {
 		cols = append(cols, columns.NewColumn(constants.UpdateColumnMarker, typing.TimestampTZ))

--- a/writers/transfer/writer.go
+++ b/writers/transfer/writer.go
@@ -138,8 +138,7 @@ func (w *Writer) CreateTable(ctx context.Context, tableName string, cols []colum
 	}
 
 	// We should include additional columns based in the typing config
-	cols = buildColumns(cols, w.tc)
-	createTableSQL, err := ddl.BuildCreateTableSQL(w.cfg.SharedDestinationSettings.ColumnSettings, dwh.Dialect(), w.getTableID(tableName), false, w.cfg.Mode, cols)
+	createTableSQL, err := ddl.BuildCreateTableSQL(w.cfg.SharedDestinationSettings.ColumnSettings, dwh.Dialect(), w.getTableID(tableName), false, w.cfg.Mode, buildColumns(cols, w.tc))
 	if err != nil {
 		return fmt.Errorf("failed to build create table SQL: %w", err)
 	}

--- a/writers/transfer/writer.go
+++ b/writers/transfer/writer.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -302,7 +303,8 @@ func (w *Writer) flush(ctx context.Context, reason string) error {
 }
 
 func (w *Writer) getTableID(tableName string) sql.TableIdentifier {
-	return w.destination.IdentifierFor(w.tc, tableName)
+	// [w.tc.TableName] could be empty, in that case we'll fall back on [tableName]
+	return w.destination.IdentifierFor(w.tc, cmp.Or(w.tc.TableName, tableName))
 }
 
 func (w *Writer) onBackfillStart(ctx context.Context, tableName string) error {

--- a/writers/transfer/writer.go
+++ b/writers/transfer/writer.go
@@ -28,6 +28,22 @@ import (
 	"github.com/artie-labs/reader/lib/mtr"
 )
 
+func buildColumns(cols []columns.Column, tc kafkalib.TopicConfig) []columns.Column {
+	if tc.IncludeArtieUpdatedAt {
+		cols = append(cols, columns.NewColumn(constants.UpdateColumnMarker, typing.TimestampTZ))
+	}
+
+	if tc.IncludeDatabaseUpdatedAt {
+		cols = append(cols, columns.NewColumn(constants.DatabaseUpdatedColumnMarker, typing.TimestampTZ))
+	}
+
+	if tc.SoftDelete {
+		cols = append(cols, columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
+	}
+
+	return cols
+}
+
 type Writer struct {
 	cfg         transferConfig.Config
 	statsD      mtr.Client
@@ -112,22 +128,6 @@ func (w *Writer) messageToEvent(message lib.RawMessage) (event.Event, error) {
 	// Setting the deleted column flag.
 	memoryEvent.Data[constants.DeleteColumnMarker] = false
 	return memoryEvent, nil
-}
-
-func buildColumns(cols []columns.Column, tc kafkalib.TopicConfig) []columns.Column {
-	if tc.IncludeArtieUpdatedAt {
-		cols = append(cols, columns.NewColumn(constants.UpdateColumnMarker, typing.TimestampTZ))
-	}
-
-	if tc.IncludeDatabaseUpdatedAt {
-		cols = append(cols, columns.NewColumn(constants.DatabaseUpdatedColumnMarker, typing.TimestampTZ))
-	}
-
-	if tc.SoftDelete {
-		cols = append(cols, columns.NewColumn(constants.DeleteColumnMarker, typing.Boolean))
-	}
-
-	return cols
 }
 
 func (w *Writer) CreateTable(ctx context.Context, tableName string, cols []columns.Column) error {


### PR DESCRIPTION
With this change https://github.com/artie-labs/reader/pull/563, we are now creating tables for tables that don't yet exist.

However, we missed adding the additional Artie generated columns such as `__artie_updated_at` which takes consideration from inspecting the `topicConfig`. This PR adds that capability.