### PR TITLE
[MySQL] SchemaAdapter missed dbName

### DIFF
--- a/sources/mysql/streaming/ddl/ddl.go
+++ b/sources/mysql/streaming/ddl/ddl.go
@@ -24,6 +24,7 @@ func NewSchemaAdapter(cfg config.MySQL) SchemaAdapter {
 	return SchemaAdapter{
 		adapters:    make(map[string]TableAdapter),
 		tableCfgMap: tableCfgMap,
+		dbName:      cfg.Database,
 	}
 }
 


### PR DESCRIPTION
We missed setting `dbName` for the `schemaAdapter`