### PR TITLE
[MySQL] Extending `Binary` converter to handle string in addition to `[]bytes`

### DIFF
--- a/lib/mysql/schema/convert.go
+++ b/lib/mysql/schema/convert.go
@@ -147,7 +147,7 @@ func ConvertValue(value any, colType DataType, opts *Opts) (any, error) {
 		case []byte:
 			return castedValue, nil
 		default:
-			return nil, fmt.Errorf("expected []byte got %T for value: %v", value, value)
+			return nil, fmt.Errorf("expected []byte or string got %T for value: %v", value, value)
 		}
 	case Date:
 		// MySQL supports 0000-00-00 for dates so we can't use time.Time

--- a/lib/mysql/schema/convert.go
+++ b/lib/mysql/schema/convert.go
@@ -141,12 +141,14 @@ func ConvertValue(value any, colType DataType, opts *Opts) (any, error) {
 		}
 		return value, nil
 	case Binary, Varbinary, Blob:
-		// Types we expect as a byte array
-		_, ok := value.([]byte)
-		if !ok {
+		switch castedValue := value.(type) {
+		case string:
+			return []byte(castedValue), nil
+		case []byte:
+			return castedValue, nil
+		default:
 			return nil, fmt.Errorf("expected []byte got %T for value: %v", value, value)
 		}
-		return value, nil
 	case Date:
 		// MySQL supports 0000-00-00 for dates so we can't use time.Time
 		return asString(value)

--- a/lib/mysql/schema/convert_test.go
+++ b/lib/mysql/schema/convert_test.go
@@ -232,8 +232,8 @@ func TestConvertValue(t *testing.T) {
 		{
 			name:        "binary - malformed",
 			dataType:    Binary,
-			value:       "bad binary",
-			expectedErr: "expected []byte got string for value",
+			value:       true,
+			expectedErr: "expected []byte or string got bool for value",
 		},
 		{
 			name:     "varbinary",


### PR DESCRIPTION
To account for the differences in returned data types from streaming and snapshot