### PR TITLE
[MySQL] Improving GTID offset management + dedupe

### DIFF
--- a/lib/mysql/gtid.go
+++ b/lib/mysql/gtid.go
@@ -1,0 +1,47 @@
+package mysql
+
+import (
+	"fmt"
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"strconv"
+	"strings"
+)
+
+func ShouldProcessRow(set mysql.GTIDSet, currentGTID string) (bool, error) {
+	gtidSet, ok := set.(*mysql.MysqlGTIDSet)
+	if !ok {
+		return false, fmt.Errorf("unsupported GTID set type: %T", set)
+	}
+
+	if len(gtidSet.Sets) == 0 {
+		// We have not seen any GTIDs yet, so we should process this one.
+		return true, nil
+	}
+
+	gtidParts := strings.Split(currentGTID, ":")
+	if len(gtidParts) != 2 {
+		return false, fmt.Errorf("invalid GTID format: %q", currentGTID)
+	}
+
+	sid := gtidParts[0]
+	seenIntervals, ok := gtidSet.Sets[sid]
+	if !ok {
+		// We have not seen this SID before, so we should process it.
+		return true, nil
+	}
+
+	txID, err := strconv.ParseInt(gtidParts[1], 10, 64)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse transaction ID: %w", err)
+	}
+
+	var highestTxID int64
+	for _, interval := range seenIntervals.Intervals {
+		if interval.Stop > highestTxID {
+			highestTxID = interval.Stop
+		}
+	}
+
+	// We should process if the current txID is above the highest txID we have seen
+	return txID > highestTxID, nil
+}

--- a/lib/mysql/gtid.go
+++ b/lib/mysql/gtid.go
@@ -42,6 +42,6 @@ func ShouldProcessRow(set mysql.GTIDSet, currentGTID string) (bool, error) {
 		}
 	}
 
-	// We should process if the current txID is above the highest txID we have seen
+	// We should process if the current txID is above or equal to the highest txID we have seen
 	return txID >= highestTxID, nil
 }

--- a/lib/mysql/gtid.go
+++ b/lib/mysql/gtid.go
@@ -43,5 +43,5 @@ func ShouldProcessRow(set mysql.GTIDSet, currentGTID string) (bool, error) {
 	}
 
 	// We should process if the current txID is above the highest txID we have seen
-	return txID > highestTxID, nil
+	return txID >= highestTxID, nil
 }

--- a/lib/mysql/gtid_test.go
+++ b/lib/mysql/gtid_test.go
@@ -1,0 +1,19 @@
+package mysql
+
+import (
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetHighWatermark(t *testing.T) {
+	{
+		// Nothing defined for the set
+		set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, "")
+		assert.NoError(t, err)
+
+		below, err := GetHighWatermark(set, "foo:1")
+
+
+	}
+}

--- a/lib/mysql/gtid_test.go
+++ b/lib/mysql/gtid_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -29,6 +30,21 @@ func TestShouldProcessRow(t *testing.T) {
 		assert.NoError(t, err)
 
 		shouldProcess, err := ShouldProcessRow(set, getGTID(sid, 2))
+		assert.NoError(t, err)
+		assert.True(t, shouldProcess)
+	}
+	{
+		// There's more than one SID pre-existing
+		sid1 := uuid.New()
+		sid2 := uuid.New()
+		set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, strings.Join([]string{getGTID(sid1, 1), getGTID(sid2, 1)}, ","))
+		assert.NoError(t, err)
+
+		shouldProcess, err := ShouldProcessRow(set, getGTID(sid1, 2))
+		assert.NoError(t, err)
+		assert.True(t, shouldProcess)
+
+		shouldProcess, err = ShouldProcessRow(set, getGTID(sid2, 2))
 		assert.NoError(t, err)
 		assert.True(t, shouldProcess)
 	}

--- a/lib/mysql/gtid_test.go
+++ b/lib/mysql/gtid_test.go
@@ -1,19 +1,45 @@
 package mysql
 
 import (
+	"fmt"
 	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
-func TestGetHighWatermark(t *testing.T) {
+func getGTID(sid uuid.UUID, txID int64) string {
+	return fmt.Sprintf("%s:%d", sid.String(), txID)
+}
+
+func TestShouldProcessRow(t *testing.T) {
 	{
-		// Nothing defined for the set
+		// Nothing defined for the set, so we should process it.
 		set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, "")
 		assert.NoError(t, err)
 
-		below, err := GetHighWatermark(set, "foo:1")
+		shouldProcess, err := ShouldProcessRow(set, "foo:1")
+		assert.NoError(t, err)
+		assert.True(t, shouldProcess)
+	}
+	{
+		// We have seen the SID before, but the txID is higher than the highest we have seen.
+		sid := uuid.New()
+		set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, getGTID(sid, 1))
+		assert.NoError(t, err)
 
+		shouldProcess, err := ShouldProcessRow(set, getGTID(sid, 2))
+		assert.NoError(t, err)
+		assert.True(t, shouldProcess)
+	}
+	{
+		// We have not seen the SID before
+		sid := uuid.New()
+		set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, getGTID(sid, 1))
+		assert.NoError(t, err)
 
+		shouldProcess, err := ShouldProcessRow(set, getGTID(uuid.New(), 1))
+		assert.NoError(t, err)
+		assert.True(t, shouldProcess)
 	}
 }

--- a/sources/mysql/streaming/iterator.go
+++ b/sources/mysql/streaming/iterator.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/artie-labs/reader/lib/mysql"
 	"log/slog"
 	"strings"
 	"time"
@@ -156,6 +157,23 @@ func (i *Iterator) Next() ([]lib.RawMessage, error) {
 				}
 
 				return nil, fmt.Errorf("failed to get binlog event: %w", err)
+			}
+
+			if gtidEvent, ok := event.Event.(*replication.GTIDEvent); ok {
+				next, err := gtidEvent.GTIDNext()
+				if err != nil {
+					return nil, fmt.Errorf("failed to retrieve next GTID set: %w", err)
+				}
+
+				shouldProcess, err := mysql.ShouldProcessRow(i.position._gtidSet, next.String())
+				if err != nil {
+					return nil, fmt.Errorf("failed to check if we should process row: %w", err)
+				}
+
+				if !shouldProcess {
+					// We should skip this row since we have already processed it
+					continue
+				}
 			}
 
 			ts := getTimeFromEvent(event)

--- a/sources/mysql/streaming/iterator.go
+++ b/sources/mysql/streaming/iterator.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/artie-labs/reader/lib/mysql"
 	"log/slog"
 	"strings"
 	"time"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/artie-labs/reader/config"
 	"github.com/artie-labs/reader/lib"
+	"github.com/artie-labs/reader/lib/mysql"
 	"github.com/artie-labs/reader/lib/mysql/schema"
 	"github.com/artie-labs/reader/lib/storage/persistedlist"
 	"github.com/artie-labs/reader/lib/storage/persistedmap"

--- a/sources/mysql/streaming/offset.go
+++ b/sources/mysql/streaming/offset.go
@@ -44,7 +44,6 @@ func (p *Position) UpdatePosition(ts time.Time, evt *replication.BinlogEvent) er
 	// We should always update the log position
 	p.Pos = evt.Header.LogPos
 	p.UnixTs = ts.Unix()
-
 	if evt.Header.EventType == replication.GTID_EVENT {
 		gtidEvent, err := typing.AssertType[*replication.GTIDEvent](evt.Event)
 		if err != nil {


### PR DESCRIPTION
## Context

### Offsets

A GTID in MySQL looks like:

```
GTID = source_id:transaction_id

For example: 3E11FA47-71CA-11E1-9E33-C80AA9429562:23

* source_id = the originating server ID.
* transaction_id = sequence number that goes up to 2^63-1 (int64)
```

A GTID Set could look like this:

```
GTID Set = source_id:transaction_id-transaction_id

For example: 3E11FA47-71CA-11E1-9E33-C80AA9429562:23-29

As well as

GTID Set = source_id:transaction_id-transaction_id,source_id1:transaction_id-transaction_id
```

As such, I've updated our PR to store the GTID set as opposed to the last known GTID.

### Ensuring no duplicates

This PR also adds a guardrail to ensure that we don't process GTIDs that have already been "seen" or "processed". Given that `transaction_id` is a sequence number. If the current `transaction_id` is less than our current position, we will skip the event.
