### PR TITLE
[DDL] Rename table and Copy table to use `getTableNameFromNode`

### DIFF
--- a/lib/antlr/create_table.go
+++ b/lib/antlr/create_table.go
@@ -108,7 +108,7 @@ func processCopyTable(ctx *generated.CopyCreateTableContext) (Event, error) {
 	if len(tableNames) != 2 {
 		return nil, fmt.Errorf("expected exactly 2 table names, got %d", len(tableNames))
 	}
-	
+
 	tableName, err := getTableNameFromNode(tableNames[0])
 	if err != nil {
 		return nil, err

--- a/lib/antlr/create_table.go
+++ b/lib/antlr/create_table.go
@@ -109,12 +109,16 @@ func processCopyTable(ctx *generated.CopyCreateTableContext) (Event, error) {
 		return nil, fmt.Errorf("expected exactly 2 table names, got %d", len(tableNames))
 	}
 
-	tableName, err := getTextFromSingleNodeBranch(tableNames[0])
+	for _, cc := range tableNames[0].GetChildren() {
+		fmt.Println("cc", cc, "type", fmt.Sprintf("%T", cc), "cc text", cc.(antlr.ParseTree).GetText())
+	}
+
+	tableName, err := getTableNameFromNode(tableNames[0])
 	if err != nil {
 		return nil, err
 	}
 
-	copiedFromTableName, err := getTextFromSingleNodeBranch(tableNames[1])
+	copiedFromTableName, err := getTableNameFromNode(tableNames[1])
 	if err != nil {
 		return nil, err
 	}

--- a/lib/antlr/create_table.go
+++ b/lib/antlr/create_table.go
@@ -108,11 +108,7 @@ func processCopyTable(ctx *generated.CopyCreateTableContext) (Event, error) {
 	if len(tableNames) != 2 {
 		return nil, fmt.Errorf("expected exactly 2 table names, got %d", len(tableNames))
 	}
-
-	for _, cc := range tableNames[0].GetChildren() {
-		fmt.Println("cc", cc, "type", fmt.Sprintf("%T", cc), "cc text", cc.(antlr.ParseTree).GetText())
-	}
-
+	
 	tableName, err := getTableNameFromNode(tableNames[0])
 	if err != nil {
 		return nil, err

--- a/lib/antlr/create_table_test.go
+++ b/lib/antlr/create_table_test.go
@@ -9,16 +9,10 @@ import (
 
 func TestCreateTable(t *testing.T) {
 	{
-		// Create table LIKE
-		sameQueries := []string{
-			"CREATE TABLE table_name LIKE other_table;",
-			"create table table_name (like other_table);",
-		}
-
-		for _, query := range sameQueries {
-			events, err := Parse(query)
+		{
+			// Create table LIKE by specifying schema
+			events, err := Parse("CREATE TABLE db_name.table_name LIKE db_name.other_table;")
 			assert.NoError(t, err)
-			assert.Len(t, events, 1)
 
 			createTableEvent, isOk := events[0].(CopyTableEvent)
 			assert.True(t, isOk)
@@ -27,7 +21,26 @@ func TestCreateTable(t *testing.T) {
 			assert.Len(t, createTableEvent.GetColumns(), 0)
 			assert.Equal(t, "other_table", createTableEvent.GetCopyFromTableName())
 		}
+		{
+			// Create table LIKE
+			sameQueries := []string{
+				"CREATE TABLE table_name LIKE other_table;",
+				"create table table_name (like other_table);",
+			}
 
+			for _, query := range sameQueries {
+				events, err := Parse(query)
+				assert.NoError(t, err)
+				assert.Len(t, events, 1)
+
+				createTableEvent, isOk := events[0].(CopyTableEvent)
+				assert.True(t, isOk)
+
+				assert.Equal(t, "table_name", createTableEvent.GetTable())
+				assert.Len(t, createTableEvent.GetColumns(), 0)
+				assert.Equal(t, "other_table", createTableEvent.GetCopyFromTableName())
+			}
+		}
 	}
 	{
 		// Create table with column as CHARACTER SET and collation specified at the column level

--- a/lib/antlr/drop_table_test.go
+++ b/lib/antlr/drop_table_test.go
@@ -8,16 +8,6 @@ import (
 
 func TestDropTable(t *testing.T) {
 	{
-		// Drop table specify schema
-		events, err := Parse("DROP TABLE db_name.table_name;")
-		assert.NoError(t, err)
-		assert.Len(t, events, 1)
-
-		dropTableEvent, isOk := events[0].(DropTableEvent)
-		assert.True(t, isOk)
-		assert.Equal(t, "table_name", dropTableEvent.GetTable())
-	}
-	{
 		// Single drop table
 		for _, tblName := range []string{"table_name", "`table_name`", "db_name.table_name", "`db_name`.`table_name`"} {
 			events, err := Parse(fmt.Sprintf("DROP TABLE %s;", tblName))

--- a/lib/antlr/drop_table_test.go
+++ b/lib/antlr/drop_table_test.go
@@ -8,6 +8,16 @@ import (
 
 func TestDropTable(t *testing.T) {
 	{
+		// Drop table specify schema
+		events, err := Parse("DROP TABLE db_name.table_name;")
+		assert.NoError(t, err)
+		assert.Len(t, events, 1)
+
+		dropTableEvent, isOk := events[0].(DropTableEvent)
+		assert.True(t, isOk)
+		assert.Equal(t, "table_name", dropTableEvent.GetTable())
+	}
+	{
 		// Single drop table
 		for _, tblName := range []string{"table_name", "`table_name`", "db_name.table_name", "`db_name`.`table_name`"} {
 			events, err := Parse(fmt.Sprintf("DROP TABLE %s;", tblName))

--- a/lib/antlr/rename_table.go
+++ b/lib/antlr/rename_table.go
@@ -13,7 +13,12 @@ func processRenameTable(ctx *generated.RenameTableContext) ([]Event, error) {
 		case *generated.RenameTableClauseContext:
 			var allTableNames []string
 			for _, tableName := range castedChild.AllTableName() {
-				allTableNames = append(allTableNames, tableName.GetText())
+				parsedTableName, err := getTableNameFromNode(tableName)
+				if err != nil {
+					return nil, fmt.Errorf("failed to get table name: %w", err)
+				}
+
+				allTableNames = append(allTableNames, parsedTableName)
 			}
 
 			// Must be at least two table names

--- a/lib/antlr/rename_table_test.go
+++ b/lib/antlr/rename_table_test.go
@@ -20,15 +20,15 @@ func TestRenameTable(t *testing.T) {
 	}
 	{
 		// Another one table variant
-		events, err := Parse(`RENAME TABLE current_db.tbl_name TO other_db.tbl_name;`)
+		events, err := Parse(`RENAME TABLE current_db.tbl_name TO current_db.tbl_name;`)
 		assert.NoError(t, err)
 		assert.Len(t, events, 1)
 
 		renameTableEvent, isOk := events[0].(RenameTableEvent)
 		assert.True(t, isOk)
 
-		assert.Equal(t, "current_db.tbl_name", renameTableEvent.GetTable())
-		assert.Equal(t, "other_db.tbl_name", renameTableEvent.GetNewTableName())
+		assert.Equal(t, "tbl_name", renameTableEvent.GetTable())
+		assert.Equal(t, "tbl_name", renameTableEvent.GetNewTableName())
 	}
 	{
 		// Multiple tables

--- a/lib/antlr/util.go
+++ b/lib/antlr/util.go
@@ -41,6 +41,7 @@ func getTextFromSingleNodeBranch(tree antlr.Tree) (string, error) {
 	return getTextFromSingleNodeBranch(tree.GetChild(0))
 }
 
+// TODO: Extend this function to return the schema (if present)
 func getTableNameFromNode(ctx generated.ITableNameContext) (string, error) {
 	children := ctx.GetChildren()
 	if len(children) != 1 {


### PR DESCRIPTION
Being consistent with how we are extracting the table names for each DDL event.