### PR TITLE
[MySQL] Handling different flavors of `SHOW CREATE TABLE ...` with regards to PKs

### DIFF
--- a/lib/antlr/create_table_test.go
+++ b/lib/antlr/create_table_test.go
@@ -42,6 +42,19 @@ func TestCreateTable(t *testing.T) {
 		}
 	}
 	{
+		// Primary key is specified outside of the column definition
+		events, err := Parse("CREATE TABLE table_name (id INT, name VARCHAR(255), PRIMARY KEY (id));")
+		assert.NoError(t, err)
+		assert.Len(t, events, 1)
+
+		createTableEvent, isOk := events[0].(CreateTableEvent)
+		assert.True(t, isOk)
+
+		assert.Equal(t, "table_name", createTableEvent.GetTable())
+		assert.Len(t, createTableEvent.GetColumns(), 2)
+		assert.Equal(t, []Column{{Name: "id", DataType: "INT", PrimaryKey: true}, {Name: "name", DataType: "VARCHAR(255)", PrimaryKey: false}}, createTableEvent.GetColumns())
+	}
+	{
 		// Create table with primary key
 		events, err := Parse("CREATE TABLE table_name (id INT PRIMARY KEY, name VARCHAR(255), tinyint1 TINYINT(1), bool_test BOOLEAN, `escaped_COL` BLOB);")
 		assert.NoError(t, err)

--- a/lib/antlr/create_table_test.go
+++ b/lib/antlr/create_table_test.go
@@ -43,16 +43,37 @@ func TestCreateTable(t *testing.T) {
 	}
 	{
 		// Primary key is specified outside of the column definition
-		events, err := Parse("CREATE TABLE table_name (id INT, name VARCHAR(255), PRIMARY KEY (id));")
-		assert.NoError(t, err)
-		assert.Len(t, events, 1)
+		{
+			// Primary key is specified, column does not exist
+			events, err := Parse("CREATE TABLE table_name (id INT, PRIMARY KEY (name));")
+			assert.ErrorContains(t, err, `failed to find column "name"`)
+			assert.Len(t, events, 0)
+		}
+		{
+			// One primary key
+			events, err := Parse("CREATE TABLE table_name (id INT, name VARCHAR(255), PRIMARY KEY (id));")
+			assert.NoError(t, err)
+			assert.Len(t, events, 1)
 
-		createTableEvent, isOk := events[0].(CreateTableEvent)
-		assert.True(t, isOk)
+			createTableEvent, isOk := events[0].(CreateTableEvent)
+			assert.True(t, isOk)
 
-		assert.Equal(t, "table_name", createTableEvent.GetTable())
-		assert.Len(t, createTableEvent.GetColumns(), 2)
-		assert.Equal(t, []Column{{Name: "id", DataType: "INT", PrimaryKey: true}, {Name: "name", DataType: "VARCHAR(255)", PrimaryKey: false}}, createTableEvent.GetColumns())
+			assert.Equal(t, "table_name", createTableEvent.GetTable())
+			assert.Len(t, createTableEvent.GetColumns(), 2)
+			assert.Equal(t, []Column{{Name: "id", DataType: "INT", PrimaryKey: true}, {Name: "name", DataType: "VARCHAR(255)", PrimaryKey: false}}, createTableEvent.GetColumns())
+		}
+		{
+			// Two primary keys
+			events, err := Parse("CREATE TABLE table_name (id INT, name VARCHAR(255), PRIMARY KEY (id, name));")
+			assert.NoError(t, err)
+
+			createTableEvent, isOk := events[0].(CreateTableEvent)
+			assert.True(t, isOk)
+
+			assert.Equal(t, "table_name", createTableEvent.GetTable())
+			assert.Len(t, createTableEvent.GetColumns(), 2)
+			assert.Equal(t, []Column{{Name: "id", DataType: "INT", PrimaryKey: true}, {Name: "name", DataType: "VARCHAR(255)", PrimaryKey: true}}, createTableEvent.GetColumns())
+		}
 	}
 	{
 		// Create table with primary key

--- a/lib/antlr/parse.go
+++ b/lib/antlr/parse.go
@@ -36,6 +36,8 @@ func unescape(s string) string {
 func Parse(sqlCmd string) ([]Event, error) {
 	lexer := generated.NewMySqlLexer(antlr.NewInputStream(sqlCmd))
 	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	// This will go through our custom visit function. If you are trying to print out the AST, split this function into [sqlStatements] and [parser]
+	// Then have print [sqlStatements.ToStringTree(nil, parser)]
 	return visit(generated.NewMySqlParser(stream).SqlStatements())
 }
 

--- a/lib/debezium/transformer/light_transformer.go
+++ b/lib/debezium/transformer/light_transformer.go
@@ -39,7 +39,7 @@ func (l LightDebeziumTransformer) BuildPartitionKey(beforeRow, afterRow Row) (ma
 	}
 
 	row := afterRow
-	if afterRow == nil {
+	if len(afterRow) == 0 {
 		// After row may not exist for a delete event.
 		row = beforeRow
 	}

--- a/lib/debezium/transformer/light_transformer.go
+++ b/lib/debezium/transformer/light_transformer.go
@@ -44,8 +44,6 @@ func (l LightDebeziumTransformer) BuildPartitionKey(beforeRow, afterRow Row) (ma
 		row = beforeRow
 	}
 
-	fmt.Println("beforeRow", beforeRow, "afterRow", afterRow, "partitionKeys", l.partitionKeys)
-
 	return convertPartitionKey(l.valueConverters, l.partitionKeys, row)
 }
 

--- a/lib/debezium/transformer/light_transformer.go
+++ b/lib/debezium/transformer/light_transformer.go
@@ -44,6 +44,8 @@ func (l LightDebeziumTransformer) BuildPartitionKey(beforeRow, afterRow Row) (ma
 		row = beforeRow
 	}
 
+	fmt.Println("beforeRow", beforeRow, "afterRow", afterRow, "partitionKeys", l.partitionKeys)
+
 	return convertPartitionKey(l.valueConverters, l.partitionKeys, row)
 }
 

--- a/sources/mysql/streaming/ddl/table_adapter.go
+++ b/sources/mysql/streaming/ddl/table_adapter.go
@@ -125,7 +125,6 @@ func (t TableAdapter) PartitionKeys() []string {
 	var keys []string
 	for _, col := range t.columns {
 		if col.PrimaryKey {
-
 			keys = append(keys, col.Name)
 		}
 	}

--- a/sources/mysql/streaming/dml.go
+++ b/sources/mysql/streaming/dml.go
@@ -92,6 +92,10 @@ func (i *Iterator) processDML(ts time.Time, event *replication.BinlogEvent) ([]l
 			return nil, fmt.Errorf("failed to build partition key: %w", err)
 		}
 
+		if len(pk) == 0 {
+			return nil, fmt.Errorf("partition key is not set for table: %q", tableName)
+		}
+
 		rawMsgs = append(rawMsgs, lib.NewRawMessage(tblAdapter.TopicSuffix(), pk, &dbzMessage))
 	}
 


### PR DESCRIPTION
TIL that there's a discrepancy between `SHOW CREATE TABLE <table_name>` for different MySQL versions.

This PR does two things:

1. Adds validation to ensure all emitted rows must have partition keys set
2. Handle the ability to process primary key DDLs where the primary key is not specified inline with the column definition.