### PR TITLE
Adding a DEBUG mode

### DIFF
--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -17,8 +18,20 @@ import (
 var handlersToTerminate []func()
 
 func NewLogger(settings *config.Settings) (*slog.Logger, func()) {
+	logLevel := slog.LevelInfo
+	if val := os.Getenv("READER_DEBUG"); val != "" {
+		debug, err := strconv.ParseBool(val)
+		if err != nil {
+			Panic("Failed to parse READER_DEBUG", slog.Any("err", err))
+		}
+
+		if debug {
+			logLevel = slog.LevelDebug
+		}
+	}
+
 	handler := tint.NewHandler(os.Stderr, &tint.Options{
-		Level:   slog.LevelInfo,
+		Level:   logLevel,
 		NoColor: !isatty.IsTerminal(os.Stderr.Fd()),
 	})
 

--- a/sources/mysql/streaming/dml.go
+++ b/sources/mysql/streaming/dml.go
@@ -39,7 +39,7 @@ func (i *Iterator) processDML(ts time.Time, event *replication.BinlogEvent) ([]l
 	}
 
 	if tblAdapter.GetUnixTs() > ts.Unix() {
-		slog.Warn("Skipping this event since the event timestamp is older than the schema timestamp",
+		slog.Debug("Skipping this event since the event timestamp is older than the schema timestamp",
 			slog.Int64("event_ts", ts.Unix()),
 			slog.Int64("schema_ts", tblAdapter.GetUnixTs()),
 		)

--- a/sources/mysql/streaming/dml.go
+++ b/sources/mysql/streaming/dml.go
@@ -20,7 +20,7 @@ func (i *Iterator) processDML(ts time.Time, event *replication.BinlogEvent) ([]l
 	}
 
 	if !strings.EqualFold(i.cfg.Database, string(rowsEvent.Table.Schema)) {
-		slog.Info("Skipping this event since the database does not match the configured database",
+		slog.Debug("Skipping this event since the database does not match the configured database",
 			slog.String("config_db", i.cfg.Database),
 			slog.String("event_db", string(rowsEvent.Table.Schema)),
 		)

--- a/sources/mysql/streaming/iterator.go
+++ b/sources/mysql/streaming/iterator.go
@@ -231,7 +231,7 @@ func (i *Iterator) persistAndProcessDDL(evt *replication.QueryEvent, ts time.Tim
 	}
 
 	if !strings.EqualFold(i.cfg.Database, string(evt.Schema)) {
-		slog.Info("Skipping this event since the database does not match the configured database",
+		slog.Debug("Skipping this event since the database does not match the configured database",
 			slog.String("config_db", i.cfg.Database),
 			slog.String("event_db", string(evt.Schema)),
 		)


### PR DESCRIPTION
Moving some logs that could be noisy into `.Debug` and then adding an ENV VAR called `READER_DEBUG` which can be used to toggle the debugging logs.