### PR TITLE
[DDL] Skipping mat tables

### DIFF
--- a/lib/antlr/create_table_test.go
+++ b/lib/antlr/create_table_test.go
@@ -9,6 +9,12 @@ import (
 
 func TestCreateTable(t *testing.T) {
 	{
+		// Skip parsing materialized tables
+		events, err := Parse(`CREATE TABLE high_salary_employees_mat AS SELECT name, position, salary FROM employees WHERE salary > 100000;`)
+		assert.NoError(t, err)
+		assert.Len(t, events, 0)
+	}
+	{
 		{
 			// Create table LIKE by specifying schema
 			events, err := Parse("CREATE TABLE db_name.table_name LIKE db_name.other_table;")

--- a/lib/antlr/parse.go
+++ b/lib/antlr/parse.go
@@ -86,6 +86,7 @@ func visit(tree antlr.Tree) ([]Event, error) {
 	case *generated.RenameTableContext:
 		return processRenameTable(ctx)
 	case
+		*generated.StartTransactionContext,
 		*generated.CreateViewContext,
 		*generated.DropViewContext,
 		// [*generated.QueryCreateTableContext] refers to materialized tables

--- a/lib/antlr/parse.go
+++ b/lib/antlr/parse.go
@@ -86,6 +86,8 @@ func visit(tree antlr.Tree) ([]Event, error) {
 	case *generated.RenameTableContext:
 		return processRenameTable(ctx)
 	case
+		*generated.CreateViewContext,
+		*generated.DropViewContext,
 		// [*generated.QueryCreateTableContext] refers to materialized tables
 		*generated.QueryCreateTableContext,
 		*generated.CreateIndexContext,

--- a/lib/antlr/parse.go
+++ b/lib/antlr/parse.go
@@ -86,6 +86,8 @@ func visit(tree antlr.Tree) ([]Event, error) {
 	case *generated.RenameTableContext:
 		return processRenameTable(ctx)
 	case
+		// [*generated.QueryCreateTableContext] refers to materialized tables
+		*generated.QueryCreateTableContext,
 		*generated.CreateIndexContext,
 		*generated.DropIndexContext,
 		*generated.CreateEventContext,


### PR DESCRIPTION
In MySQL, Materialized views are labelled as `BASE TABLES` in `SHOW FULL TABLES`. This PR improves our DDL library to filter them out.