### PR TITLE
Additional GTID check

### DIFF
--- a/lib/mysql/gtid.go
+++ b/lib/mysql/gtid.go
@@ -8,6 +8,11 @@ import (
 )
 
 func ShouldProcessRow(set mysql.GTIDSet, currentGTID string) (bool, error) {
+	if set == nil {
+		// We have not seen any GTIDs yet, so we should process this one.
+		return true, nil
+	}
+
 	gtidSet, ok := set.(*mysql.MysqlGTIDSet)
 	if !ok {
 		return false, fmt.Errorf("unsupported GTID set type: %T", set)

--- a/lib/mysql/gtid_test.go
+++ b/lib/mysql/gtid_test.go
@@ -15,6 +15,12 @@ func getGTID(sid uuid.UUID, txID int64) string {
 
 func TestShouldProcessRow(t *testing.T) {
 	{
+		// GTID is not set, should still return
+		shouldProcess, err := ShouldProcessRow(nil, "foo:1")
+		assert.NoError(t, err)
+		assert.True(t, shouldProcess)
+	}
+	{
 		// Nothing defined for the set, so we should process it.
 		set, err := mysql.ParseGTIDSet(mysql.MySQLFlavor, "")
 		assert.NoError(t, err)


### PR DESCRIPTION
A MySQL instance that does not have GTID enabled may still emit `GTID Event`. The `GTID Set` in that case could be empty since we never tried to parse it.

That would then lead to a type assertion failure, which this is now accounting for.